### PR TITLE
all: use pyrfc3339 instead of dateutil

### DIFF
--- a/juju/machine.py
+++ b/juju/machine.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import os
 
-from dateutil.parser import parse as parse_date
+import pyrfc3339
 
 from . import model, utils
 from .client import client
@@ -66,8 +66,8 @@ class Machine(model.ModelEntity):
             change_log.append(('agent-version', '', agent_version))
 
         # only update (other) delta fields if status data is newer
-        status_since = parse_date(machine['instance-status']['since'])
-        delta_since = parse_date(delta.data['instance-status']['since'])
+        status_since = pyrfc3339.parse(machine['instance-status']['since'])
+        delta_since = pyrfc3339.parse(delta.data['instance-status']['since'])
         if status_since > delta_since:
             for status_key in ('status', 'info', 'since'):
                 delta_key = key_map[status_key]
@@ -211,7 +211,7 @@ class Machine(model.ModelEntity):
         """Get the time when the `agent_status` was last updated.
 
         """
-        return parse_date(self.safe_data['agent-status']['since'])
+        return pyrfc3339.parse(self.safe_data['agent-status']['since'])
 
     @property
     def agent_version(self):
@@ -244,7 +244,7 @@ class Machine(model.ModelEntity):
         """Get the time when the `status` was last updated.
 
         """
-        return parse_date(self.safe_data['instance-status']['since'])
+        return pyrfc3339.parse(self.safe_data['instance-status']['since'])
 
     @property
     def dns_name(self):

--- a/juju/unit.py
+++ b/juju/unit.py
@@ -1,6 +1,6 @@
 import logging
 
-from dateutil.parser import parse as parse_date
+import pyrfc3339
 
 from . import model
 from .client import client
@@ -21,7 +21,7 @@ class Unit(model.ModelEntity):
         """Get the time when the `agent_status` was last updated.
 
         """
-        return parse_date(self.safe_data['agent-status']['since'])
+        return pyrfc3339.parse(self.safe_data['agent-status']['since'])
 
     @property
     def agent_status_message(self):
@@ -42,7 +42,7 @@ class Unit(model.ModelEntity):
         """Get the time when the `workload_status` was last updated.
 
         """
-        return parse_date(self.safe_data['workload-status']['since'])
+        return pyrfc3339.parse(self.safe_data['workload-status']['since'])
 
     @property
     def workload_status_message(self):

--- a/juju/user.py
+++ b/juju/user.py
@@ -1,5 +1,5 @@
 import logging
-from dateutil.parser import parse as parse_date
+import pyrfc3339
 
 from . import tag
 
@@ -25,7 +25,7 @@ class User(object):
 
     @property
     def last_connection(self):
-        return parse_date(self._user_info.last_connection)
+        return pyrfc3339.parse(self._user_info.last_connection)
 
     @property
     def access(self):

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'websockets',
         'pyyaml',
         'theblues',
-        'python-dateutil'
+        'pyRFC3339>=1.0,<2.0',
     ],
     include_package_data=True,
     maintainer='Juju Ecosystem Engineering',


### PR DESCRIPTION
The pyrfc3339.parse function can be considerably more lightweight
than dateutil.parser.parse_time as it knows the format that
it's expected to parse (and in all the cases we use it, the API
specifically uses RFC3339 format).

Also, the pyrfc3339 package provides an easy way to format
RFC3339 times, which dateutil does not (and we need that for
the next PR which writes Go-style cookie jars).

Furthermore, pyrfc3339 is a dependency already used by
py-macaroon-bakery, so we can share it when we import
that.