### PR TITLE
Adding comment in example/controller.py regarding cloudcred format

### DIFF
--- a/examples/controller.py
+++ b/examples/controller.py
@@ -27,7 +27,7 @@ async def run():
     model = await controller.add_model(
         'libjuju-test',
         'cloud-aws',
-        'cloudcred-aws_tvansteenburgh_external@aws-tim',
+        'cloudcred-aws_tvansteenburgh@external_aws-tim',
     )
     await model.deploy(
         'ubuntu-0',

--- a/examples/controller.py
+++ b/examples/controller.py
@@ -5,6 +5,9 @@ This example:
 2. Creates a new model.
 3. Deploys an application on the new model.
 
+Note: 'cloudcred' format to add a model should be:
+cloudcred-<cloudname>_<user>_<credentialname>
+
 """
 import asyncio
 import logging
@@ -24,7 +27,7 @@ async def run():
     model = await controller.add_model(
         'libjuju-test',
         'cloud-aws',
-        'cloudcred-aws_tvansteenburgh_external_aws-tim',
+        'cloudcred-aws_tvansteenburgh_external@aws-tim',
     )
     await model.deploy(
         'ubuntu-0',

--- a/examples/controller.py
+++ b/examples/controller.py
@@ -24,7 +24,7 @@ async def run():
     model = await controller.add_model(
         'libjuju-test',
         'cloud-aws',
-        'cloudcred-aws_tvansteenburgh@external_aws-tim',
+        'cloudcred-aws_tvansteenburgh_external_aws-tim',
     )
     await model.deploy(
         'ubuntu-0',


### PR DESCRIPTION
Possible Typo in the Example/Controller.py
I updated cloud-creds:  :s/@/_

'cloudcred-aws_tvansteenburgh_external_aws-tim',

For LXD I used:
'cloudcred-localhost_admin_default'

'cloudcred-localhost_admin@default' fails, unless the @ is intentional for AWS