### PR TITLE
Fix rare hang during Unit.run

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -785,7 +785,7 @@ class Model(object):
         def predicate(delta):
             return delta.data['status'] in ('completed', 'failed')
 
-        return await self._wait('action', action_id, 'change', predicate)
+        return await self._wait('action', action_id, None, predicate)
 
     async def add_machine(
             self, spec=None, constraints=None, disks=None, series=None):


### PR DESCRIPTION
This hopefully fixes a rare case where `Unit.run` never returns. I haven't had a chance to test this (yay outage) but looks like the integration tests should cover it anyway.

Normally, when I invoke `Unit.run`, I see two deltas: one delta with an initial "pending" status, and a second delta with "completed" status:

```
DEBUG:websockets.protocol:client << Frame(fin=True, opcode=1, data=b'{"request-id":1294,"response":{"results":[{"action":{"tag":"action-4ff94548-820d-4f11-8449-69890fc41787","receiver":"unit-kubernetes-master-0","name":"juju-run","parameters":{"command":"pgrep -a kube-apiserver","timeout":0}},"enqueued":"2017-10-25T19:04:44Z","started":"0001-01-01T00:00:00Z","completed":"0001-01-01T00:00:00Z","status":"pending"}]}}\n')
DEBUG:websockets.protocol:client << Frame(fin=True, opcode=1, data=b'{"request-id":1296,"response":{"deltas":[["machine","change",{"model-uuid":"c09350b6-3584-4e93-8268-0a84a228bda3","id":"7","instance-id":"i-07001300944f3a985","agent-status":{"current":"stopped","message":"","since":"2017-10-25T19:04:43.806940123Z","version":""},"instance-status":{"current":"running","message":"running","since":"2017-10-25T18:29:03.912771737Z","version":""},"life":"dead","series":"xenial","supported-containers":["lxd"],"supported-containers-known":true,"hardware-characteristics":{"arch":"amd64","mem":16384,"root-disk":8192,"cpu-cores":4,"cpu-power":1679,"availability-zone":"us-east-1b"},"jobs":["JobHostUnits"],"addresses":[{"value":"54.91.215.194","type":"ipv4","scope":"public"},{"value":"172.31.61.113","type":"ipv4","scope":"local-cloud"},{"value":"252.61.113.1","type":"ipv4","scope":"local-fan"},{"value":"127.0.0.1","type":"ipv4","scope":"local-machine"},{"value":"::1","type":"ipv6","scope":"local-machine"}],"has-vote":false,"wants-vote":false}],["action","change",{"model-uuid":"c09350b6-3584-4e93-8268-0a84a228bda3","id":"4ff94548-820d-4f11-8449-69890fc41787","receiver":"kubernetes-master/0","name":"juju-run","parameters":{"command":"pgrep -a kube-apiserver","timeout":0},"status":"pending","message":"","enqueued":"2017-10-25T19:04:44Z","started":"0001-01-01T00:00:00Z","completed":"0001-01-01T00:00:00Z"}]]}}\n')
DEBUG:juju.model:Model changed: action add 4ff94548-820d-4f11-8449-69890fc41787
DEBUG:websockets.protocol:client << Frame(fin=True, opcode=1, data=b'{"request-id":1413,"response":{"deltas":[["action","change",{"model-uuid":"c09350b6-3584-4e93-8268-0a84a228bda3","id":"4ff94548-820d-4f11-8449-69890fc41787","receiver":"kubernetes-master/0","name":"juju-run","parameters":{"command":"pgrep -a kube-apiserver","timeout":0},"status":"completed","message":"","results":{"Code":"0","Stderr":"","Stdout":"12222 /snap/kube-apiserver/196/kube-apiserver --admission-control Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultTolerationSeconds --allow-privileged --authorization-mode AlwaysAllow --basic-auth-file /root/cdk/basic_auth.csv --etcd-cafile /root/cdk/etcd/client-ca.pem --etcd-certfile /root/cdk/etcd/client-cert.pem --etcd-keyfile /root/cdk/etcd/client-key.pem --etcd-servers https://172.31.11.84:2379,https://172.31.28.162:2379,https://172.31.52.81:2379 --insecure-bind-address 127.0.0.1 --insecure-port 8080 --kubelet-certificate-authority /root/cdk/ca.crt --kubelet-client-certificate /root/cdk/client.crt --kubelet-client-key /root/cdk/client.key --logtostderr --min-request-timeout 300 --service-account-key-file /root/cdk/serviceaccount.key --service-cluster-ip-range 10.152.183.0/24 --storage-backend etcd2 --tls-cert-file /root/cdk/server.crt --tls-private-key-file /root/cdk/server.key --token-auth-file /root/cdk/known_tokens.csv --v 4\\n"},"enqueued":"2017-10-25T19:04:44Z","started":"2017-10-25T19:04:49Z","completed":"2017-10-25T19:04:49Z"}]]}}\n')
DEBUG:juju.model:Model changed: action change 4ff94548-820d-4f11-8449-69890fc41787
```

