### PR TITLE
Configurable and larger max message size

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ deps =
     pytest-xdist
     mock
     asynctest
+    ipdb
 
 [testenv:py35]
 # default tox env excludes integration tests


### PR DESCRIPTION
The default max message / frame size for the websocket library is 1MB.  However, the initial AllWatcher response for large models can exceed that.  Increased the default to 4MB and made it configurable.

Fixes #136