### PR TITLE
Fix intermittent test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,3 @@ script:
   - sudo ln -s /snap/bin/juju /usr/bin/juju || true
   - sudo -E sudo -u $USER -E bash -c "/snap/bin/juju bootstrap localhost test"
   - tox -e py35,integration
-  - sudo -E sudo -u $USER -E bash -c "/snap/bin/juju destroy-controller --destroy-all-models -y test"
-  - sudo snap remove juju

--- a/juju/controller.py
+++ b/juju/controller.py
@@ -236,6 +236,7 @@ class Controller(object):
                 return await controller_facade.AllModels()
             except errors.JujuAPIError as e:
                 # retry concurrency error until resolved in Juju
+                # see: https://bugs.launchpad.net/juju/+bug/1721786
                 if 'has been removed' not in e.message or attempt == 3:
                     raise
 

--- a/juju/controller.py
+++ b/juju/controller.py
@@ -231,7 +231,13 @@ class Controller(object):
         """
         controller_facade = client.ControllerFacade.from_connection(
             self.connection)
-        return await controller_facade.AllModels()
+        for attempt in (1, 2, 3):
+            try:
+                return await controller_facade.AllModels()
+            except errors.JujuAPIError as e:
+                # retry concurrency error until resolved in Juju
+                if 'has been removed' not in e.message or attempt == 3:
+                    raise
 
     def get_payloads(self, *patterns):
         """Return list of known payloads.

--- a/tests/integration/test_machine.py
+++ b/tests/integration/test_machine.py
@@ -28,7 +28,8 @@ async def test_status(event_loop):
 
         await asyncio.wait_for(
             model.block_until(lambda: (machine.status == 'running' and
-                                       machine.agent_status == 'started')),
+                                       machine.agent_status == 'started' and
+                                       machine.agent_version is not None)),
             timeout=480)
 
         assert machine.status == 'running'


### PR DESCRIPTION
Fix for this intermittent test failure:

```
=========================== short test summary info ============================
FAIL tests/integration/test_machine.py::test_status
=================================== FAILURES ===================================
_________________________________ test_status __________________________________
[gw1] linux -- Python 3.5.3 /home/travis/build/juju/python-libjuju/.tox/integration/bin/python3
event_loop = <_UnixSelectorEventLoop running=False closed=False debug=False>
    @base.bootstrapped
    @pytest.mark.asyncio
    async def test_status(event_loop):
        async with base.CleanModel() as model:
            await model.deploy(
                'ubuntu-0',
                application_name='ubuntu',
                series='trusty',
                channel='stable',
            )
    
            await asyncio.wait_for(
                model.block_until(lambda: len(model.machines)),
                timeout=240)
            machine = model.machines['0']
    
            assert machine.status in ('allocating', 'pending')
            assert machine.agent_status == 'pending'
            assert not machine.agent_version
    
            await asyncio.wait_for(
                model.block_until(lambda: (machine.status == 'running' and
                                           machine.agent_status == 'started')),
                timeout=480)
    
            assert machine.status == 'running'
            # there is some inconsistency in the message case between providers
            assert machine.status_message.lower() == 'running'
            assert machine.agent_status == 'started'
>           assert machine.agent_version.major >= 2
E           AttributeError: 'NoneType' object has no attribute 'major'
tests/integration/test_machine.py:38: AttributeError
```