### PR TITLE
Replace pass with NotImplementedError in method stubs

### DIFF
--- a/juju/application.py
+++ b/juju/application.py
@@ -106,7 +106,7 @@ class Application(model.ModelEntity):
         :param int value: Budget limit
 
         """
-        pass
+        raise NotImplementedError()
 
     def attach(self, resource_name, file_path):
         """Upload a file as a resource for this application.
@@ -115,13 +115,13 @@ class Application(model.ModelEntity):
         :param str file_path: Path to the file to upload
 
         """
-        pass
+        raise NotImplementedError()
 
     def collect_metrics(self):
         """Collect metrics on this application.
 
         """
-        pass
+        raise NotImplementedError()
 
     async def destroy_relation(self, local_relation, remote_relation):
         """Remove a relation to another application.
@@ -207,7 +207,7 @@ class Application(model.ModelEntity):
         :param bool schema: Return the full action schema
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_resources(self, details=False):
         """Return resources for this application.
@@ -216,7 +216,7 @@ class Application(model.ModelEntity):
             unit
 
         """
-        pass
+        raise NotImplementedError()
 
     async def run(self, command, timeout=None):
         """Run command on all units for this application.
@@ -294,7 +294,7 @@ class Application(model.ModelEntity):
         :param str info: Extra info message
 
         """
-        pass
+        raise NotImplementedError()
 
     def set_plan(self, plan_name):
         """Set the plan for this application, effective immediately.
@@ -302,7 +302,7 @@ class Application(model.ModelEntity):
         :param str plan_name: Name of plan
 
         """
-        pass
+        raise NotImplementedError()
 
     async def unexpose(self):
         """Remove public availability over the network for this application.
@@ -322,7 +322,7 @@ class Application(model.ModelEntity):
         :param int allocation: The allocation to set
 
         """
