### PR TITLE
Fix race condition in connection monitor test

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -679,6 +679,11 @@ class Model(object):
                             log.warning(
                                 'Watcher: connection closed, reopening')
                             await self.connection.reconnect()
+                            if monitor.status != monitor.CONNECTED:
+                                # reconnect failed; abort and shutdown
+                                log.error('Watcher: automatic reconnect '
+                                          'failed; stopping watcher')
+                                break
                             del allwatcher.Id
                             continue
                         else:

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ skipsdist=True
 basepython=python3
 usedevelop=True
 # for testing with other python versions
-commands = py.test -ra -v -s -x -n auto {posargs}
+commands = py.test -ra -v -s -n auto {posargs}
 passenv =
     HOME
 deps =
@@ -24,7 +24,7 @@ deps =
 
 [testenv:py35]
 # default tox env excludes integration tests
-commands = py.test -ra -v -s -x -n auto -k 'not integration' {posargs}
+commands = py.test -ra -v -s -n auto -k 'not integration' {posargs}
 
 [testenv:lint]
 envdir = {toxworkdir}/py35


### PR DESCRIPTION
Also removes -x flag from test runner because failing fast causes a lot of noise when tests are killed without gracefully cleaning up, due to asyncio tasks being left pending.

Fixes test failure seen in #182 