### PR TITLE
Implement scp functionality

### DIFF
--- a/juju/machine.py
+++ b/juju/machine.py
@@ -140,7 +140,7 @@ class Machine(model.ModelEntity):
         if proxy:
             raise NotImplementedError('proxy option is not implemented')
 
-        address = self.public_address
+        address = self.dns_name
         destination = '%s@%s:%s' % (user, address, destination)
         await self._scp(source, destination, scp_opts)
 
@@ -157,7 +157,7 @@ class Machine(model.ModelEntity):
         if proxy:
             raise NotImplementedError('proxy option is not implemented')
 
-        address = self.public_address
+        address = self.dns_name
         source = '%s@%s:%s' % (user, address, source)
         await self._scp(source, destination, scp_opts)
 
@@ -247,10 +247,11 @@ class Machine(model.ModelEntity):
         return parse_date(self.safe_data['instance-status']['since'])
 
     @property
-    def public_address(self):
-        """Get a public address for this machine.
+    def dns_name(self):
+        """Get the DNS name for this machine. This is a best guess based on the
+        addresses available in current data.
 
-        May return None if no public address is found.
+        May return None if no suitable address is found.
         """
         for scope in ['public', 'local-cloud']:
             addresses = self.safe_data['addresses'] or []

--- a/juju/machine.py
+++ b/juju/machine.py
@@ -124,18 +124,27 @@ class Machine(model.ModelEntity):
         )
         return await self.ann_facade.Set([ann])
 
-    def scp(
-            self, source_path, user=None, destination_path=None, proxy=False,
-            scp_opts=None):
+    async def scp_to(self, source, destination, user='ubuntu', proxy=False,
+                     scp_opts=None):
         """Transfer files to this machine.
 
-        :param str source_path: Path of file(s) to transfer
+        :param str source: Local path of file(s) to transfer
+        :param str destination: Remote destination of transferred files
         :param str user: Remote username
-        :param str destination_path: Destination of transferred files on
-            remote machine
         :param bool proxy: Proxy through the Juju API server
         :param str scp_opts: Additional options to the `scp` command
+        """
+        raise NotImplementedError()
 
+    async def scp_from(self, source, destination, user='ubuntu', proxy=False,
+                     scp_opts=None):
+        """Transfer files from this machine.
+
+        :param str source: Remote path of file(s) to transfer
+        :param str destination: Local destination of transferred files
+        :param str user: Remote username
+        :param bool proxy: Proxy through the Juju API server
+        :param str scp_opts: Additional options to the `scp` command
         """
         raise NotImplementedError()
 

--- a/juju/machine.py
+++ b/juju/machine.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 
 from dateutil.parser import parse as parse_date
 
@@ -166,7 +167,7 @@ class Machine(model.ModelEntity):
         """
         cmd = [
             'scp',
-            '-i', '~/.local/share/juju/ssh/juju_id_rsa',
+            '-i', os.path.expanduser('~/.local/share/juju/ssh/juju_id_rsa'),
             '-o', 'StrictHostKeyChecking=no',
             source, destination
         ]

--- a/juju/machine.py
+++ b/juju/machine.py
@@ -252,7 +252,10 @@ class Machine(model.ModelEntity):
 
         May return None if no public address is found.
         """
-        addresses = self.safe_data['addresses'] or []
-        addresses = [address for address in addresses
-                     if address['scope'] == 'public']
-        return addresses[0]['value'] if addresses else None
+        for scope in ['public', 'local-cloud']:
+            addresses = self.safe_data['addresses'] or []
+            addresses = [address for address in addresses
+                         if address['scope'] == scope]
+            if addresses:
+                return addresses[0]['value']
+        return None

--- a/juju/unit.py
+++ b/juju/unit.py
@@ -57,8 +57,10 @@ class Unit(model.ModelEntity):
 
         """
         machine_id = self.safe_data['machine-id']
-        machine = self.model.machines[machine_id] if machine_id else None
-        return machine
+        if machine_id:
+            return self.model.machines.get(machine_id, None)
+        else:
+            return None
 
     @property
     def public_address(self):

--- a/juju/unit.py
+++ b/juju/unit.py
@@ -163,18 +163,27 @@ class Unit(model.ModelEntity):
         # action is complete, rather than just being in the model
         return await self.model._wait_for_new('action', action_id)
 
-    def scp(
-            self, source_path, user=None, destination_path=None, proxy=False,
-            scp_opts=None):
+    async def scp_to(self, source, destination, user='ubuntu', proxy=False,
+                     scp_opts=None):
         """Transfer files to this unit.
 
-        :param str source_path: Path of file(s) to transfer
+        :param str source: Local path of file(s) to transfer
+        :param str destination: Remote destination of transferred files
         :param str user: Remote username
-        :param str destination_path: Destination of transferred files on
-            remote machine
         :param bool proxy: Proxy through the Juju API server
         :param str scp_opts: Additional options to the `scp` command
+        """
+        raise NotImplementedError()
 
