### PR TITLE
Refactored login code to better handle redirects

### DIFF
--- a/examples/add_model.py
+++ b/examples/add_model.py
@@ -51,13 +51,14 @@ async def main():
         print("Destroying model")
         await controller.destroy_model(model.info.uuid)
 
-    except Exception as e:
+    except Exception:
         LOG.exception(
             "Test failed! Model {} may not be cleaned up".format(model_name))
 
     finally:
         print('Disconnecting from controller')
-        await model.disconnect()
+        if model:
+            await model.disconnect()
         await controller.disconnect()
 
 

--- a/juju/errors.py
+++ b/juju/errors.py
@@ -4,7 +4,9 @@ class JujuError(Exception):
 
 class JujuAPIError(JujuError):
     def __init__(self, result):
+        self.result = result
         self.message = result['error']
+        self.error_code = result.get('error-code')
         self.response = result['response']
         self.request_id = result['request-id']
         super().__init__(self.message)

--- a/juju/model.py
+++ b/juju/model.py
@@ -621,9 +621,8 @@ class Model(object):
         async def _start_watch():
             self._watch_shutdown.clear()
             try:
-                self._watch_conn = await self.connection.clone()
                 allwatcher = client.AllWatcherFacade.from_connection(
-                    self._watch_conn)
+                    self.connection)
                 while True:
                     results = await allwatcher.Next()
                     for delta in results.deltas:
@@ -640,11 +639,8 @@ class Model(object):
                             loop=self.loop)
                     self._watch_received.set()
             except CancelledError:
-                log.debug('Closing watcher connection')
-                await self._watch_conn.close()
                 self._watch_shutdown.set()
-                self._watch_conn = None
-            except Exception as e:
+            except Exception:
                 log.exception('Error in watcher')
                 raise
 

--- a/tests/integration/test_controller.py
+++ b/tests/integration/test_controller.py
@@ -1,5 +1,3 @@
-import asyncio
-from concurrent.futures import ThreadPoolExecutor
 import pytest
 import uuid
 
@@ -43,9 +41,11 @@ async def test_change_user_password(event_loop):
         await controller.add_user(username)
         await controller.change_user_password(username, 'password')
         try:
-            con = await controller.connect(
+            new_controller = Controller()
+            await new_controller.connect(
                 controller.connection.endpoint, username, 'password')
             result = True
+            await new_controller.disconnect()
         except JujuAPIError:
             result = False
         assert result is True
@@ -59,11 +59,13 @@ async def test_grant(event_loop):
         await controller.add_user(username)
         await controller.grant(username, 'superuser')
         result = await controller.get_user(username)
-        result = result.serialize()['results'][0].serialize()['result'].serialize()
+        result = result.serialize()['results'][0].serialize()['result']\
+            .serialize()
         assert result['access'] == 'superuser'
         await controller.grant(username, 'login')
         result = await controller.get_user(username)
-        result = result.serialize()['results'][0].serialize()['result'].serialize()
+        result = result.serialize()['results'][0].serialize()['result']\
+            .serialize()
         assert result['access'] == 'login'
 
 


### PR DESCRIPTION
Fixes #114: build_facades not handling discharge-required results
Fixes #115: JAAS update broke controller connections

Also ensures that the receiver and pinger tasks get cleaned up properly when a connection is closed.

Also makes the model AllWatcher share the model connection to reduce the number of open connections required.  The independent connection is no longer needed since the websocket responses are properly paired with the requests.  (The secondary connection was causing additional authentication errors, for some reason.)