### PR TITLE
Fixes for conjure-up

### DIFF
--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -260,12 +260,17 @@ class Connection:
     async def connect_model(cls, model, loop=None):
         """Connect to a model by name.
 
-        :param str model: <controller>:<model>
+        :param str model: [<controller>:]<model>
 
         """
-        controller_name, model_name = model.split(':')
-
         jujudata = JujuData()
+
+        if ':' in model:
+            controller_name, model_name = model.split(':')
+        else:
+            controller_name = jujudata.current_controller()
+            model_name = model
+
         controller = jujudata.controllers()[controller_name]
         endpoint = controller['api-endpoints'][0]
         cacert = controller.get('ca-cert')

--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -267,6 +267,7 @@ class Connection:
         username = accounts['user']
         password = accounts.get('password')
         models = jujudata.models()[controller_name]
+        model_name = '{}/{}'.format(username, model_name)
         model_uuid = models['models'][model_name]['uuid']
         macaroons = get_macaroons() if not password else None
 
@@ -349,7 +350,7 @@ def get_macaroons():
         cookie_file = os.path.expanduser('~/.go-cookies')
         with open(cookie_file, 'r') as f:
             cookies = json.load(f)
-    except (OSError, ValueError) as e:
+    except (OSError, ValueError):
         log.warn("Couldn't load macaroons from %s", cookie_file)
         return []
 

--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -273,7 +273,8 @@ class Connection:
         username = accounts['user']
         password = accounts.get('password')
         models = jujudata.models()[controller_name]
-        model_name = '{}/{}'.format(username, model_name)
+        if '/' not in model_name:
+            model_name = '{}/{}'.format(username, model_name)
         model_uuid = models['models'][model_name]['uuid']
         macaroons = get_macaroons() if not password else None
 

--- a/juju/client/facade.py
+++ b/juju/client/facade.py
@@ -438,6 +438,8 @@ class Type:
 
     @classmethod
     def from_json(cls, data):
+        if isinstance(data, cls):
+            return data
         if isinstance(data, str):
             data = json.loads(data)
         d = {}

--- a/juju/constraints.py
+++ b/juju/constraints.py
@@ -39,10 +39,7 @@ def parse(constraints):
     and key value pairs joined by an '='.
 
     """
-    if constraints is None:
-        return None
-
-    if constraints == "":
+    if not constraints:
         return None
 
     if type(constraints) is dict:

--- a/juju/controller.py
+++ b/juju/controller.py
@@ -103,8 +103,9 @@ class Controller(object):
         try:
             ssh_key = await utils.read_ssh_key(loop=self.loop)
             await utils.execute_process(
-                'juju', 'add-ssh-key', '-m', model_name, ssh_key, log=log)
-        except Exception as e:
+                'juju', 'add-ssh-key', '-m', model_name, ssh_key, log=log,
+                loop=self.loop)
+        except Exception:
             log.exception(
                 "Could not add ssh key to model. You will not be able "
                 "to ssh into machines in this model. "
@@ -119,6 +120,7 @@ class Controller(object):
             self.connection.password,
             self.connection.cacert,
             self.connection.macaroons,
+            loop=self.loop,
         )
 
         return model

--- a/juju/model.py
+++ b/juju/model.py
@@ -1305,15 +1305,17 @@ class Model(object):
         """
         raise NotImplementedError()
 
-    def get_status(self, filter_=None, utc=False):
+    async def get_status(self, filters=None, utc=False):
         """Return the status of the model.
 
-        :param str filter_: Service or unit name or wildcard ('*')
+        :param str filters: Optional list of applications, units, or machines
+            to include, which can use wildcards ('*').
         :param bool utc: Display time as UTC in RFC3339 format
 
         """
-        raise NotImplementedError()
-    status = get_status
+        client_facade = client.ClientFacade()
+        client_facade.connect(self.connection)
+        return await client_facade.FullStatus(filters)
 
     def sync_tools(
             self, all_=False, destination=None, dry_run=False, public=False,

--- a/juju/model.py
+++ b/juju/model.py
@@ -1022,6 +1022,18 @@ class Model(object):
                 'Deploying %s', entity_id)
 
             if not is_local:
