### PR TITLE
Improved datetime parsing for unit.py

### DIFF
--- a/juju/unit.py
+++ b/juju/unit.py
@@ -1,5 +1,6 @@
 import logging
-from datetime import datetime
+
+from dateutil.parser import parser as parse_date
 
 from . import model
 from .client import client
@@ -20,10 +21,7 @@ class Unit(model.ModelEntity):
         """Get the time when the `agent_status` was last updated.
 
         """
-        since = self.data['agent-status']['since']
-        # Juju gives us nanoseconds, but Python only supports microseconds
-        since = since[:26]
-        return datetime.strptime(since, "%Y-%m-%dT%H:%M:%S.%f")
+        return parse_date(self.data['agent-status']['since'])
 
     @property
     def agent_status_message(self):
@@ -44,10 +42,7 @@ class Unit(model.ModelEntity):
         """Get the time when the `workload_status` was last updated.
 
         """
-        since = self.data['workload-status']['since']
-        # Juju gives us nanoseconds, but Python only supports microseconds
-        since = since[:26]
-        return datetime.strptime(since, "%Y-%m-%dT%H:%M:%S.%f")
+        return parse_date(self.data['workload-status']['since'])
 
     @property
     def workload_status_message(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # until https://github.com/juju/theblues/pull/46 and https://github.com/juju/theblues/pull/47
 # are merged, this depends on the following fork:
 git+https://github.com/johnsca/theblues@libjuju#egg=theblues
+python-dateutil==2.6.0

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'websockets',
         'pyyaml',
         'theblues',
+        'python-dateutil'
     ],
     include_package_data=True,
     maintainer='Juju Ecosystem Engineering',


### PR DESCRIPTION
Now uses dateutils lib to handle timezones, nanoseconds, and other
headaches.

@tvansteenburgh @johnsca This adds a dependency. But per IRC discussion, we can't guarantee that timestamps coming from the juju api are UTC, so creating naive datetime objects is probably a bad idea ...