### PR TITLE
Improve handling of thread error handling for loop.run()

### DIFF
--- a/juju/loop.py
+++ b/juju/loop.py
@@ -24,7 +24,7 @@ def run(*steps):
     try:
         loop.add_signal_handler(signal.SIGINT, abort)
         added = True
-    except ValueError as e:
+    except (ValueError, OSError, RuntimeError) as e:
         # add_signal_handler doesn't work in a thread
         if 'main thread' not in str(e):
             raise


### PR DESCRIPTION
It seems that there may be some inconsistencies across asyncio versions as to what type of error is raised when we try to attach the signal handler when not in a main thread.

Fixes this occasional test failure:

```
=========================== short test summary info ============================
FAIL tests/unit/test_loop.py::TestLoop::test_run
=================================== FAILURES ===================================
______________________________ TestLoop.test_run _______________________________
[gw1] linux -- Python 3.5.3 /home/travis/build/juju/python-libjuju/.tox/py35/bin/python3.5
self = <tests.unit.test_loop.TestLoop testMethod=test_run>
    def test_run(self):
        assert asyncio.get_event_loop() == self.loop
        async def _test():
            return 'success'
>       self.assertEqual(juju.loop.run(_test()), 'success')
tests/unit/test_loop.py:20: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
juju/loop.py:25: in run
    loop.add_signal_handler(signal.SIGINT, abort)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
self = <_UnixSelectorEventLoop running=False closed=True debug=False>
sig = <Signals.SIGINT: 2>
callback = <function run.<locals>.abort at 0x7f7094269b70>, args = ()
    def add_signal_handler(self, sig, callback, *args):
        """Add a handler for a signal.  UNIX only.
    
            Raise ValueError if the signal number is invalid or uncatchable.
            Raise RuntimeError if there is a problem setting up the handler.
            """
        if (coroutines.iscoroutine(callback)
        or coroutines.iscoroutinefunction(callback)):
            raise TypeError("coroutines cannot be used "
                            "with add_signal_handler()")
        self._check_signal(sig)
        self._check_closed()
        try:
            # set_wakeup_fd() raises ValueError if this is not the
            # main thread.  By calling it early we ensure that an
            # event loop running in another thread cannot add a signal
            # handler.
            signal.set_wakeup_fd(self._csock.fileno())
        except (ValueError, OSError) as exc:
>           raise RuntimeError(str(exc))
E           RuntimeError: set_wakeup_fd only works in main thread
/opt/python/3.5.3/lib/python3.5/asyncio/unix_events.py:93: RuntimeError
```