### PR TITLE
Allow underscore to dash translation when accessing model attributes

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -230,7 +230,14 @@ class ModelEntity(object):
         model.
 
         """
-        return self.safe_data[name]
+        try:
+            return self.safe_data[name]
+        except KeyError:
+            name = name.replace('_', '-')
+            if name in self.safe_data:
+                return self.safe_data[name]
+            else:
+                raise
 
     def __bool__(self):
         return bool(self.data)


### PR DESCRIPTION
Would let you do `unit.machine_id` rather than having to do `getattr(unit, "machine-id")`.

I'm not going to cry about it if you're not accepting this, though I do think it looks a lot prettier. :)