### PR TITLE
removing cli command to add ssh keys

### DIFF
--- a/juju/controller.py
+++ b/juju/controller.py
@@ -116,7 +116,7 @@ class Controller(object):
             loop=self.loop,
         )
         ssh_key = await utils.read_ssh_key(loop=self.loop)
-        model.add_ssh_key(owner, ssh_key)
+        await model.add_ssh_key(owner, ssh_key)
 
         return model
 

--- a/juju/controller.py
+++ b/juju/controller.py
@@ -95,6 +95,10 @@ class Controller(object):
             credential = None
 
         log.debug('Creating model %s', model_name)
+        
+        if not config or 'authorized-keys' not in config:
+            config = config or {}
+            config['authorized-keys'] = await utils.read_ssh_key(loop=self.loop)
 
         model_info = await model_facade.CreateModel(
             tag.cloud(cloud_name),
@@ -115,10 +119,6 @@ class Controller(object):
             self.connection.macaroons,
             loop=self.loop,
         )
-        
-        if not config or 'authorized-keys' not in config:
-            config = config or {}
-            config['authorized-keys'] = await utils.read_ssh_key(loop=self.loop)
 
         return model
 

--- a/juju/controller.py
+++ b/juju/controller.py
@@ -115,10 +115,13 @@ class Controller(object):
             self.connection.macaroons,
             loop=self.loop,
         )
-        #ssh_key = await utils.read_ssh_key(loop=self.loop)
-        #await model.add_ssh_key(owner, ssh_key)
+        
+        if not config or 'authorized-keys' not in config:
+            config = config or {}
+            config['authorized-keys'] = await utils.read_ssh_key(loop=self.loop)
 
         return model
+
 
     async def destroy_models(self, *uuids):
         """Destroy one or more models.

--- a/juju/controller.py
+++ b/juju/controller.py
@@ -115,8 +115,8 @@ class Controller(object):
             self.connection.macaroons,
             loop=self.loop,
         )
-        ssh_key = await utils.read_ssh_key(loop=self.loop)
-        await model.add_ssh_key(owner, ssh_key)
+        #ssh_key = await utils.read_ssh_key(loop=self.loop)
+        #await model.add_ssh_key(owner, ssh_key)
 
         return model
 

--- a/juju/controller.py
+++ b/juju/controller.py
@@ -105,24 +105,6 @@ class Controller(object):
             region
         )
 
-        # Add our ssh key to the model, to work around
-        # https://bugs.launchpad.net/juju/+bug/1643076
-        try:
-            ssh_key = await utils.read_ssh_key(loop=self.loop)
-
-            if self.controller_name:
-                model_name = "{}:{}".format(self.controller_name, model_name)
-
-            cmd = ['juju', 'add-ssh-key', '-m', model_name, ssh_key]
-
-            await utils.execute_process(*cmd, log=log, loop=self.loop)
-        except Exception:
-            log.exception(
-                "Could not add ssh key to model. You will not be able "
-                "to ssh into machines in this model. "
-                "Manually running `juju add-ssh-key <key>` in the cli "
-                "may fix this problem.")
-
         model = Model()
         await model.connect(
             self.connection.endpoint,

--- a/juju/controller.py
+++ b/juju/controller.py
@@ -115,6 +115,8 @@ class Controller(object):
             self.connection.macaroons,
             loop=self.loop,
         )
+        ssh_key = await utils.read_ssh_key(loop=self.loop)
+        model.add_ssh_key(owner, ssh_key)
 
         return model
 


### PR DESCRIPTION
I removed the cli call that was causing issue #160. The issue occured because we hadn't used the cli in more than 24 hours so the macaroons expired. That's why the cli command to add ssh-key was not responding. I could easily reproduce it by deleting the macaroons and check what happens if I used a cli command.

`please enter password for admin on google-controller: ERROR cannot log in: context deadline exceeded`
 The ERROR only came after 10 minutes so that would explain why it took so long to get the response.

So removing the cli call fixed it. I was wondering if it is necessary to afterwords call the `add_ssh_key` after connecting to the model? or should this not be included into the `add_model` wrapper?