### PR TITLE
Improve handling of closed connections

### DIFF
--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -395,9 +395,10 @@ class Connection:
     async def reconnect(self):
         """ Force a reconnection.
         """
-        if self.monitor.reconnecting.locked():
+        monitor = self.monitor
+        if monitor.reconnecting.locked() or monitor.close_called.is_set():
             return
-        async with self.monitor.reconnecting:
+        async with monitor.reconnecting:
             await self.close()
             await self._connect()
 

--- a/juju/model.py
+++ b/juju/model.py
@@ -656,6 +656,18 @@ class Model(object):
                             allwatcher.Next(),
                             self._watch_stopping,
                             self.loop)
+                    except JujuAPIError as e:
+                        if 'watcher was stopped' not in str(e):
+                            raise
+                        # controller stopped our watcher for some reason
+                        # (we never actually call AllWatcherFacade.Stop(),
+                        # so there's no reason we should see this, but the
+                        # controller does occasionally send it anyway; so
+                        # if we get it, just start a new watcher)
+                        log.warning(
+                            'Watcher: watcher stopped, restarting')
+                        del allwatcher.Id
+                        continue
                     except websockets.ConnectionClosed:
                         monitor = self.connection.monitor
                         if monitor.status == monitor.ERROR:

--- a/juju/model.py
+++ b/juju/model.py
@@ -14,6 +14,7 @@ from concurrent.futures import CancelledError
 from functools import partial
 from pathlib import Path
 
+import websockets
 import yaml
 import theblues.charmstore
 import theblues.errors
@@ -661,6 +662,8 @@ class Model(object):
                     self._watch_received.set()
             except CancelledError:
                 pass
+            except websockets.ConnectionClosed:
+                log.error('Connection closed on watcher')
             except Exception:
                 log.exception('Error in watcher')
                 raise

--- a/juju/model.py
+++ b/juju/model.py
@@ -551,6 +551,8 @@ class Model(object):
         """
         async def _block():
             while not all(c() for c in conditions):
+                if not (self.connection and self.connection.is_open):
+                    raise websockets.ConnectionClosed(1006, 'no reason')
                 await asyncio.sleep(wait_period, loop=self.loop)
         await asyncio.wait_for(_block(), timeout, loop=self.loop)
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -44,6 +44,9 @@ class CleanModel():
         model_name = 'model-{}'.format(uuid.uuid4())
         self.model = await self.controller.add_model(model_name)
 
+        # save the model UUID in case test closes model
+        self.model_uuid = self.model.info.uuid
+
         # Ensure that we connect to the new model by default.  This also
         # prevents failures if test was started with no current model.
         self._patch_cm = mock.patch.object(JujuData, 'current_model',
@@ -55,7 +58,7 @@ class CleanModel():
     async def __aexit__(self, exc_type, exc, tb):
         self._patch_cm.stop()
         await self.model.disconnect()
-        await self.controller.destroy_model(self.model.info.uuid)
+        await self.controller.destroy_model(self.model_uuid)
         await self.controller.disconnect()
 
 

--- a/tests/integration/test_connection.py
+++ b/tests/integration/test_connection.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 
 from juju.client.connection import Connection
@@ -47,7 +48,7 @@ async def test_monitor_catches_error(event_loop):
 @pytest.mark.asyncio
 async def test_full_status(event_loop):
     async with base.CleanModel() as model:
-        app = await model.deploy(
+        await model.deploy(
             'ubuntu-0',
             application_name='ubuntu',
             series='trusty',
@@ -56,4 +57,27 @@ async def test_full_status(event_loop):
 
         c = client.ClientFacade.from_connection(model.connection)
 
-        status = await c.FullStatus(None)
+        await c.FullStatus(None)
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_reconnect(event_loop):
+    async with base.CleanModel() as model:
+        conn = await Connection.connect(
+            model.connection.endpoint,
+            model.connection.uuid,
+            model.connection.username,
+            model.connection.password,
+            model.connection.cacert,
+            model.connection.macaroons,
+            model.connection.loop,
+            model.connection.max_frame_size)
+        try:
+            await asyncio.sleep(0.1)
+            assert conn.is_open
+            await conn.ws.close()
+            assert not conn.is_open
+            await model.block_until(lambda: conn.is_open, timeout=3)
+        finally:
+            await conn.close()

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -212,6 +212,15 @@ async def test_get_machines(event_loop):
         assert isinstance(result, list)
 
 
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_watcher_reconnect(event_loop):
+    async with base.CleanModel() as model:
+        await model.connection.ws.close()
+        await asyncio.sleep(0.1)
+        assert model.connection.is_open
+
+
 # @base.bootstrapped
 # @pytest.mark.asyncio
 # async def test_grant(event_loop)

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import mock
 import pytest
@@ -20,6 +21,7 @@ class WebsocketMock:
 
     async def recv(self):
         if not self.responses:
+            await asyncio.sleep(1)  # delay to give test time to finish
             raise ConnectionClosed(0, 'ran out of responses')
         return json.dumps(self.responses.popleft())
 


### PR DESCRIPTION
This fixes #147 by closing the watcher gracefully when the connection is closed unexpectedly so that the `Monitor` can report it as intended.  It also fixes a circular reference between the `Connection` and `Monitor`, improves the logic in the monitor status, and makes `Model.block_until` raise a `websockets.ConnectionClosed` exception instead of blocking indefinitely.

**Edit:** Also fixes conjure-up/conjure-up#965