### PR TITLE
Fixes for landscape bundle.

### DIFF
--- a/juju/application.py
+++ b/juju/application.py
@@ -88,7 +88,7 @@ class Application(model.ModelEntity):
 
         result = await app_facade.AddUnits(
             application=self.name,
-            placement=[parse_placement(to)] if to else None,
+            placement=parse_placement(to) if to else None,
             num_units=count,
         )
 

--- a/juju/constraints.py
+++ b/juju/constraints.py
@@ -28,6 +28,9 @@ FACTORS = {
     "P": 1024 * 1024 * 1024
 }
 
+SNAKE1 = re.compile(r'(.)([A-Z][a-z]+)')
+SNAKE2 = re.compile('([a-z0-9])([A-Z])')
+
 def parse(constraints):
     """
     Constraints must be expressed as a string containing only spaces
@@ -35,6 +38,9 @@ def parse(constraints):
 
     """
     if constraints is None:
+        return None
+
+    if constraints == "":
         return None
 
     if type(constraints) is dict:
@@ -52,6 +58,11 @@ def normalize_key(key):
     key = key.strip()
 
     key = key.replace("-", "_")  # Our _client lib wants "_" in place of "-"
+
+    # Convert camelCase to snake_case
+    key = SNAKE1.sub(r'\1_\2', key)
+    key = SNAKE2.sub(r'\1_\2', key).lower()
+
     return key
 
 
@@ -67,5 +78,8 @@ def normalize_value(value):
         values = value.split(",")
         values = [normalize_value(v) for v in values]
         return values
+
+    if value.isdigit():
+        return int(value)
 
     return value

--- a/juju/placement.py
+++ b/juju/placement.py
@@ -25,18 +25,28 @@ def parse(directive):
     if type(directive) in [dict, client.Placement]:
         # We've been handed something that we can simply hand back to
         # the api. (Forwards compatibility)
-        return directive
+        return [directive]
+
+    # Juju 2.0 can't handle lxc containers.
+    directive = directive.replace('lxc', 'lxd')
 
     if ":" in directive:
         # Planner has given us a scope and directive in string form
         scope, directive = directive.split(":")
-        return client.Placement(scope=scope, directive=directive)
+        return [client.Placement(scope=scope, directive=directive)]
 
     if directive.isdigit():
         # Planner has given us a machine id (we rely on juju core to
         # verify its validity.)
-        return client.Placement(scope=MACHINE_SCOPE, directive=directive)
+        return [client.Placement(scope=MACHINE_SCOPE, directive=directive)]
+
+    if "/" in directive:
+        machine, container, container_num = directive.split("/")
+        return [
+            client.Placement(scope=MACHINE_SCOPE, directive=machine),
+            client.Placement(scope=container, directive=container_num)
+        ]
 
     # Planner has probably given us a container type. Leave it up to
     # juju core to verify that it is valid.
-    return client.Placement(scope=directive)
+    return [client.Placement(scope=directive)]

--- a/tests/unit/test_constraints.py
+++ b/tests/unit/test_constraints.py
@@ -22,13 +22,15 @@ class TestConstraints(unittest.TestCase):
         self.assertEqual(_("test-key"), "test_key")
         self.assertEqual(_("test-key  "), "test_key")
         self.assertEqual(_("  test-key"), "test_key")
+        self.assertEqual(_("TestKey"), "test_key")
+        self.assertEqual(_("testKey"), "test_key")
 
     def test_normalize_val(self):
         _ = constraints.normalize_value
 
         self.assertEqual(_("10G"), 10 * 1024)
         self.assertEqual(_("10M"), 10)
-        self.assertEqual(_("10"), "10")
+        self.assertEqual(_("10"), 10)
         self.assertEqual(_("foo,bar"), ["foo", "bar"])
 
     def test_parse_constraints(self):

--- a/tests/unit/test_placement.py
+++ b/tests/unit/test_placement.py
@@ -11,10 +11,10 @@ class TestPlacement(unittest.TestCase):
 
     def test_parse_both_specified(self):
         res = placement.parse("foo:bar")
-        self.assertEqual(res.scope, "foo")
-        self.assertEqual(res.directive, "bar")
+        self.assertEqual(res[0].scope, "foo")
+        self.assertEqual(res[0].directive, "bar")
 
     def test_parse_machine(self):
         res = placement.parse("22")
-        self.assertEqual(res.scope, "#")
-        self.assertEqual(res.directive, "22")
+        self.assertEqual(res[0].scope, "#")
+        self.assertEqual(res[0].directive, "22")


### PR DESCRIPTION
Parses constraints in some places where we weren't parsing them.

Normalizes keys in machine params.

Adds support for Placements on an lxd container *or* a machine.

Substitutes lxd containers for lxc containers.

@tvansteenburgh @johnsca This brings python-libjuju up to feature parity with the gui when it comes to deploying the landscape bundle: they both fail on a config issue in haproxy, but otherwise get the bundle deployed.

Am working on the config issue, and will submit a separate PR once it is fixed.