### PR TITLE
Updated examples to use juju.loop

### DIFF
--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -51,10 +51,11 @@ and in the documentation.
   import asyncio
   import logging
 
+  from juju import loop
   from juju.model import Model
 
 
-  async def run():
+  async def deploy():
       # Create a Model instance. We need to connect our Model to a Juju api
       # server before we can use it.
       model = Model()
@@ -74,9 +75,6 @@ and in the documentation.
       # Disconnect from the api server and cleanup.
       model.disconnect()
 
-      # Stop the asyncio event loop.
-      model.loop.stop()
-
 
   def main():
       # Set logging level to debug so we can see verbose output from the
@@ -88,14 +86,9 @@ and in the documentation.
       ws_logger = logging.getLogger('websockets.protocol')
       ws_logger.setLevel(logging.INFO)
 
-      # Create the asyncio event loop
-      loop = asyncio.get_event_loop()
-
-      # Queue up our `run()` coroutine for execution
-      loop.create_task(run())
-
-      # Start the event loop
-      loop.run_forever()
+      # Run the deploy coroutine in an asyncio event loop, using a helper
+      # that abstracts loop creation and teardown.
+      loop.run(deploy())
 
 
   if __name__ == '__main__':

--- a/examples/action.py
+++ b/examples/action.py
@@ -10,6 +10,7 @@ This example:
 import asyncio
 import logging
 
+from juju import loop
 from juju.model import Model
 
 
@@ -24,7 +25,7 @@ async def run_action(unit):
     logging.debug("Action results: %s", action.results)
 
 
-async def run():
+async def main():
     model = Model()
     await model.connect_current()
     await model.reset(force=True)
@@ -40,13 +41,10 @@ async def run():
         await run_action(unit)
 
     await model.disconnect()
-    model.loop.stop()
 
 
-logging.basicConfig(level=logging.DEBUG)
-ws_logger = logging.getLogger('websockets.protocol')
-ws_logger.setLevel(logging.INFO)
-loop = asyncio.get_event_loop()
-loop.set_debug(False)
-loop.create_task(run())
-loop.run_forever()
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    ws_logger = logging.getLogger('websockets.protocol')
+    ws_logger.setLevel(logging.INFO)
+    loop.run(main())

--- a/examples/add_machine.py
+++ b/examples/add_machine.py
@@ -62,8 +62,9 @@ async def main():
         await model.disconnect()
 
 
-logging.basicConfig(level=logging.DEBUG)
-ws_logger = logging.getLogger('websockets.protocol')
-ws_logger.setLevel(logging.INFO)
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    ws_logger = logging.getLogger('websockets.protocol')
+    ws_logger.setLevel(logging.INFO)
 
-loop.run(main())
+    loop.run(main())

--- a/examples/add_model.py
+++ b/examples/add_model.py
@@ -61,4 +61,5 @@ async def main():
         await controller.disconnect()
 
 
-loop.run(main())
+if __name__ == '__main__':
+    loop.run(main())

--- a/examples/allwatcher.py
+++ b/examples/allwatcher.py
@@ -12,10 +12,12 @@ import logging
 
 from juju.client.connection import Connection
 from juju.client import watcher
+from juju import loop
 
 
 async def watch():
     allwatcher = watcher.AllWatcher()
+    conn = await Connection.connect_current()
     allwatcher.connect(conn)
     while True:
         change = await allwatcher.Next()
@@ -23,7 +25,8 @@ async def watch():
             print(delta.deltas)
 
 
-logging.basicConfig(level=logging.DEBUG)
-loop = asyncio.get_event_loop()
-conn = loop.run_until_complete(Connection.connect_current())
-loop.run_until_complete(watch())
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    # Run loop until the process is manually stopped (watch will loop
+    # forever).
+    loop.run(watch())

--- a/examples/config.py
+++ b/examples/config.py
@@ -10,13 +10,14 @@ import asyncio
 import logging
 
 from juju.model import Model
