### PR TITLE
Refactor model handling

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -48,7 +48,7 @@ class CleanModel():
         self.user_name = juju_data.accounts()[self.controller_name]['user']
         await self.controller.connect_controller(self.controller_name)
 
-        self.model_name = 'model-{}'.format(uuid.uuid4())
+        self.model_name = 'test-{}'.format(uuid.uuid4())
         self.model = await self.controller.add_model(self.model_name)
 
         # save the model UUID in case test closes model

--- a/tests/integration/test_controller.py
+++ b/tests/integration/test_controller.py
@@ -1,3 +1,4 @@
+import asyncio
 import pytest
 import uuid
 
@@ -88,7 +89,64 @@ async def test_grant_revoke(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_get_models(event_loop):
+async def test_list_models(event_loop):
     async with base.CleanController() as controller:
-        result = await controller.get_models()
-        assert isinstance(result.serialize()['user-models'], list)
+        async with base.CleanModel() as model:
+            result = await controller.list_models()
+            assert model.info.name in result
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_get_model(event_loop):
+    async with base.CleanController() as controller:
+        by_name, by_uuid = None, None
+        model_name = 'test-{}'.format(uuid.uuid4())
+        model = await controller.add_model(model_name)
+        model_uuid = model.info.uuid
+        await model.disconnect()
+        try:
+            by_name = await controller.get_model(model_name)
+            by_uuid = await controller.get_model(model_uuid)
+            assert by_name.info.name == model_name
+            assert by_name.info.uuid == model_uuid
+            assert by_uuid.info.name == model_name
+            assert by_uuid.info.uuid == model_uuid
+        finally:
+            if by_name:
+                await by_name.disconnect()
+            if by_uuid:
+                await by_uuid.disconnect()
+            await controller.destroy_model(model_name)
+
+
+async def _wait_for_model_gone(controller, model_name):
+    while model_name in await controller.list_models():
+        await asyncio.sleep(0.5, loop=controller.loop)
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_destroy_model_by_name(event_loop):
+    async with base.CleanController() as controller:
+        model_name = 'test-{}'.format(uuid.uuid4())
+        model = await controller.add_model(model_name)
+        await model.disconnect()
+        await controller.destroy_model(model_name)
+        await asyncio.wait_for(_wait_for_model_gone(controller,
+                                                    model_name),
+                               timeout=60)
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_add_destroy_model_by_uuid(event_loop):
+    async with base.CleanController() as controller:
+        model_name = 'test-{}'.format(uuid.uuid4())
+        model = await controller.add_model(model_name)
+        model_uuid = model.info.uuid
+        await model.disconnect()
+        await controller.destroy_model(model_uuid)
+        await asyncio.wait_for(_wait_for_model_gone(controller,
+                                                    model_name),
+                               timeout=60)


### PR DESCRIPTION
This changes get_models to list_models, implements get_model, and allows destroy_models to accept model names (fixes #54).

Unfortunately, this makes us much more likely to hit https://bugs.launchpad.net/juju/+bug/1721786 with the tests.