### PR TITLE
Added .is_leader method to Unit class.

### DIFF
--- a/examples/leadership.py
+++ b/examples/leadership.py
@@ -1,0 +1,26 @@
+"""
+This example:
+
+1. Connects to the current model.
+2. Prints out leadership status for all deployed units in the model.
+3. Cleanly disconnects.
+
+"""
+import asyncio
+
+from juju.model import Model
+
+async def report_leadership():
+    model = Model()
+    await model.connect_current()
+
+    print("Leadership: ")
+    for app in model.applications.values():
+        for unit in app.units:
+            print("{}: {}".format(
+                unit.name, await unit.is_leader_from_status()))
+
+    await model.disconnect()
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(report_leadership())

--- a/juju/unit.py
+++ b/juju/unit.py
@@ -178,3 +178,26 @@ class Unit(model.ModelEntity):
 
         """
         pass
+
+    async def is_leader_from_status(self):
+        """
+        Check to see if this unit is the leader. Returns True if so, and
+        False if it is not, or if leadership does not make sense
+        (e.g., there is no leader in this application.)
+
+        This method is a kluge that calls FullStatus in the
+        ClientFacade to get its information. Once
+        https://bugs.launchpad.net/juju/+bug/1643691 is resolved, we
+        should add a simple .is_leader property, and deprecate this
+        method.
+
+        """
+        app = self.name.split("/")[0]
+
+        c = client.ClientFacade()
+        c.connect(self.model.connection)
+
+        status = await c.FullStatus(None)
+
+        return status.applications[app]['units'][self.name].get(
+            'leader', False)


### PR DESCRIPTION
As leadership is not exposed via deltas in the current version of the
juju websocket api, we have to spin up a ClientFacade and dig through
FullStatus for the information we need.

A ticket for adding leadership info to the deltas lives here:
https://bugs.launchpad.net/juju/+bug/1643691

@tvansteenburgh @johnsca (Gave the method a funky name because I don't want it to collide with .is_leader in the future, which will be called without an `await`)