### PR TITLE
Make Application.upgrade_charm upgrade resources

### DIFF
--- a/juju/application.py
+++ b/juju/application.py
@@ -342,6 +342,8 @@ class Application(model.ModelEntity):
             raise ValueError("switch and revision are mutually exclusive")
 
         client_facade = client.ClientFacade.from_connection(self.connection)
+        resources_facade = client.ResourcesFacade.from_connection(
+            self.connection)
         app_facade = client.ApplicationFacade.from_connection(self.connection)
 
         if switch is not None:
@@ -361,11 +363,57 @@ class Application(model.ModelEntity):
         if charm_url == self.data['charm-url']:
             raise JujuError('already running charm "%s"' % charm_url)
 
+        # Update charm
         await client_facade.AddCharm(
             url=charm_url,
             channel=channel
         )
 
+        # Update resources
+        response = await self.model.charmstore.entity(charm_url,
+                                                      channel=channel)
+        store_resources = response['Meta']['resources']
+
+        request_data = [client.Entity(self.tag)]
+        response = await resources_facade.ListResources(request_data)
+        existing_resources = {
+            resource.name: resource
+            for resource in response.results[0].resources
+        }
+
+        resources_to_update = [
+            resource for resource in store_resources
+            if resource['Name'] not in existing_resources or
+            existing_resources[resource['Name']].origin != 'upload'
+        ]
+
+        if resources_to_update:
+            request_data = [
+                client.CharmResource(
+                    description=resource.get('Description'),
+                    fingerprint=resource['Fingerprint'],
+                    name=resource['Name'],
+                    path=resource['Path'],
+                    revision=resource['Revision'],
+                    size=resource['Size'],
+                    type_=resource['Type'],
+                    origin='store',
+                ) for resource in resources_to_update
+            ]
+            response = await resources_facade.AddPendingResources(
+                self.tag,
+                charm_url,
+                request_data
+            )
+            pending_ids = response.pending_ids
+            resource_ids = {
+                resource['Name']: id
+                for resource, id in zip(resources_to_update, pending_ids)
+            }
+        else:
+            resource_ids = None
+
+        # Update application
         await app_facade.SetCharm(
             application=self.entity_id,
             channel=channel,
@@ -374,7 +422,7 @@ class Application(model.ModelEntity):
             config_settings_yaml=None,
             force_series=force_series,
             force_units=force_units,
-            resource_ids=None,
+            resource_ids=resource_ids,
             storage_constraints=None
         )
 

--- a/juju/client/overrides.py
+++ b/juju/client/overrides.py
@@ -11,6 +11,7 @@ __all__ = [
     'Number',
     'Binary',
     'ConfigValue',
+    'Resource',
 ]
 
 __patches__ = [
@@ -273,3 +274,26 @@ class ConfigValue(_definitions.ConfigValue):
         return '<{} source={} value={}>'.format(type(self).__name__,
                                                 repr(self.source),
                                                 repr(self.value))
+
+class Resource(Type):
+    _toSchema = {'application': 'application', 'charmresource': 'CharmResource', 'id_': 'id', 'pending_id': 'pending-id', 'timestamp': 'timestamp', 'username': 'username', 'name': 'name', 'origin': 'origin'}
+    _toPy = {'CharmResource': 'charmresource', 'application': 'application', 'id': 'id_', 'pending-id': 'pending_id', 'timestamp': 'timestamp', 'username': 'username', 'name': 'name', 'origin': 'origin'}
+    def __init__(self, charmresource=None, application=None, id_=None, pending_id=None, timestamp=None, username=None, name=None, origin=None, **unknown_fields):
+        '''
+        charmresource : CharmResource
+        application : str
+        id_ : str
+        pending_id : str
+        timestamp : str
+        username : str
+        name: str
+        origin : str
+        '''
+        self.charmresource = CharmResource.from_json(charmresource) if charmresource else None
+        self.application = application
+        self.id_ = id_
+        self.pending_id = pending_id
+        self.timestamp = timestamp
+        self.username = username
+        self.name = name
+        self.origin = origin

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 
 from .. import base
@@ -92,3 +93,32 @@ async def test_upgrade_charm_switch(event_loop):
         assert app.data['charm-url'] == 'cs:ubuntu-0'
         await app.upgrade_charm(switch='ubuntu-8')
         assert app.data['charm-url'] == 'cs:ubuntu-8'
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_upgrade_charm_resource(event_loop):
+    async with base.CleanModel() as model:
+        app = await model.deploy('cs:~cynerva/upgrade-charm-resource-test-1')
+
+        def units_ready():
+            if not app.units:
+                return False
+            unit = app.units[0]
+            return unit.workload_status == 'active' and \
+                unit.agent_status == 'idle'
+
+        await asyncio.wait_for(model.block_until(units_ready), timeout=480)
+        unit = app.units[0]
+        expected_message = 'I have no resource.'
+        assert unit.workload_status_message == expected_message
+
+        await app.upgrade_charm(revision=2)
+        await asyncio.wait_for(
+            model.block_until(
+                lambda: unit.workload_status_message != 'I have no resource.'
+            ),
+            timeout=60
+        )
+        expected_message = 'My resource: I am the resource.'
+        assert app.units[0].workload_status_message == expected_message


### PR DESCRIPTION
Don't merge, this still needs integration tests. Opening for early review.

Fixes https://github.com/juju/python-libjuju/issues/157

The client is responsible for determining which resources to upgrade, determining which revisions to upgrade to, uploading the resources via `AddPendingResources`, and finally passing the new resource IDs to `SetCharm`. For reference, see [the same code in golang Juju](https://github.com/juju/juju/blob/7ddc8fb8ed8cbea361bd5867d9188af1b9e7cc92/cmd/juju/application/upgradecharm.go#L349-L463).

The `Resource` override adds missing `name` and `origin` fields. I would have expected to find that data within the `.charmresource` field, but in my testing, that field is always set to `None`. I don't know if this is the proper way to get the missing data, but it works in my testing at least.