### PR TITLE
Minor fix to get_metrics

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -1261,7 +1261,7 @@ class Model(object):
                     raise Exception(error.message)
 
             for metric in entity_metrics.metrics:
-                metrics[metric.unit].append(metric.to_json())
+                metrics[metric.unit].append(vars(metric))
 
         return metrics
 


### PR DESCRIPTION
Realized I got a bit too hasty when doing the pull request for get_metrics and forgot to make the metric data into a dictionary rather than just a json string. Here's the fix.