### PR TITLE
Bug/fixes for null cases

### DIFF
--- a/juju/application.py
+++ b/juju/application.py
@@ -88,7 +88,7 @@ class Application(model.ModelEntity):
 
         result = await app_facade.AddUnits(
             application=self.name,
-            placement=[parse_placement(to)],
+            placement=[parse_placement(to)] if to else None,
             num_units=count,
         )
 


### PR DESCRIPTION
@tvansteenburgh @johnsca This fixes a few more edge/null cases when deploying bundles. I've verified by running matrix on wiki-simple and hadoop-processing with a local build of python-libjuju based on this branch.

The two issues are:
1) Checking for leadership on a subordinate breaks. I believe the correct thing to do is just to assume that the subordinate is not the leader. (Pls reject if this assumption is false.)
2) Deploying a unit with a placement directive of `[null]` creates a null pointer exception in juju core. Deploying with a placement directive of `null` seems to work a lot better.