### PR TITLE
Fixed status to check for for failed messages in unit.run

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -578,7 +578,7 @@ class Model(object):
             action_id = action_id[7:]
 
         def predicate(delta):
-            return delta.data['status'] in ('completed', 'error')
+            return delta.data['status'] in ('completed', 'failed')
 
         return await self._wait('action', action_id, 'change', predicate)
 


### PR DESCRIPTION
error -> failed

@tvansteenburgh Just caught this while testing matrix -- I was checking for "error" rather than "failed", which is the correct tag for a failed message.