### PR TITLE
Explicitly set basepython=python3 for integration tests.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,4 +22,5 @@ deps =
 commands = py.test -ra -s -x -n auto -k 'not integration'
 
 [testenv:integration]
+basepython=python3
 commands = py.test -ra -s -x -n auto


### PR DESCRIPTION
Fixes them on machines that don't have python3 set as the default.

@tvansteenburgh 