### PR TITLE
juju/client: factor out JujuData class

### DIFF
--- a/juju/client/jujudata.py
+++ b/juju/client/jujudata.py
@@ -1,0 +1,129 @@
+import os
+import yaml
+import io
+
+from juju import tag
+import juju.client.client as jujuclient
+from juju.errors import JujuError
+
+
+class JujuData:
+    '''Provide access to the Juju client configuration files.
+    Any configuration file is read once and then cached.'''
+    def __init__(self):
+        self.path = os.environ.get('JUJU_DATA') or '~/.local/share/juju'
+        self.path = os.path.abspath(os.path.expanduser(self.path))
+        # _loaded keeps track of the loaded YAML from
+        # the Juju data files so we don't need to load the same
+        # file many times.
+        self._loaded = {}
+
+    def refresh(self):
+        '''Forget the cache of configuration file data'''
+        self._loaded = {}
+
+    def current_controller(self):
+        '''Return the current controller name'''
+        return self._load_yaml('controllers.yaml', 'current-controller')
+
+    def current_model(self, controller_name=None):
+        '''Return the current model, qualified by its controller name.
+        If controller_name is specified, the current model for
+        that controller will be returned.
+        '''
+        # TODO respect JUJU_MODEL environment variable.
+        if not controller_name:
+            controller_name = self.current_controller()
+        if not controller_name:
+            raise JujuError('No current controller')
+        models = self.models()[controller_name]
+        if 'current-model' not in models:
+            return None
+        return controller_name + ':' + models['current-model']
+
+    def parse_model(self, model):
+        """Split the given model_name into controller and model parts.
+        If the controller part is empty, the current controller will be used.
+        If the model part is empty, the current model will be used for
+        the controller.
+        The returned model name will always be qualified with a username.
+        :param model str: The model name to parse.
+        :return (str, str): The controller and model names.
+        """
+        # TODO if model is empty, use $JUJU_MODEL environment variable.
+        if model and ':' in model:
+            # explicit controller given
+            controller_name, model_name = model.split(':')
+        else:
+            # use the current controller if one isn't explicitly given
+            controller_name = self.current_controller()
+            model_name = model
+        if not controller_name:
+            controller_name = self.current_controller()
+        if not model_name:
+            model_name = self.current_model(controller_name)
+
+        if '/' not in model_name:
+            # model name doesn't include a user prefix, so add one
+            # by using the current user for the controller.
+            accounts = self.accounts().get('controller_name')
+            if accounts is None:
+                raise JujuError('No account found for controller {}'.format(controller_name))
+            username = accounts.get['user']
+            if username is None:
+                raise JujuError('No username found for controller {}'.format(controller_name))
+            model_name = username + "/" + model_name
+
+        return controller_name, model_name
+
+    def load_credential(self, cloud, name=None):
+        """Load a local credential.
+
+        :param str cloud: Name of cloud to load credentials from.
+        :param str name: Name of credential. If None, the default credential
+            will be used, if available.
+        :return: A CloudCredential instance, or None.
+        """
+        try:
+            cloud = tag.untag('cloud-', cloud)
+            creds_data = self.credentials()[cloud]
+            if not name:
+                default_credential = creds_data.pop('default-credential', None)
+                default_region = creds_data.pop('default-region', None)  # noqa
+                if default_credential:
+                    name = creds_data['default-credential']
+                elif len(creds_data) == 1:
+                    name = list(creds_data)[0]
+                else:
+                    return None, None
+            cred_data = creds_data[name]
+            auth_type = cred_data.pop('auth-type')
+            return name, jujuclient.CloudCredential(
+                auth_type=auth_type,
+                attrs=cred_data,
+            )
+        except (KeyError, FileNotFoundError):
+            return None, None
+
+    def controllers(self):
+        return self._load_yaml('controllers.yaml', 'controllers')
+
+    def models(self):
+        return self._load_yaml('models.yaml', 'controllers')
+
+    def accounts(self):
+        return self._load_yaml('accounts.yaml', 'controllers')
+
+    def credentials(self):
+        return self._load_yaml('credentials.yaml', 'credentials')
+
+    def _load_yaml(self, filename, key):
+        if filename in self._loaded:
+            # Data already exists in the cache.
+            return self._loaded[filename].get(key)
+        # TODO use the file lock like Juju does.
+        filepath = os.path.join(self.path, filename)
+        with io.open(filepath, 'rt') as f:
+            data = yaml.safe_load(f)
+            self._loaded[filename] = data
+            return data.get(key)

--- a/juju/controller.py
+++ b/juju/controller.py
@@ -6,6 +6,7 @@ from . import tag
 from . import utils
 from .client import client
 from .client import connection
+from .client.jujudata import JujuData
 from .model import Model
 from .user import User
 
@@ -41,7 +42,7 @@ class Controller(object):
         """Connect to the current Juju controller.
 
         """
-        jujudata = connection.JujuData()
+        jujudata = JujuData()
         controller_name = jujudata.current_controller()
         if not controller_name:
             raise errors.JujuConnectionError('No current controller')
@@ -90,11 +91,10 @@ class Controller(object):
             raise errors.JujuError('Name must be provided for credential')
 
         if not credential:
-            name, credential = connection.JujuData().load_credential(cloud,
-                                                                     name)
+            name, credential = JujuData().load_credential(cloud, name)
             if credential is None:
-                raise errors.JujuError('Unable to find credential: '
-                                       '{}'.format(name))
+                raise errors.JujuError(
+                    'Unable to find credential: {}'.format(name))
 
         log.debug('Uploading credential %s', name)
         cloud_facade = client.CloudFacade.from_connection(self.connection)


### PR DESCRIPTION
We move JujuData into its own file because it's logically
independent of the Connection class.

We also make it cache the data that's been read so that we don't need
to read and parse the YAML file every time a method
is called.

We also change it so that it doesn't shell out to Juju to obtain the
current controller name - the name can be retrieved from the controllers.yaml
file.

In a subsequent PR, we'll factor those Connection methods
that depend on JujuData out of the Connection class so
that Connection doesn't need to depend on the details of
the juju configuration files.