+from juju import loop
 
 log = logging.getLogger(__name__)
 
 MB = 1
 
 
-async def run():
+async def main():
     model = Model()
     await model.connect_current()
     await model.reset(force=True)
@@ -45,12 +46,10 @@ async def run():
     assert(constraints['mem'] == 512 * MB)
 
     await model.disconnect()
-    model.loop.stop()
 
-logging.basicConfig(level=logging.DEBUG)
-ws_logger = logging.getLogger('websockets.protocol')
-ws_logger.setLevel(logging.INFO)
-loop = asyncio.get_event_loop()
-loop.set_debug(False)
-loop.create_task(run())
-loop.run_forever()
+    
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    ws_logger = logging.getLogger('websockets.protocol')
+    ws_logger.setLevel(logging.INFO)
+    loop.run(main())

--- a/examples/controller.py
+++ b/examples/controller.py
@@ -12,9 +12,10 @@ import asyncio
 import logging
 
 from juju.controller import Controller
+from juju import loop
 
 
-async def run():
+async def main():
     controller = Controller()
     await controller.connect_current()
     model = await controller.add_model(
@@ -31,13 +32,10 @@ async def run():
     await model.disconnect()
     await controller.destroy_model(model.info.uuid)
     await controller.disconnect()
-    model.loop.stop()
 
 
-logging.basicConfig(level=logging.DEBUG)
-ws_logger = logging.getLogger('websockets.protocol')
-ws_logger.setLevel(logging.INFO)
-loop = asyncio.get_event_loop()
-loop.set_debug(False)
-loop.create_task(run())
-loop.run_forever()
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    ws_logger = logging.getLogger('websockets.protocol')
+    ws_logger.setLevel(logging.INFO)
+    loop.run(main())

--- a/examples/deploy.py
+++ b/examples/deploy.py
@@ -36,4 +36,5 @@ async def main():
         await model.disconnect()
 
 
-loop.run(main())
+if __name__ == '__main__':
+    loop.run(main())

--- a/examples/fullstatus.py
+++ b/examples/fullstatus.py
@@ -2,14 +2,11 @@ import asyncio
 
 from juju.client.connection import Connection
 from juju.client.client import ClientFacade
-
-
-loop = asyncio.get_event_loop()
-conn = loop.run_until_complete(Connection.connect_current())
-
+from juju import loop
 
 async def status():
     client = ClientFacade()
+    conn = await Connection.connect_current()
     client.connect(conn)
 
     patterns = None
@@ -22,5 +19,6 @@ async def status():
 
     return status
 
-loop.run_until_complete(status())
-loop.stop()
+if __name__ == '__main__':
+    loop.run(status())
+

--- a/examples/future.py
+++ b/examples/future.py
@@ -6,9 +6,10 @@ import asyncio
 import logging
 
 from juju.model import Model
+from juju import loop
 
 
-async def run():
+async def main():
     model = Model()
     await model.connect_current()
     await model.reset(force=True)
@@ -40,9 +41,8 @@ async def run():
     )
 
 
-logging.basicConfig(level=logging.DEBUG)
-ws_logger = logging.getLogger('websockets.protocol')
-ws_logger.setLevel(logging.INFO)
-loop = asyncio.get_event_loop()
-loop.create_task(run())
-loop.run_forever()
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    ws_logger = logging.getLogger('websockets.protocol')
+    ws_logger.setLevel(logging.INFO)
+    loop.run(main())

--- a/examples/leadership.py
+++ b/examples/leadership.py
@@ -9,6 +9,7 @@ This example:
 import asyncio
 
 from juju.model import Model
+from juju import loop
 
 async def report_leadership():
     model = Model()
@@ -22,5 +23,6 @@ async def report_leadership():
 
     await model.disconnect()
 
-loop = asyncio.get_event_loop()
-loop.run_until_complete(report_leadership())
+
+if __name__ == '__main__':
+    loop.run(report_leadership())

