### PR TITLE
Add model context manager

### DIFF
--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -407,7 +407,11 @@ class Connection:
 
         """
         jujudata = JujuData()
+
         controller_name = jujudata.current_controller()
+        if not controller_name:
+            raise JujuConnectionError('No current controller')
+
         model_name = jujudata.current_model()
 
         return await cls.connect_model(

--- a/juju/model.py
+++ b/juju/model.py
@@ -390,6 +390,16 @@ class Model(object):
         self._watch_received = asyncio.Event(loop=self.loop)
         self._charmstore = CharmStore(self.loop)
 
+    async def __aenter__(self):
+        await self.connect_current()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.disconnect()
+
+        if exc_type is not None:
+            return False
+
     async def connect(self, *args, **kw):
         """Connect to an arbitrary Juju model.
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,10 +16,11 @@ deps =
     pytest-asyncio
     pytest-xdist
     mock
+    asynctest
 
 [testenv:py35]
 # default tox env excludes integration tests
-commands = py.test -ra -s -x -n auto -k 'not integration'
+commands = py.test -ra -s -x -n auto -k 'not integration' {posargs}
 
 [testenv:integration]
 basepython=python3


### PR DESCRIPTION
This implements a context manager for the Model class which automatically connects to the current model and disconnects when you exit the scope. I found myself repeating the connect and disconnect functions a lot in charm tests so I thought this could be beneficial to someone else as well.

Example usage:
```
with Model() as model:
    model.deploy(...)
```

I also added the asynctest package to the testsuite because pytest-asyncio doesn't support TestCase classes.
See: https://github.com/pytest-dev/pytest-asyncio/issues/15
asynctest made it extremely easy to write tests for async functions, it could be useful to check out for other tests where asyncio is heavily involved.