-        pass
+        raise NotImplementedError()
 
     def upgrade_charm(
             self, channel=None, force_series=False, force_units=False,
@@ -341,7 +341,7 @@ class Application(model.ModelEntity):
         :param str switch: Crossgrade charm url
 
         """
-        pass
+        raise NotImplementedError()
 
     async def get_metrics(self):
         """Get metrics for this application's units.

--- a/juju/cloud.py
+++ b/juju/cloud.py
@@ -10,13 +10,13 @@ class Cloud(object):
         :param `juju.Credential` credential: The Credential to add
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_credentials(self):
         """Return list of all credentials for this cloud.
 
         """
-        pass
+        raise NotImplementedError()
 
     def remove_credential(self, credential_name):
         """Remove a credential for this cloud.
@@ -24,7 +24,7 @@ class Cloud(object):
         :param str credential_name: Name of the credential to remove
 
         """
-        pass
+        raise NotImplementedError()
 
     def bootstrap(
             self, controller_name, region=None, agent_version=None,
@@ -62,7 +62,7 @@ class Cloud(object):
             bootstrapping
 
         """
-        pass
+        raise NotImplementedError()
 
     def set_default_credential(self, credential_name):
         """Set the default credentials for this cloud.
@@ -70,7 +70,7 @@ class Cloud(object):
         :param str credential_name: Credential to make default
 
         """
-        pass
+        raise NotImplementedError()
 
     def set_default_region(self, region):
         """Set the default region for this cloud.
@@ -78,4 +78,4 @@ class Cloud(object):
         :param str region: Name of region to make default
 
         """
-        pass
+        raise NotImplementedError()

--- a/juju/controller.py
+++ b/juju/controller.py
@@ -5,7 +5,6 @@ from . import tag
 from . import utils
 from .client import client
 from .client import connection
-from .client import watcher
 from .model import Model
 
 log = logging.getLogger(__name__)
@@ -154,7 +153,7 @@ class Controller(object):
         :param list models: Models to which the user is granted access
 
         """
-        pass
+        raise NotImplementedError()
 
     def change_user_password(self, username, password):
         """Change the password for a user in this controller.
@@ -163,7 +162,7 @@ class Controller(object):
         :param str password: New password
 
         """
-        pass
+        raise NotImplementedError()
 
     def destroy(self, destroy_all_models=False):
         """Destroy this controller.
@@ -172,7 +171,7 @@ class Controller(object):
             controller.
 
         """
-        pass
+        raise NotImplementedError()
 
     def disable_user(self, username):
         """Disable a user.
@@ -180,20 +179,20 @@ class Controller(object):
         :param str username: Username
 
         """
-        pass
+        raise NotImplementedError()
 
     def enable_user(self):
         """Re-enable a previously disabled user.
 
         """
-        pass
+        raise NotImplementedError()
 
     def kill(self):
         """Forcibly terminate all machines and other associated resources for
         this controller.
 
         """
-        pass
+        raise NotImplementedError()
 
     async def get_cloud(self):
         """
@@ -214,7 +213,7 @@ class Controller(object):
         :param str username: User for which to list models (admin use only)
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_payloads(self, *patterns):
         """Return list of known payloads.
@@ -232,7 +231,7 @@ class Controller(object):
             - payload status
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_users(self, all_=False):
         """Return list of users that can connect to this controller.
@@ -240,13 +239,13 @@ class Controller(object):
         :param bool all_: Include disabled users
 
         """
-        pass
+        raise NotImplementedError()
 
     def login(self):
         """Log in to this controller.
 
         """
-        pass
+        raise NotImplementedError()
 
     def logout(self, force=False):
         """Log out of this controller.
@@ -255,7 +254,7 @@ class Controller(object):
             with a password
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_model(self, name):
         """Get a model by name.
@@ -263,7 +262,7 @@ class Controller(object):
         :param str name: Model name
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_user(self, username):
         """Get a user by name.
@@ -271,4 +270,4 @@ class Controller(object):
         :param str username: Username
 
         """
-        pass
+        raise NotImplementedError()

--- a/juju/juju.py
+++ b/juju/juju.py
@@ -14,7 +14,7 @@ class Juju(object):
                 endpoint: https://london.mycloud.com:35574/v3.0/
 
         """
-        pass
+        raise NotImplementedError()
 
     def agree(self, *terms):
         """Agree to the terms of a charm.
@@ -22,45 +22,45 @@ class Juju(object):
         :param str \*terms: Terms to agree to
 
         """
-        pass
+        raise NotImplementedError()
 
     def autoload_credentials(self):
         """Finds cloud credentials and caches them for use by Juju when
         bootstrapping.
 
         """
-        pass
+        raise NotImplementedError()
 
     def create_budget(self):
         """Create a new budget.
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_agreements(self):
         """Return list of terms to which the current user has agreed.
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_budgets(self):
         """Return list of available budgets.
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_clouds(self):
         """Return list of all available clouds.
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_controllers(self):
         """Return list of all available controllers.
 
         (maybe move this to Cloud?)
         """
-        pass
+        raise NotImplementedError()
 
     def get_plans(self, charm_url):
         """Return list of plans available for the specified charm.
@@ -68,7 +68,7 @@ class Juju(object):
         :param str charm_url: Charm url
 
         """
-        pass
+        raise NotImplementedError()
 
     def register(self, registration_string):
         """Register a user to a controller.
@@ -76,7 +76,7 @@ class Juju(object):
         :param str registration_string: The registration string
 
         """
-        pass
+        raise NotImplementedError()
 
     def set_budget(self, name, limit):
         """Set a monthly budget limit.
@@ -85,7 +85,7 @@ class Juju(object):
         :param int limit: Monthly limit
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_cloud(self, name):
         """Get a cloud by name.
@@ -93,7 +93,7 @@ class Juju(object):
         :param str name: Name of cloud
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_controller(self, name, include_passwords=False):
         """Get a controller by name.
@@ -103,16 +103,16 @@ class Juju(object):
 
         (maybe move this to Cloud?)
         """
-        pass
+        raise NotImplementedError()
 
     def update_clouds(self):
         """Update public cloud info available to Juju.
 
         """
-        pass
+        raise NotImplementedError()
 
     def version(self):
         """Return the Juju version.
 
         """
-        pass
+        raise NotImplementedError()

--- a/juju/machine.py
+++ b/juju/machine.py
@@ -31,7 +31,7 @@ class Machine(model.ModelEntity):
         :param int timeout: Time to wait before command is considered failed
 
         """
-        pass
+        raise NotImplementedError()
 
     async def set_annotations(self, annotations):
         """Set annotations on this machine.
@@ -64,7 +64,7 @@ class Machine(model.ModelEntity):
         :param str scp_opts: Additional options to the `scp` command
 
         """
-        pass
+        raise NotImplementedError()
 
     def ssh(
             self, command, user=None, proxy=False, ssh_opts=None):
@@ -76,7 +76,7 @@ class Machine(model.ModelEntity):
         :param str ssh_opts: Additional options to the `ssh` command
 
         """
-        pass
+        raise NotImplementedError()
 
     def status_history(self, num=20, utc=False):
         """Get status history for this machine.
@@ -85,4 +85,4 @@ class Machine(model.ModelEntity):
         :param bool utc: Display time as UTC in RFC3339 format
 
         """
-        pass
+        raise NotImplementedError()

--- a/juju/model.py
+++ b/juju/model.py
@@ -832,7 +832,7 @@ class Model(object):
         :param \*cidrs: Optional list of existing subnet CIDRs
 
         """
-        pass
+        raise NotImplementedError()
 
     def add_ssh_key(self, key):
         """Add a public SSH key to this model.
@@ -840,7 +840,7 @@ class Model(object):
         :param str key: The public ssh key
 
         """
-        pass
+        raise NotImplementedError()
     add_ssh_keys = add_ssh_key
 
     def add_subnet(self, cidr_or_id, space, *zones):
@@ -851,13 +851,13 @@ class Model(object):
         :param str \*zones: Zone(s) in which the subnet resides
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_backups(self):
         """Retrieve metadata for backups in this model.
 
         """
-        pass
+        raise NotImplementedError()
 
     def block(self, *commands):
         """Add a new block to this model.
@@ -866,13 +866,13 @@ class Model(object):
             'all-changes', 'destroy-model', 'remove-object'
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_blocks(self):
         """List blocks for this model.
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_cached_images(self, arch=None, kind=None, series=None):
         """Return a list of cached OS images.
@@ -882,7 +882,7 @@ class Model(object):
         :param str series: Filter by image series, e.g. 'xenial'
 
         """
-        pass
+        raise NotImplementedError()
 
     def create_backup(self, note=None, no_download=False):
         """Create a backup of this model.
@@ -892,7 +892,7 @@ class Model(object):
         :return str: Path to downloaded archive
 
         """
-        pass
+        raise NotImplementedError()
 
     def create_storage_pool(self, name, provider_type, **pool_config):
         """Create or define a storage pool.
@@ -902,7 +902,7 @@ class Model(object):
         :param \*\*pool_config: key/value pool configuration pairs
 
         """
-        pass
+        raise NotImplementedError()
 
     def debug_log(
             self, no_tail=False, exclude_module=None, include_module=None,
@@ -926,7 +926,7 @@ class Model(object):
         :param list exclude: Do not show log messages for these entities
 
         """
-        pass
+        raise NotImplementedError()
 
     async def deploy(
             self, entity_url, application_name=None, bind=None, budget=None,
@@ -1052,7 +1052,7 @@ class Model(object):
         """Terminate all machines and resources for this model.
 
         """
-        pass
+        raise NotImplementedError()
 
     async def destroy_unit(self, *unit_names):
         """Destroy units by name.
@@ -1076,7 +1076,7 @@ class Model(object):
         :return str: Path to the archive file
 
         """
-        pass
+        raise NotImplementedError()
 
     def enable_ha(
             self, num_controllers=0, constraints=None, series=None, to=None):
@@ -1095,19 +1095,19 @@ class Model(object):
             If None, a new machine is provisioned.
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_config(self):
         """Return the configuration settings for this model.
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_constraints(self):
         """Return the machine constraints for this model.
 
         """
-        pass
+        raise NotImplementedError()
 
     def grant(self, username, acl='read'):
         """Grant a user access to this model.
@@ -1116,7 +1116,7 @@ class Model(object):
         :param str acl: Access control ('read' or 'write')
 
         """
-        pass
+        raise NotImplementedError()
 
     def import_ssh_key(self, identity):
         """Add a public SSH key from a trusted indentity source to this model.
@@ -1124,7 +1124,7 @@ class Model(object):
         :param str identity: User identity in the form <lp|gh>:<username>
 
         """
-        pass
+        raise NotImplementedError()
     import_ssh_keys = import_ssh_key
 
     def get_machines(self, machine, utc=False):
@@ -1134,25 +1134,25 @@ class Model(object):
         :param bool utc: Display time as UTC in RFC3339 format
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_shares(self):
         """Return list of all users with access to this model.
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_spaces(self):
         """Return list of all known spaces, including associated subnets.
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_ssh_key(self):
         """Return known SSH keys for this model.
 
         """
-        pass
+        raise NotImplementedError()
     get_ssh_keys = get_ssh_key
 
     def get_storage(self, filesystem=False, volume=False):
@@ -1162,7 +1162,7 @@ class Model(object):
         :param bool volume: Include volume storage
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_storage_pools(self, names=None, providers=None):
         """Return list of storage pools.
@@ -1171,7 +1171,7 @@ class Model(object):
         :param list providers: Only include pools for these providers
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_subnets(self, space=None, zone=None):
         """Return list of known subnets.
@@ -1180,13 +1180,13 @@ class Model(object):
         :param str zone: Only include subnets in this zone
 
         """
-        pass
+        raise NotImplementedError()
 
     def remove_blocks(self):
         """Remove all blocks from this model.
 
         """
-        pass
+        raise NotImplementedError()
 
     def remove_backup(self, backup_id):
         """Delete a backup.
@@ -1194,7 +1194,7 @@ class Model(object):
         :param str backup_id: The id of the backup to remove
 
         """
-        pass
+        raise NotImplementedError()
 
     def remove_cached_images(self, arch=None, kind=None, series=None):
         """Remove cached OS images.
@@ -1204,7 +1204,7 @@ class Model(object):
         :param str series: Image series to remove, e.g. 'xenial'
 
         """
-        pass
+        raise NotImplementedError()
 
     def remove_machine(self, *machine_ids):
         """Remove a machine from this model.
@@ -1212,7 +1212,7 @@ class Model(object):
         :param str \*machine_ids: Ids of the machines to remove
 
         """
-        pass
+        raise NotImplementedError()
     remove_machines = remove_machine
 
     def remove_ssh_key(self, *keys):
@@ -1221,7 +1221,7 @@ class Model(object):
         :param str \*keys: Keys to remove
 
         """
-        pass
+        raise NotImplementedError()
     remove_ssh_keys = remove_ssh_key
 
     def restore_backup(
@@ -1237,13 +1237,13 @@ class Model(object):
         :param bool upload_tools: Upload tools if bootstrapping a new machine
 
         """
-        pass
+        raise NotImplementedError()
 
     def retry_provisioning(self):
         """Retry provisioning for failed machines.
 
         """
-        pass
+        raise NotImplementedError()
 
     def revoke(self, username, acl='read'):
         """Revoke a user's access to this model.
@@ -1252,7 +1252,7 @@ class Model(object):
         :param str acl: Access control ('read' or 'write')
 
         """
-        pass
+        raise NotImplementedError()
 
     def run(self, command, timeout=None):
         """Run command on all machines in this model.
@@ -1261,7 +1261,7 @@ class Model(object):
         :param int timeout: Time to wait before command is considered failed
 
         """
-        pass
+        raise NotImplementedError()
 
     def set_config(self, **config):
         """Set configuration keys on this model.
@@ -1269,7 +1269,7 @@ class Model(object):
         :param \*\*config: Config key/values
 
         """
-        pass
+        raise NotImplementedError()
 
     def set_constraints(self, constraints):
         """Set machine constraints on this model.
@@ -1277,7 +1277,7 @@ class Model(object):
         :param :class:`juju.Constraints` constraints: Machine constraints
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_action_output(self, action_uuid, wait=-1):
         """Get the results of an action by ID.
@@ -1286,7 +1286,7 @@ class Model(object):
         :param int wait: Time in seconds to wait for action to complete
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_action_status(self, uuid_or_prefix=None, name=None):
         """Get the status of all actions, filtered by ID, ID prefix, or action name.
@@ -1295,7 +1295,7 @@ class Model(object):
         :param str name: Filter by action name
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_budget(self, budget_name):
         """Get budget usage info.
@@ -1303,7 +1303,7 @@ class Model(object):
         :param str budget_name: Name of budget
 
         """
-        pass
+        raise NotImplementedError()
 
     def get_status(self, filter_=None, utc=False):
         """Return the status of the model.
@@ -1312,7 +1312,7 @@ class Model(object):
         :param bool utc: Display time as UTC in RFC3339 format
 
         """
-        pass
+        raise NotImplementedError()
     status = get_status
 
     def sync_tools(
@@ -1330,7 +1330,7 @@ class Model(object):
         :param str version: Copy a specific major.minor version
 
         """
-        pass
+        raise NotImplementedError()
 
     def unblock(self, *commands):
         """Unblock an operation that would alter this model.
@@ -1339,7 +1339,7 @@ class Model(object):
             'all-changes', 'destroy-model', 'remove-object'
 
         """
-        pass
+        raise NotImplementedError()
 
     def unset_config(self, *keys):
         """Unset configuration on this model.
@@ -1347,13 +1347,13 @@ class Model(object):
         :param str \*keys: The keys to unset
 
         """
-        pass
+        raise NotImplementedError()
 
     def upgrade_gui(self):
         """Upgrade the Juju GUI for this model.
 
         """
-        pass
+        raise NotImplementedError()
 
     def upgrade_juju(
             self, dry_run=False, reset_previous_upgrade=False,
@@ -1367,7 +1367,7 @@ class Model(object):
         :param str version: Upgrade to a specific version
 
         """
-        pass
+        raise NotImplementedError()
 
     def upload_backup(self, archive_path):
         """Store a backup archive remotely in Juju.
@@ -1375,7 +1375,7 @@ class Model(object):
         :param str archive_path: Path to local archive
 
         """
-        pass
+        raise NotImplementedError()
 
     @property
     def charmstore(self):

--- a/juju/relation.py
+++ b/juju/relation.py
@@ -7,5 +7,5 @@ log = logging.getLogger(__name__)
 
 class Relation(model.ModelEntity):
     async def destroy(self):
-        pass
+        raise NotImplementedError()
         # TODO: destroy a relation

--- a/juju/unit.py
+++ b/juju/unit.py
@@ -63,13 +63,13 @@ class Unit(model.ModelEntity):
             form 'POOL,COUNT,SIZE'
 
         """
-        pass
+        raise NotImplementedError()
 
     def collect_metrics(self):
         """Collect metrics on this unit.
 
         """
-        pass
+        raise NotImplementedError()
 
     async def destroy(self):
         """Destroy this unit.
@@ -91,7 +91,7 @@ class Unit(model.ModelEntity):
             unit
 
         """
-        pass
+        raise NotImplementedError()
 
     def resolved(self, retry=False):
         """Mark unit errors resolved.
@@ -99,7 +99,7 @@ class Unit(model.ModelEntity):
         :param bool retry: Re-execute failed hooks
 
         """
-        pass
+        raise NotImplementedError()
 
     async def run(self, command, timeout=None):
         """Run command on this unit.
@@ -172,13 +172,13 @@ class Unit(model.ModelEntity):
         :param str scp_opts: Additional options to the `scp` command
 
         """
-        pass
+        raise NotImplementedError()
 
     def set_meter_status(self):
         """Set the meter status on this unit.
 
         """
-        pass
+        raise NotImplementedError()
 
     def ssh(
             self, command, user=None, proxy=False, ssh_opts=None):
@@ -190,7 +190,7 @@ class Unit(model.ModelEntity):
         :param str ssh_opts: Additional options to the `ssh` command
 
         """
-        pass
+        raise NotImplementedError()
 
     def status_history(self, num=20, utc=False):
         """Get status history for this unit.
@@ -199,7 +199,7 @@ class Unit(model.ModelEntity):
         :param bool utc: Display time as UTC in RFC3339 format
 
         """
-        pass
+        raise NotImplementedError()
 
     async def is_leader_from_status(self):
         """


### PR DESCRIPTION
This is arguably more user-friendly than silently passing when an
unimplemented method is called.

Fixes #58.