### PR TITLE
Added a catch for the case where we call is_leader_from_status on a destroyed unit.

### DIFF
--- a/juju/unit.py
+++ b/juju/unit.py
@@ -227,5 +227,14 @@ class Unit(model.ModelEntity):
 
         status = await c.FullStatus(None)
 
-        return status.applications[app]['units'][self.name].get(
-            'leader', False)
+        try:
+            return status.applications[app]['units'][self.name].get(
+                'leader', False)
+        except KeyError:
+            # FullStatus may be more up-to-date than the model
+            # referenced by this class. If this unit has been
+            # destroyed between the time the class was created and the
+            # time that we call this method, we'll get a KeyError. In
+            # that case, we simply return False, as a destroyed unit
+            # is not a leader.
+            return False


### PR DESCRIPTION
@johnsca @tvansteenburgh I think that this is the right place to handle this error: in the case where you call is_leader_from_status on a unit that has been destroyed, you'll get an exception. I'd rather you just get "False", which is technically true.