### PR TITLE
Fixed detecting controller for non-superuser

### DIFF
--- a/juju/errors.py
+++ b/juju/errors.py
@@ -5,3 +5,7 @@ class JujuAPIError(Exception):
         self.response = result['response']
         self.request_id = result['request-id']
         super().__init__(self.message)
+
+
+class JujuConnectionError(ConnectionError):
+    pass


### PR DESCRIPTION
The `show-controller` command can only be used by superusers, so usually
fails on shared controllers.

https://bugs.launchpad.net/juju/+bug/1652106