--- a/examples/livemodel.py
+++ b/examples/livemodel.py
@@ -9,6 +9,7 @@ This example:
 import asyncio
 
 from juju.model import Model
+from juju import loop
 
 
 async def on_model_change(delta, old, new, model):
@@ -25,6 +26,7 @@ async def watch_model():
     model.add_observer(on_model_change)
 
 
-loop = asyncio.get_event_loop()
-loop.create_task(watch_model())
-loop.run_forever()
+if __name__ == '__main__':
+    # Run loop until the process is manually stopped (watch_model will loop
+    # forever).
+    loop.run(watch_model())

--- a/examples/localcharm.py
+++ b/examples/localcharm.py
@@ -10,9 +10,10 @@ import asyncio
 import logging
 
 from juju.model import Model
+from juju import loop
 
 
-async def run():
+async def main():
     model = Model()
     await model.connect_current()
 
@@ -24,13 +25,10 @@ async def run():
     )
 
     await model.disconnect()
-    model.loop.stop()
 
 
-logging.basicConfig(level=logging.DEBUG)
-ws_logger = logging.getLogger('websockets.protocol')
-ws_logger.setLevel(logging.INFO)
-loop = asyncio.get_event_loop()
-loop.set_debug(False)
-loop.create_task(run())
-loop.run_forever()
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    ws_logger = logging.getLogger('websockets.protocol')
+    ws_logger.setLevel(logging.INFO)
+    loop.run(main())

--- a/examples/relate.py
+++ b/examples/relate.py
@@ -11,6 +11,7 @@ import asyncio
 import logging
 
 from juju.model import Model, ModelObserver
+from juju import loop
 
 
 class MyRemoveObserver(ModelObserver):
@@ -35,10 +36,9 @@ class MyModelObserver(ModelObserver):
             logging.debug('All units idle, disconnecting')
             await model.reset(force=True)
             await model.disconnect()
-            model.loop.stop()
 
 
-async def run():
+async def main():
     model = Model()
     await model.connect_current()
 
@@ -90,10 +90,9 @@ async def run():
             print('Relation removed: {}'.format(old_rel.endpoints))
     ))
 
-logging.basicConfig(level=logging.DEBUG)
-ws_logger = logging.getLogger('websockets.protocol')
-ws_logger.setLevel(logging.INFO)
-loop = asyncio.get_event_loop()
-loop.set_debug(True)
-loop.create_task(run())
-loop.run_forever()
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    ws_logger = logging.getLogger('websockets.protocol')
+    ws_logger.setLevel(logging.INFO)
+    loop.run(main())

--- a/examples/unitrun.py
+++ b/examples/unitrun.py
@@ -11,6 +11,7 @@ import asyncio
 import logging
 
 from juju.model import Model
+from juju import loop
 
 
 async def run_command(unit):
@@ -21,7 +22,7 @@ async def run_command(unit):
     logging.debug("Action results: %s", action.results)
 
 
-async def run():
+async def main():
     model = Model()
     await model.connect_current()
     await model.reset(force=True)
@@ -37,13 +38,10 @@ async def run():
         await run_command(unit)
 
     await model.disconnect()
-    model.loop.stop()
 
 
-logging.basicConfig(level=logging.DEBUG)
-ws_logger = logging.getLogger('websockets.protocol')
-ws_logger.setLevel(logging.INFO)
-loop = asyncio.get_event_loop()
-loop.set_debug(False)
-loop.create_task(run())
-loop.run_forever()
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.DEBUG)
+    ws_logger = logging.getLogger('websockets.protocol')
+    ws_logger.setLevel(logging.INFO)
+    loop.run(main())


### PR DESCRIPTION
Also updated the README.

Made a few other tweaks to make them more consistent in style.

@tvansteenburgh @abentley @johnsca: I wanted to make sure that when people encounter this library the first time, they encounter our loop helper, and aren't turned off by the details of standing up an asyncio event loop.