### PR TITLE
Workaround or missing redirect_info in JaaS.

### DIFF
--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -323,7 +323,16 @@ class Connection:
                      loop)
         await client.open()
 
-        redirect_info = await client.redirect_info()
+        try:
+            redirect_info = await client.redirect_info()
+        except JujuAPIError as e:
+            # JaaS doesn't seem to current support redirect_info. We
+            # get an APIError, which I believe that we can safely
+            # ignore.
+            log.warning(
+                "Unable to get redirect info due to "
+                "JujuAPIError: '{}'. Ignoring and continuing".format(e))
+            redirect_info = None
         if not redirect_info:
             await client.login(username, password, macaroons)
             return client


### PR DESCRIPTION
JaaS deployments were throwing a JujuAPIError because the JaaS
controller does not appear to have implemented redirect_info.

Dropped in a change to catch the error and ignore it in that case.

@tvansteenburgh @johnsca I'm not sure how to test JaaS stuff effectively. To validate that my code works, you can run examples/add_model.py, after editing the file to pass `cloud_name="aws"` into the call to .add_model.

(Without this change, add_model will fail due to a JujuAPIErrror.)