In the case where `Unit.run` never returned, I saw only a single delta with immediate "completed" status:

```
DEBUG:websockets.protocol:client << Frame(fin=True, opcode=1, data=b'{"request-id":1536,"response":{"results":[{"action":{"tag":"action-2152f596-17dd-42da-88a0-ec591a6eb6ce","receiver":"unit-kubernetes-master-0","name":"juju-run","parameters":{"command":"pgrep -a kube-apiserver","timeout":0}},"enqueued":"2017-10-25T19:04:58Z","started":"0001-01-01T00:00:00Z","completed":"0001-01-01T00:00:00Z","status":"pending"}]}}\n')
DEBUG:websockets.protocol:client << Frame(fin=True, opcode=1, data=b'{"request-id":1537,"response":{"deltas":[["action","change",{"model-uuid":"c09350b6-3584-4e93-8268-0a84a228bda3","id":"2152f596-17dd-42da-88a0-ec591a6eb6ce","receiver":"kubernetes-master/0","name":"juju-run","parameters":{"command":"pgrep -a kube-apiserver","timeout":0},"status":"completed","message":"","results":{"Code":"0","Stderr":"","Stdout":"12222 /snap/kube-apiserver/196/kube-apiserver --admission-control Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultTolerationSeconds --allow-privileged --authorization-mode AlwaysAllow --basic-auth-file /root/cdk/basic_auth.csv --etcd-cafile /root/cdk/etcd/client-ca.pem --etcd-certfile /root/cdk/etcd/client-cert.pem --etcd-keyfile /root/cdk/etcd/client-key.pem --etcd-servers https://172.31.11.84:2379,https://172.31.28.162:2379,https://172.31.52.81:2379 --insecure-bind-address 127.0.0.1 --insecure-port 8080 --kubelet-certificate-authority /root/cdk/ca.crt --kubelet-client-certificate /root/cdk/client.crt --kubelet-client-key /root/cdk/client.key --logtostderr --min-request-timeout 300 --service-account-key-file /root/cdk/serviceaccount.key --service-cluster-ip-range 10.152.183.0/24 --storage-backend etcd2 --tls-cert-file /root/cdk/server.crt --tls-private-key-file /root/cdk/server.key --token-auth-file /root/cdk/known_tokens.csv --v 4\\n"},"enqueued":"2017-10-25T19:04:58Z","started":"2017-10-25T19:04:59Z","completed":"2017-10-25T19:04:59Z"}],["unit","change",{"model-uuid":"c09350b6-3584-4e93-8268-0a84a228bda3","name":"kubernetes-master/0","application":"kubernetes-master","series":"xenial","charm-url":"cs:~containers/kubernetes-master-62","public-address":"52.207.225.244","private-address":"172.31.0.41","machine-id":"5","ports":[{"protocol":"tcp","number":6443}],"port-ranges":[{"from-port":6443,"to-port":6443,"protocol":"tcp"}],"subordinate":false,"workload-status":{"current":"active","message":"Kubernetes master running.","since":"2017-10-25T19:04:23.287353969Z","version":""},"agent-status":{"current":"executing","message":"running config-changed hook","since":"2017-10-25T19:04:59.043680754Z","version":""}}]]}}\n')
DEBUG:juju.model:Model changed: action add 2152f596-17dd-42da-88a0-ec591a6eb6ce
```

Since no `action change` occurred, the observer in `Model.wait_for_action` never got called.

The proposed fix is to remove the "change" filter on the observer in `Model.wait_for_action`.