### PR TITLE
NoneType and style fixes for placement parsing lib

### DIFF
--- a/juju/placement.py
+++ b/juju/placement.py
@@ -6,9 +6,10 @@
 # module should be deprecated.
 #
 
+from .client import client
+
 MACHINE_SCOPE = "#"
 
-from .client import client
 
 def parse(directive):
     """
@@ -17,7 +18,7 @@ def parse(directive):
     back over the websocket API.
 
     """
-    if directive == "":
+    if not directive:
         # Handle null case
         return None
 


### PR DESCRIPTION
Was getting the following:

```
matrix:169:execute: Error in Rule(task=Task(command='matrix.tasks.deploy', args={'version': 'current', 'entity': 'cs:bundle/wiki-simple'}), conditions=[])'s task Task(command='matrix.tasks.deploy', args={'version': 'current', 'entity': 'cs:bundle/wiki-simple'})
Traceback (most recent call last):
  File "/home/johnsca/juju/matrix/matrix/model.py", line 163, in execute
    result = await self.execute_plugin(context, cmd, rule)
  File "/home/johnsca/juju/matrix/matrix/model.py", line 180, in execute_plugin
    result = await cmd(context, rule, self, event)
  File "/home/johnsca/juju/matrix/matrix/tasks/deploy.py", line 6, in deploy
    new_apps = await context.juju_model.deploy(task.args['entity'])
  File "/home/johnsca/juju/matrix/.tox/py35/lib/python3.5/site-packages/juju/model.py", line 842, in deploy
    await handler.execute_plan()
  File "/home/johnsca/juju/matrix/.tox/py35/lib/python3.5/site-packages/juju/model.py", line 1272, in execute_plan
    result = await method(*step.args)
  File "/home/johnsca/juju/matrix/.tox/py35/lib/python3.5/site-packages/juju/model.py", line 1430, in addUnit
    to=placement,
  File "/home/johnsca/juju/matrix/.tox/py35/lib/python3.5/site-packages/juju/application.py", line 91, in add_unit
    placement=[parse_placement(to)],
  File "/home/johnsca/juju/matrix/.tox/py35/lib/python3.5/site-packages/juju/placement.py", line 29, in parse
    if ":" in directive:
TypeError: argument of type 'NoneType' is not iterable
```

This fixes that.  However, with that I am seeing a WebSocket connection error immediately after the charms are added:

```
Traceback for <Task finished coro=<RuleEngine.rule_runner() done, defined at /home/johnsca/juju/matrix/matrix/rules.py:138> exception=ConnectionClosed('WebSocket connection is closed: code = 1006, no reason.',)> (most recent call last):
  File "/usr/lib/python3.5/asyncio/tasks.py", line 292, in _step
    self = None  # Needed to break cycles when an exception occurs.
  File "/home/johnsca/juju/matrix/matrix/rules.py", line 223, in rule_runner
    break
  File "/home/johnsca/juju/matrix/matrix/model.py", line 343, in execute
    result = await self.task.execute(context, self)
  File "/home/johnsca/juju/matrix/matrix/model.py", line 170, in execute
    raise
  File "/home/johnsca/juju/matrix/matrix/model.py", line 180, in execute_plugin
    result = await cmd(context, rule, self, event)
  File "/home/johnsca/juju/matrix/matrix/tasks/deploy.py", line 6, in deploy
    new_apps = await context.juju_model.deploy(task.args['entity'])
  File "/home/johnsca/juju/matrix/.tox/py35/lib/python3.5/site-packages/juju/model.py", line 870, in deploy
    await handler.execute_plan()
  File "/home/johnsca/juju/matrix/.tox/py35/lib/python3.5/site-packages/juju/model.py", line 1300, in execute_plan
    result = await method(*step.args)
  File "/home/johnsca/juju/matrix/.tox/py35/lib/python3.5/site-packages/juju/model.py", line 1458, in addUnit
    to=placement,
  File "/home/johnsca/juju/matrix/.tox/py35/lib/python3.5/site-packages/juju/application.py", line 92, in add_unit
    num_units=count,
  File "/home/johnsca/juju/matrix/.tox/py35/lib/python3.5/site-packages/juju/client/facade.py", line 317, in wrapper
    reply = await f(*args, **kwargs)
  File "/home/johnsca/juju/matrix/.tox/py35/lib/python3.5/site-packages/juju/client/_client.py", line 7588, in AddUnits
    reply = await self.rpc(msg)
  File "/home/johnsca/juju/matrix/.tox/py35/lib/python3.5/site-packages/juju/client/facade.py", line 436, in rpc
    result = await self.connection.rpc(msg, encoder=TypeEncoder)
  File "/home/johnsca/juju/matrix/.tox/py35/lib/python3.5/site-packages/juju/client/connection.py", line 91, in rpc
    result = await self.recv()
  File "/home/johnsca/juju/matrix/.tox/py35/lib/python3.5/site-packages/juju/client/connection.py", line 77, in recv
    result = await self.ws.recv()
  File "/home/johnsca/juju/matrix/.tox/py35/lib/python3.5/site-packages/websockets/protocol.py", line 298, in recv
    raise ConnectionClosed(self.close_code, self.close_reason)
websockets.exceptions.ConnectionClosed: WebSocket connection is closed: code = 1006, no reason.
```

I'm not sure if it's related to #7 because there's no delay on it and it's 100% consistent.