### PR TITLE
Implement Model.add_machine()

### DIFF
--- a/docs/api/juju.rst
+++ b/docs/api/juju.rst
@@ -91,6 +91,14 @@ juju.juju module
     :undoc-members:
     :show-inheritance:
 
+juju.loop module
+----------------
+
+.. automodule:: juju.loop
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 juju.machine module
 -------------------
 
@@ -135,6 +143,14 @@ juju.unit module
 ----------------
 
 .. automodule:: juju.unit
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+juju.utils module
+-----------------
+
+.. automodule:: juju.utils
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/narrative/model.rst
+++ b/docs/narrative/model.rst
@@ -131,6 +131,50 @@ Example of creating a new model and then destroying it. See
   model = None
 
 
+Adding Machines and Containers
+------------------------------
+To add a machine or container, connect to a model and then call its
+:meth:`~juju.model.Model.add_machine` method. A
+:class:`~juju.machine.Machine` instance is returned. The machine id
+can be used to deploy a charm to a specific machine or container.
+
+.. code:: python
+
+  from juju.model import Model
+
+  model = Model()
+  await model.connect_current()
+
+  # add a new default machine
+  machine1 = await model.add_machine()
+
+  # add a machine with constraints, disks, and series specified
+  machine2 = await model.add_machine(
+      constraints={
+          'mem': 256 * MB,
+      },
+      disks=[{
+          'pool': 'rootfs',
+          'size': 10 * GB,
+          'count': 1,
+      }],
+      series='xenial',
+  )
+
+  # add a lxd container to machine2
+  machine3 = await model.add_machine(
+      'lxd:{}'.format(machine2.id))
+
+  # deploy charm to the lxd container
+  application = await model.deploy(
+      'ubuntu-10',
+      application_name='ubuntu',
+      series='xenial',
+      channel='stable',
+      to=machine3.id
+  )
+
+
 Reacting to Changes in a Model
 ------------------------------
 To watch for and respond to changes in a model, register an observer with the

--- a/examples/add_machine.py
+++ b/examples/add_machine.py
@@ -13,8 +13,8 @@ import logging
 from juju import loop
 from juju.model import Model
 
-MB = 1024 * 1024
-GB = MB * 1024
+MB = 1
+GB = 1024
 
 
 async def main():

--- a/examples/add_machine.py
+++ b/examples/add_machine.py
@@ -54,9 +54,10 @@ async def main():
                         for unit in application.units))
 
         await application.remove()
-        await machine3.destroy()
-        await machine2.destroy()
-        await machine1.destroy()
+
+        await machine3.destroy(force=True)
+        await machine2.destroy(force=True)
+        await machine1.destroy(force=True)
     finally:
         await model.disconnect()
 

--- a/examples/add_machine.py
+++ b/examples/add_machine.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3.5
+
+"""
+This example:
+
+1. Connects to the current model
+2. Creates two machines and a lxd container
+3. Deploys charm to the lxd container
+
+"""
+import logging
+
+from juju import loop
+from juju.model import Model
+
+MB = 1024 * 1024
+GB = MB * 1024
+
+
+async def main():
+    model = Model()
+    await model.connect_current()
+
+    try:
+        # add a new default machine
+        machine1 = await model.add_machine()
+        # add a machine with constraints, disks, and series
+        machine2 = await model.add_machine(
+            constraints={
+                'mem': 256 * MB,
+            },
+            disks=[{
+                'pool': 'rootfs',
+                'size': 10 * GB,
+                'count': 1,
+            }],
+            series='xenial',
+        )
+        # add a lxd container to machine2
+        machine3 = await model.add_machine(
+            'lxd:{}'.format(machine2.id))
+
+        # deploy charm to the lxd container
+        application = await model.deploy(
+            'ubuntu-10',
+            application_name='ubuntu',
+            series='xenial',
+            channel='stable',
+            to=machine3.id
+        )
+
+        await model.block_until(
+            lambda: all(unit.workload_status == 'active'
+                        for unit in application.units))
+
+        await application.remove()
+        await machine3.destroy()
+        await machine2.destroy()
+        await machine1.destroy()
+    finally:
+        await model.disconnect()
+
+
+logging.basicConfig(level=logging.DEBUG)
+ws_logger = logging.getLogger('websockets.protocol')
+ws_logger.setLevel(logging.INFO)
+
+loop.run(main())

--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -1,4 +1,3 @@
-import asyncio
 import base64
 import io
 import json

--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import io
 import json

--- a/juju/constraints.py
+++ b/juju/constraints.py
@@ -21,6 +21,7 @@ import re
 MEM = re.compile('^[1-9][0-9]*[MGTP]$')
 
 # Multiplication factors to get Megabytes