+                parts = entity_id[3:].split('/')
+                if parts[0].startswith('~'):
+                    parts.pop(0)
+                if not application_name:
+                    application_name = parts[-1].split('-')[0]
+                if not series:
+                    if len(parts) > 1:
+                        series = parts[0]
+                    else:
+                        entity = await self.charmstore.entity(entity_id)
+                        ss = entity['Meta']['supported-series']
+                        series = ss['SupportedSeries'][0]
                 await client_facade.AddCharm(channel, entity_id)
             elif not entity_id.startswith('local:'):
                 # We have a local charm dir that needs to be uploaded

--- a/juju/model.py
+++ b/juju/model.py
@@ -1500,7 +1500,7 @@ class BundleHandler(object):
             charm_urls = await asyncio.gather(*[
                 self.model.add_local_charm_dir(*params)
                 for params in args
-            ], loop=self.loop)
+            ], loop=self.model.loop)
             # Update the 'charm:' entry for each app with the new 'local:' url.
             for app_name, charm_url in zip(apps, charm_urls):
                 bundle['services'][app_name]['charm'] = charm_url

--- a/juju/utils.py
+++ b/juju/utils.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 
 
-async def execute_process(*cmd, log=None):
+async def execute_process(*cmd, log=None, loop=None):
     '''
     Wrapper around asyncio.create_subprocess_exec.
 
@@ -13,7 +13,7 @@ async def execute_process(*cmd, log=None):
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            )
+            loop=loop)
     stdout, stderr = await p.communicate()
     if log:
         log.debug("Exec %s -> %d", cmd, p.returncode)

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,9 +1,11 @@
-import uuid
+import mock
 import subprocess
+import uuid
 
 import pytest
 
 from juju.controller import Controller
+from juju.client.connection import JujuData
 
 
 def is_bootstrapped():
@@ -29,9 +31,16 @@ class CleanModel():
         model_name = 'model-{}'.format(uuid.uuid4())
         self.model = await self.controller.add_model(model_name)
 
+        # Ensure that we connect to the new model by default.  This also
+        # prevents failures if test was started with no current model.
+        self._patch_cm = mock.patch.object(JujuData, 'current_model',
+                                           return_value=model_name)
+        self._patch_cm.start()
+
         return self.model
 
     async def __aexit__(self, exc_type, exc, tb):
+        self._patch_cm.stop()
         await self.model.disconnect()
         await self.controller.destroy_model(self.model.info.uuid)
         await self.controller.disconnect()

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -92,3 +92,24 @@ class TestModelState(unittest.TestCase):
         self.assertFalse(new)
         self.assertIsInstance(prev, Application)
         self.assertTrue(prev)
+
+
+def test_get_series():
+    from juju.model import Model
+    model = Model()
+    entity = {
+        'Meta': {
+            'supported-series': {
+                'SupportedSeries': [
+                    'xenial',
+                    'trusty',
+                ],
+            },
+        },
+    }
+    assert model._get_series('cs:trusty/ubuntu', entity) == 'trusty'
+    assert model._get_series('xenial/ubuntu', entity) == 'xenial'
+    assert model._get_series('~foo/xenial/ubuntu', entity) == 'xenial'
+    assert model._get_series('~foo/ubuntu', entity) == 'xenial'
+    assert model._get_series('ubuntu', entity) == 'xenial'
+    assert model._get_series('cs:ubuntu', entity) == 'xenial'

--- a/tox.ini
+++ b/tox.ini
@@ -23,4 +23,4 @@ commands = py.test -ra -s -x -n auto -k 'not integration'
 
 [testenv:integration]
 basepython=python3
-commands = py.test -ra -s -x -n auto
+commands = py.test -ra -s -x -n auto {posargs}


### PR DESCRIPTION
Includes:
* Implement `Model().get_status`
* Fixes `Model.connect_model()` failing in 2.1 due to model names now including username in `models.yaml`
* Fixes explicit loop instance not being used in several places, causing the default loop to be used for some things but not others