+    async def scp_from(self, source, destination, user='ubuntu', proxy=False,
+                     scp_opts=None):
+        """Transfer files from this unit.
+
+        :param str source: Remote path of file(s) to transfer
+        :param str destination: Local destination of transferred files
+        :param str user: Remote username
+        :param bool proxy: Proxy through the Juju API server
+        :param str scp_opts: Additional options to the `scp` command
         """
         raise NotImplementedError()
 

--- a/juju/unit.py
+++ b/juju/unit.py
@@ -52,6 +52,15 @@ class Unit(model.ModelEntity):
         return self.safe_data['workload-status']['message']
 
     @property
+    def machine(self):
+        """Get the machine object for this unit.
+
+        """
+        machine_id = self.safe_data['machine-id']
+        machine = self.model.machines[machine_id] if machine_id else None
+        return machine
+
+    @property
     def public_address(self):
         """ Get the public address.
 
@@ -164,7 +173,7 @@ class Unit(model.ModelEntity):
         return await self.model._wait_for_new('action', action_id)
 
     async def scp_to(self, source, destination, user='ubuntu', proxy=False,
-                     scp_opts=None):
+                     scp_opts=''):
         """Transfer files to this unit.
 
         :param str source: Local path of file(s) to transfer
@@ -173,10 +182,11 @@ class Unit(model.ModelEntity):
         :param bool proxy: Proxy through the Juju API server
         :param str scp_opts: Additional options to the `scp` command
         """
-        raise NotImplementedError()
+        await self.machine.scp_to(source, destination, user=user, proxy=proxy,
+                                  scp_opts=scp_opts)
 
     async def scp_from(self, source, destination, user='ubuntu', proxy=False,
-                     scp_opts=None):
+                       scp_opts=''):
         """Transfer files from this unit.
 
         :param str source: Remote path of file(s) to transfer
@@ -185,7 +195,8 @@ class Unit(model.ModelEntity):
         :param bool proxy: Proxy through the Juju API server
         :param str scp_opts: Additional options to the `scp` command
         """
-        raise NotImplementedError()
+        await self.machine.scp_from(source, destination, user=user,
+                                    proxy=proxy, scp_opts=scp_opts)
 
     def set_meter_status(self):
         """Set the meter status on this unit.

--- a/tests/integration/test_machine.py
+++ b/tests/integration/test_machine.py
@@ -48,7 +48,8 @@ async def test_scp(event_loop):
             timeout=240)
         machine = model.machines['0']
         await asyncio.wait_for(
-            model.block_until(lambda: machine.status == 'running'),
+            model.block_until(lambda: (machine.status == 'running' and
+                                       machine.agent_status == 'started')),
             timeout=480)
 
         with NamedTemporaryFile() as f:

--- a/tests/integration/test_machine.py
+++ b/tests/integration/test_machine.py
@@ -1,6 +1,7 @@
 import asyncio
-
 import pytest
+
+from tempfile import NamedTemporaryFile
 
 from .. import base
 
@@ -35,3 +36,26 @@ async def test_status(event_loop):
         assert machine.status_message.lower() == 'running'
         assert machine.agent_status == 'started'
         assert machine.agent_version.major >= 2
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_scp(event_loop):
+    async with base.CleanModel() as model:
+        await model.add_machine()
+        await asyncio.wait_for(
+            model.block_until(lambda: model.machines),
+            timeout=240)
+        machine = model.machines['0']
+        await asyncio.wait_for(
+            model.block_until(lambda: machine.status == 'running'),
+            timeout=480)
+
+        with NamedTemporaryFile() as f:
+            f.write(b'testcontents')
+            f.flush()
+            await machine.scp_to(f.name, 'testfile')
+
+        with NamedTemporaryFile() as f:
+            await machine.scp_from('testfile', f.name)
+            assert f.read() == b'testcontents'

--- a/tests/integration/test_unit.py
+++ b/tests/integration/test_unit.py
@@ -54,17 +54,19 @@ async def test_run_action(event_loop):
 async def test_scp(event_loop):
     async with base.CleanModel() as model:
         app = await model.deploy('ubuntu')
+
         await asyncio.wait_for(
             model.block_until(lambda: app.units),
-            timeout=60
-        )
+            timeout=60)
         unit = app.units[0]
         await asyncio.wait_for(
-            model.block_until(
-                lambda: unit.machine and unit.machine.status == 'running'
-            ),
-            timeout=480
-        )
+            model.block_until(lambda: unit.machine),
+            timeout=60)
+        machine = unit.machine
+        await asyncio.wait_for(
+            model.block_until(lambda: (machine.status == 'running' and
+                                       machine.agent_status == 'started')),
+            timeout=480)
 
         with NamedTemporaryFile() as f:
             f.write(b'testcontents')


### PR DESCRIPTION
This adds scp methods to the Unit and Machine classes. I had to redefine the interfaces a little bit since the previous scp stubs didn't account for push vs. pull.

Also added a couple properties along the way, `unit.machine` and `machine.public_address`.