### PR TITLE
Added test to reproduce bug with FullStatus against latest juju.

### DIFF
--- a/tests/integration/test_connection.py
+++ b/tests/integration/test_connection.py
@@ -1,6 +1,7 @@
 import pytest
 
 from juju.client.connection import Connection
+from juju.client import client
 from .. import base
 
 
@@ -12,3 +13,20 @@ async def test_connect_current(event_loop):
 
         assert isinstance(conn, Connection)
         await conn.close()
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_full_status(event_loop):
+    async with base.CleanModel() as model:
+        app = await model.deploy(
+            'ubuntu-0',
+            application_name='ubuntu',
+            series='trusty',
+            channel='stable',
+        )
+
+        c = client.ClientFacade()
+        c.connect(model.connection)
+
+        status = await c.FullStatus(None)


### PR DESCRIPTION
If the current python-libjuju is run against juju-2.2-alpha1 (or the
daily builds), client.FullStatus breaks due to a missing 'model-status'
key.

This is a repro for https://github.com/juju/python-libjuju/issues/90

@johnsca @tvansteenburgh 