+# https://github.com/juju/juju/blob/master/constraints/constraints.go#L666
 FACTORS = {
     "M": 1,
     "G": 1024,
@@ -30,6 +31,7 @@ FACTORS = {
 
 SNAKE1 = re.compile(r'(.)([A-Z][a-z]+)')
 SNAKE2 = re.compile('([a-z0-9])([A-Z])')
+
 
 def parse(constraints):
     """

--- a/juju/machine.py
+++ b/juju/machine.py
@@ -10,6 +10,8 @@ class Machine(model.ModelEntity):
     async def destroy(self, force=False):
         """Remove this machine from the model.
 
+        Blocks until the machine is actually removed.
+
         """
         facade = client.ClientFacade()
         facade.connect(self.connection)
@@ -17,7 +19,9 @@ class Machine(model.ModelEntity):
         log.debug(
             'Destroying machine %s', self.id)
 
-        return await facade.DestroyMachines(force, [self.id])
+        await facade.DestroyMachines(force, [self.id])
+        return await self.model._wait(
+            'machine', self.id, 'remove')
     remove = destroy
 
     def run(self, command, timeout=None):

--- a/juju/model.py
+++ b/juju/model.py
@@ -671,7 +671,7 @@ class Model(object):
 
         :param entity_type: The entity's type.
         :param entity_id: The entity's id.
-        :param action: the type of action (e.g., 'add' or 'change')
+        :param action: the type of action (e.g., 'add', 'change', or 'remove')
         :param predicate: optional callable that must take as an
             argument a delta, and must return a boolean, indicating
             whether the delta contains the specific action we're looking
@@ -686,7 +686,9 @@ class Model(object):
 
         self.add_observer(callback, entity_type, action, entity_id, predicate)
         entity_id = await q.get()
-        return self.state._live_entity_map(entity_type)[entity_id]
+        # object might not be in the entity_map if we were waiting for a
+        # 'remove' action
+        return self.state._live_entity_map(entity_type).get(entity_id)
 
     async def _wait_for_new(self, entity_type, entity_id=None, predicate=None):
         """Wait for a new object to appear in the Model and return it.

--- a/juju/placement.py
+++ b/juju/placement.py
@@ -41,10 +41,10 @@ def parse(directive):
         return [client.Placement(scope=MACHINE_SCOPE, directive=directive)]
 
     if "/" in directive:
-        machine, container, container_num = directive.split("/")
+        # e.g. "0/lxd/0"
+        # https://github.com/juju/juju/blob/master/instance/placement_test.go#L29
         return [
-            client.Placement(scope=MACHINE_SCOPE, directive=machine),
-            client.Placement(scope=container, directive=container_num)
+            client.Placement(scope=MACHINE_SCOPE, directive=directive),
         ]
 
     # Planner has probably given us a container type. Leave it up to

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,6 +1,9 @@
+import uuid
 import subprocess
 
 import pytest
+
+from juju.controller import Controller
 
 
 def is_bootstrapped():
@@ -12,3 +15,23 @@ def is_bootstrapped():
 bootstrapped = pytest.mark.skipif(
     not is_bootstrapped(),
     reason='bootstrapped Juju environment required')
+
+
+class CleanModel():
+    def __init__(self):
+        self.controller = None
+        self.model = None
+
+    async def __aenter__(self):
+        self.controller = Controller()
+        await self.controller.connect_current()
+
+        model_name = 'model-{}'.format(uuid.uuid4())
+        self.model = await self.controller.add_model(model_name)
+
+        return self.model
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.model.disconnect()
+        await self.controller.destroy_model(self.model.info.uuid)
+        await self.controller.disconnect()

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1,5 +1,4 @@
-import asyncio
-import unittest
+import pytest
 
 from juju.client.connection import Connection
 from juju.client import client
@@ -8,19 +7,18 @@ from ..base import bootstrapped
 
 
 @bootstrapped
-class UserManagerTest(unittest.TestCase):
-    def test_user_info(self):
-        loop = asyncio.get_event_loop()
-        conn = loop.run_until_complete(
-            Connection.connect_current())
-        conn = loop.run_until_complete(
-            conn.controller())
+@pytest.mark.asyncio
+async def test_user_info(event_loop):
+    conn = await Connection.connect_current()
+    controller_conn = await conn.controller()
 
-        um = client.UserManagerFacade()
-        um.connect(conn)
-        result = loop.run_until_complete(
-            um.UserInfo([client.Entity('user-admin')], True))
+    um = client.UserManagerFacade()
+    um.connect(controller_conn)
+    result = await um.UserInfo(
+        [client.Entity('user-admin')], True)
+    await conn.close()
+    await controller_conn.close()
 
-        self.assertIsInstance(result, client.UserInfoResults)
-        for r in result.results:
-            self.assertIsInstance(r, client.UserInfoResult)
+    assert isinstance(result, client.UserInfoResults)
+    for r in result.results:
+        assert isinstance(r, client.UserInfoResult)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1,24 +1,22 @@
 import pytest
 
-from juju.client.connection import Connection
 from juju.client import client
 
-from ..base import bootstrapped
+from .. import base
 
 
-@bootstrapped
+@base.bootstrapped
 @pytest.mark.asyncio
 async def test_user_info(event_loop):
-    conn = await Connection.connect_current()
-    controller_conn = await conn.controller()
+    async with base.CleanModel() as model:
+        controller_conn = await model.connection.controller()
 
-    um = client.UserManagerFacade()
-    um.connect(controller_conn)
-    result = await um.UserInfo(
-        [client.Entity('user-admin')], True)
-    await conn.close()
-    await controller_conn.close()
+        um = client.UserManagerFacade()
+        um.connect(controller_conn)
+        result = await um.UserInfo(
+            [client.Entity('user-admin')], True)
+        await controller_conn.close()
 
-    assert isinstance(result, client.UserInfoResults)
-    for r in result.results:
-        assert isinstance(r, client.UserInfoResult)
+        assert isinstance(result, client.UserInfoResults)
+        for r in result.results:
+            assert isinstance(r, client.UserInfoResult)

--- a/tests/client/test_connection.py
+++ b/tests/client/test_connection.py
@@ -1,13 +1,14 @@
 import pytest
 
 from juju.client.connection import Connection
-from ..base import bootstrapped
+from .. import base
 
 
-@bootstrapped
+@base.bootstrapped
 @pytest.mark.asyncio
 async def test_connect_current(event_loop):
-    conn = await Connection.connect_current()
+    async with base.CleanModel():
+        conn = await Connection.connect_current()
 
-    assert isinstance(conn, Connection)
-    await conn.close()
+        assert isinstance(conn, Connection)
+        await conn.close()

--- a/tests/client/test_connection.py
+++ b/tests/client/test_connection.py
@@ -1,15 +1,13 @@
-import asyncio
-import unittest
+import pytest
 
 from juju.client.connection import Connection
 from ..base import bootstrapped
 
 
 @bootstrapped
-class FunctionalConnectionTest(unittest.TestCase):
-    def test_connect_current(self):
-        loop = asyncio.get_event_loop()
-        conn = loop.run_until_complete(
-            Connection.connect_current())
+@pytest.mark.asyncio
+async def test_connect_current(event_loop):
+    conn = await Connection.connect_current()
 
-        self.assertIsInstance(conn, Connection)
+    assert isinstance(conn, Connection)
+    await conn.close()

--- a/tests/functional/test_model.py
+++ b/tests/functional/test_model.py
@@ -1,0 +1,62 @@
+import uuid
+
+import pytest
+
+from juju.controller import Controller
+
+from ..base import bootstrapped
+
+MB = 1
+GB = 1024
+
+
+class CleanModel():
+    def __init__(self):
+        self.controller = None
+        self.model = None
+
+    async def __aenter__(self):
+        self.controller = Controller()
+        await self.controller.connect_current()
+
+        model_name = 'model-{}'.format(uuid.uuid4())
+        self.model = await self.controller.add_model(model_name)
+
+        return self.model
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.model.disconnect()
+        await self.controller.destroy_model(self.model.info.uuid)
+        await self.controller.disconnect()
+
+
+@bootstrapped
+@pytest.mark.asyncio
+async def test_add_machine(event_loop):
+    from juju.machine import Machine
+
+    async with CleanModel() as model:
+        # add a new default machine
+        machine1 = await model.add_machine()
+
+        # add a machine with constraints, disks, and series
+        machine2 = await model.add_machine(
+            constraints={
+                'mem': 256 * MB,
+            },
+            disks=[{
+                'pool': 'rootfs',
+                'size': 10 * GB,
+                'count': 1,
+            }],
+            series='xenial',
+        )
+
+        # add a lxd container to machine2
+        machine3 = await model.add_machine(
+            'lxd:{}'.format(machine2.id))
+
+        for m in (machine1, machine2, machine3):
+            assert isinstance(m, Machine)
+
+        assert len(model.machines) == 3

--- a/tests/unit/test_loop.py
+++ b/tests/unit/test_loop.py
@@ -1,9 +1,20 @@
+import asyncio
 import unittest
 import juju.loop
 
 
 class TestLoop(unittest.TestCase):
+    def setUp(self):
+        # new event loop for each test
+        policy = asyncio.get_event_loop_policy()
+        self.loop = policy.new_event_loop()
+        policy.set_event_loop(self.loop)
+
+    def tearDown(self):
+        self.loop.close()
+
     def test_run(self):
+        assert asyncio.get_event_loop() == self.loop
         async def _test():
             return 'success'
         self.assertEqual(juju.loop.run(_test()), 'success')

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,9 @@ skipsdist=True
 usedevelop=True
 passenv =
     HOME
-commands = py.test -ra -s -x
+commands = py.test -ra -s -x -n auto
 deps =
     pytest
     pytest-asyncio
+    pytest-xdist
     mock

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,8 @@ skipsdist=True
 usedevelop=True
 passenv =
     HOME
-commands = py.test -rsx
+commands = py.test -ra -s -x
 deps =
     pytest
+    pytest-asyncio
     mock


### PR DESCRIPTION
Also fixes a bug that was causing the 'to' parameter to
Model.deploy() to not be handled correctly.

Add docs and examples for adding machines and containers
and deploying charms to them.

Fixes #51.