### PR TITLE
added juju.controller.destroy_models()

### DIFF
--- a/juju/controller.py
+++ b/juju/controller.py
@@ -63,6 +63,20 @@ class Controller(object):
 
         return model
 
+    async def destroy_models(self, *args):
+
+        """Destroy a model to this controller.
+
+        :param str : model-<UUID>
+
+        """
+        model_facade = client.ModelManagerFacade()
+        model_facade.connect(self.connection)
+
+        for arg in args:
+            log.debug('Destroying Model %s', arg)
+            await model_facade.DestroyModels([client.Entity(arg)])
+
     def add_user(self, username, display_name=None, acl=None, models=None):
         """Add a user to this controller.
 

--- a/juju/controller.py
+++ b/juju/controller.py
@@ -67,15 +67,27 @@ class Controller(object):
 
         """Destroy a model to this controller.
 
-        :param str : model-<UUID>
+        :param str : <UUID> of the Model
+        param accepts string of <UUID> only OR `model-<UUID>`
+
 
         """
         model_facade = client.ModelManagerFacade()
         model_facade.connect(self.connection)
 
-        for arg in args:
+        #Generate list of args, pre-pend 'model-'
+        prependarg = list(args)
+        for index, item in enumerate(prependarg):
+            if not item.startswith('model-'):
+                prependarg[index]="model-%s" % item
+
+        #Create list of objects to pass to DestroyModels()
+        arglist = []
+        for arg in prependarg:
+            arglist.append(client.Entity(arg))
             log.debug('Destroying Model %s', arg)
-            await model_facade.DestroyModels([client.Entity(arg)])
+
+        await model_facade.DestroyModels(arglist)
 
     def add_user(self, username, display_name=None, acl=None, models=None):
         """Add a user to this controller.


### PR DESCRIPTION
This small update adds the ability to destroy models. I've been using this in my qa framework throughout the day, it seems to be working as expected.

This was tested using the the following snippet from a script:

```
import asyncio
import logging

from juju.controller import Controller

async def run():
    controller = Controller()
    await controller.connect_current()
    await controller.destroy_model(
                       'model-ceb0e596-dc12-4f44-81c2-f33f0eddd546',
                       'model-24b024e0-b631-4c34-8701-db4d64eb85a4')
                       'model-616bd305-f3df-407f-8414-eca0397c87a1')
...
```

The user can pass as many models as they desire using the format "model-<UUID>"  1,2,3 , etc... 
I'm not catching any exceptions if the model does not exist it will simply move on.  Do we care? 

Let me know if any updates are needed.
