### PR TITLE
Added juju.model.connect_model()

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -367,6 +367,15 @@ class Model(object):
         self._watch()
         await self._watch_received.wait()
 
+    async def connect_model(self, arg):
+        """Connect to a specific Juju model.
+        :param arg:  <controller>:<user/model>
+
+        """
+        self.connection = await connection.Connection.connect_model(arg)
+        self._watch()
+        await self._watch_received.wait()
+
     async def disconnect(self):
         """Shut down the watcher task and close websockets.
 


### PR DESCRIPTION
Added juju.model.connect_model(arg) 

Allowing the developer to test against an already existing model 

Example Usage:

    from juju.model import Model

    model = Model()
    await model.connect_model("mycontroller:admin/testmodel")
