### PR TITLE
refactor connections prior to bakery authentication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ python:
   - "3.5"
 before_install:
   - sudo add-apt-repository ppa:ubuntu-lxc/lxd-stable -y
+  - sudo add-apt-repository ppa:chris-lea/libsodium -y
   - sudo apt-get update -q
-  - sudo apt-get install lxd snapd -y
+  - sudo apt-get install lxd snapd libsodium-dev -y
   - sudo usermod -a -G lxd $USER
   - sudo service lxd start || true
   - sudo lxd init --auto

--- a/examples/action.py
+++ b/examples/action.py
@@ -27,7 +27,7 @@ async def run_action(unit):
 
 async def main():
     model = Model()
-    await model.connect_current()
+    await model.connect()
     await model.reset(force=True)
 
     app = await model.deploy(

--- a/examples/add_machine.py
+++ b/examples/add_machine.py
@@ -19,7 +19,7 @@ GB = 1024
 
 async def main():
     model = Model()
-    await model.connect_current()
+    await model.connect()
 
     try:
         # add a new default machine

--- a/examples/add_model.py
+++ b/examples/add_model.py
@@ -19,7 +19,7 @@ LOG = getLogger(__name__)
 async def main():
     controller = Controller()
     print("Connecting to controller")
-    await controller.connect_current()
+    await controller.connect()
 
     try:
         model_name = "addmodeltest-{}".format(uuid.uuid4())

--- a/examples/allwatcher.py
+++ b/examples/allwatcher.py
@@ -16,7 +16,7 @@ from juju import loop
 
 
 async def watch():
-    conn = await Connection.connect_current()
+    conn = await Connection.connect()
     allwatcher = client.AllWatcherFacade.from_connection(conn)
     while True:
         change = await allwatcher.Next()

--- a/examples/config.py
+++ b/examples/config.py
@@ -19,7 +19,7 @@ MB = 1
 
 async def main():
     model = Model()
-    await model.connect_current()
+    await model.connect()
     await model.reset(force=True)
 
     ubuntu_app = await model.deploy(

--- a/examples/controller.py
+++ b/examples/controller.py
@@ -17,7 +17,7 @@ from juju import loop
 
 async def main():
     controller = Controller()
-    await controller.connect_current()
+    await controller.connect()
     model = await controller.add_model(
         'my-test-model',
         'aws',

--- a/examples/credential.py
+++ b/examples/credential.py
@@ -7,7 +7,7 @@ async def main(cloud_name, credential_name):
     controller = Controller()
     model = None
     print('Connecting to controller')
-    await controller.connect_current()
+    await controller.connect()
     try:
         print('Adding model')
         model = await controller.add_model(

--- a/examples/deploy.py
+++ b/examples/deploy.py
@@ -13,7 +13,7 @@ from juju.model import Model
 async def main():
     model = Model()
     print('Connecting to model')
-    await model.connect_current()
+    await model.connect()
 
     try:
         print('Deploying ubuntu')

--- a/examples/fullstatus.py
+++ b/examples/fullstatus.py
@@ -5,7 +5,7 @@ from juju.client.client import ClientFacade
 from juju import loop
 
 async def status():
-    conn = await Connection.connect_current()
+    conn = await Connection.connect()
     client = ClientFacade.from_connection(conn)
 
     patterns = None

--- a/examples/future.py
+++ b/examples/future.py
@@ -11,7 +11,7 @@ from juju import loop
 
 async def main():
     model = Model()
-    await model.connect_current()
+    await model.connect()
     await model.reset(force=True)
 
     goal_state = Model.from_yaml('bundle-like-thing')

--- a/examples/leadership.py
+++ b/examples/leadership.py
@@ -13,7 +13,7 @@ from juju import loop
 
 async def report_leadership():
     model = Model()
-    await model.connect_current()
+    await model.connect()
 
     print("Leadership: ")
     for app in model.applications.values():

--- a/examples/livemodel.py
+++ b/examples/livemodel.py
@@ -21,7 +21,7 @@ async def on_model_change(delta, old, new, model):
 
 async def watch_model():
     model = Model()
-    await model.connect_current()
+    await model.connect()
 
     model.add_observer(on_model_change)
 

--- a/examples/localcharm.py
+++ b/examples/localcharm.py
@@ -15,7 +15,7 @@ from juju import loop
 
 async def main():
     model = Model()
-    await model.connect_current()
+    await model.connect()
 
     # Deploy a local charm using a path to the charm directory
     await model.deploy(

--- a/examples/relate.py
+++ b/examples/relate.py
@@ -40,7 +40,7 @@ class MyModelObserver(ModelObserver):
 
 async def main():
     model = Model()
-    await model.connect_current()
+    await model.connect()
 
     model.add_observer(MyRemoveObserver())
     await model.reset(force=True)

--- a/examples/unitrun.py
+++ b/examples/unitrun.py
@@ -24,7 +24,7 @@ async def run_command(unit):
 
 async def main():
     model = Model()
-    await model.connect_current()
+    await model.connect()
     await model.reset(force=True)
 
     app = await model.deploy(

--- a/juju/client/_client.py
+++ b/juju/client/_client.py
@@ -41,7 +41,13 @@ class TypeFactory:
         @param connection: initialized Connection object.
 
         """
-        version = connection.facades[cls.__name__[:-6]]
+        facade_name = cls.__name__
+        if not facade_name.endswith('Facade'):
+           raise TypeError('Unexpected class name: {}'.format(facade_name))
+        facade_name = facade_name[:-len('Facade')]
+        version = connection.facades.get(facade_name)
+        if version is None:
+            raise Exception('No facade {} in facades {}'.format(facade_name, connection.facades))
 
         c = lookup_facade(cls.__name__, version)
         c = c()

--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -2,19 +2,17 @@ import asyncio
 import base64
 import json
 import logging
-import random
 import ssl
-import string
+import urllib.request
 import weakref
 from concurrent.futures import CancelledError
 from http.client import HTTPSConnection
-from pathlib import Path
 
+import macaroonbakery.httpbakery as httpbakery
 import websockets
-from juju import tag, utils
+from juju import utils
 from juju.client import client
-from juju.client.jujudata import JujuData
-from juju.errors import JujuAPIError, JujuConnectionError, JujuError
+from juju.errors import JujuAPIError, JujuError
 from juju.utils import IdQueue
 
 log = logging.getLogger("websocket")
@@ -25,7 +23,7 @@ class Monitor:
     Monitor helper class for our Connection class.
 
     Contains a reference to an instantiated Connection, along with a
-    reference to the Connection.receiver Future. Upon inspecttion of
+    reference to the Connection.receiver Future. Upon inspection of
     these objects, this class determines whether the connection is in
     an 'error', 'connected' or 'disconnected' state.
 
@@ -43,10 +41,6 @@ class Monitor:
         self.connection = weakref.ref(connection)
         self.reconnecting = asyncio.Lock(loop=connection.loop)
         self.close_called = asyncio.Event(loop=connection.loop)
-        self.receiver_stopped = asyncio.Event(loop=connection.loop)
-        self.pinger_stopped = asyncio.Event(loop=connection.loop)
-        self.receiver_stopped.set()
-        self.pinger_stopped.set()
 
     @property
     def status(self):
@@ -76,7 +70,7 @@ class Monitor:
             return self.DISCONNECTING
 
         # connection closed uncleanly (we didn't call connection.close)
-        if self.receiver_stopped.is_set() or not connection.ws.open:
+        if connection._receiver_task.stopped.is_set() or not connection.ws.open:
             return self.ERROR
 
         # everything is fine!
@@ -91,47 +85,87 @@ class Connection:
         client = await Connection.connect(
             api_endpoint, model_uuid, username, password, cacert)
 
-        # Connect using a controller/model name
-        client = await Connection.connect_model('local.local:default')
-
-        # Connect to the currently active model
-        client = await Connection.connect_current()
-
     Note: Any connection method or constructor can accept an optional `loop`
     argument to override the default event loop from `asyncio.get_event_loop`.
     """
 
-    DEFAULT_FRAME_SIZE = 'default_frame_size'
     MAX_FRAME_SIZE = 2**22
     "Maximum size for a single frame.  Defaults to 4MB."
 
-    def __init__(
-            self, endpoint, uuid, username, password, cacert=None,
-            macaroons=None, loop=None, max_frame_size=DEFAULT_FRAME_SIZE):
-        self.endpoint = endpoint
-        self._endpoint = endpoint
+    @classmethod
+    async def connect(
+            cls,
+            endpoint,
+            uuid=None,
+            username=None,
+            password=None,
+            cacert=None,
+            bakery_client=None,
+            loop=None,
+            max_frame_size=None,
+    ):
+        """Connect to the websocket.
+
+        If uuid is None, the connection will be to the controller. Otherwise it
+        will be to the model.
+        :param str endpoint The hostname:port of the controller to connect to.
+        :param str uuid The model UUID to connect to (None for a
+            controller-only connection).
+        :param str username The username for controller-local users (or None
+            to use macaroon-based login.)
+        :param str password The password for controller-local users.
+        :param str cacert The CA certificate of the controller (PEM formatted).
+        :param httpbakery.Client bakery_client The macaroon bakery client to
+            to use when performing macaroon-based login. Macaroon tokens
+            acquired when logging will be saved to bakery_client.cookies.
+            If this is None, a default bakery_client will be used.
+        :param loop asyncio.BaseEventLoop The event loop to use for async
+            operations.
+        :param max_frame_size The maximum websocket frame size to allow.
+        """
+        self = cls()
         self.uuid = uuid
-        if macaroons:
-            self.macaroons = macaroons
-            self.username = ''
-            self.password = ''
-        else:
-            self.macaroons = []
-            self.username = username
-            self.password = password
-        self.cacert = cacert
-        self._cacert = cacert
+        if bakery_client is None:
+            bakery_client = httpbakery.Client()
+        self.bakery_client = bakery_client
+        self.usertag = username
+        if username is not None and not username.startswith('user-'):
+            # TODO this doesn't seem quite right, as 'user-foo' is
+            # actually a valid username (its tag would be user-user-foo),
+            # but don't break the existing API.
+            self.usertag = 'user-' + username
+        self.password = password
         self.loop = loop or asyncio.get_event_loop()
 
         self.__request_id__ = 0
+
+        # The following instance variables are initialized by the
+        # _connect_with_redirect method, but create them here
+        # as a reminder that they will exist.
         self.addr = None
         self.ws = None
+        self.endpoint = None
+        self.cacert = None
+        self.info = None
+
+        # Create that _Task objects but don't start the tasks yet.
+        self._pinger_task = _Task(self._pinger, self.loop)
+        self._receiver_task = _Task(self._receiver, self.loop)
+
         self.facades = {}
         self.messages = IdQueue(loop=self.loop)
         self.monitor = Monitor(connection=self)
-        if max_frame_size is self.DEFAULT_FRAME_SIZE:
+        if max_frame_size is None:
             max_frame_size = self.MAX_FRAME_SIZE
         self.max_frame_size = max_frame_size
+        await self._connect_with_redirect([(endpoint, cacert)])
+        return self
+
+    @property
+    def username(self):
+        if not self.usertag:
+            return None
+        return self.usertag[len('user-'):]
 
     @property
     def is_open(self):
@@ -141,39 +175,34 @@ class Connection:
         return ssl.create_default_context(
             purpose=ssl.Purpose.CLIENT_AUTH, cadata=cert)
 
-    async def open(self):
+    async def _open(self, endpoint, cacert):
         if self.uuid:
-            url = "wss://{}/model/{}/api".format(self.endpoint, self.uuid)
+            url = "wss://{}/model/{}/api".format(endpoint, self.uuid)
         else:
-            url = "wss://{}/api".format(self.endpoint)
+            url = "wss://{}/api".format(endpoint)
 
-        kw = dict()
-        kw['ssl'] = self._get_ssl(self.cacert)
-        kw['loop'] = self.loop
-        kw['max_size'] = self.max_frame_size
-        self.addr = url
-        self.ws = await websockets.connect(url, **kw)
-        self.loop.create_task(self.receiver())
-        self.monitor.receiver_stopped.clear()
-        log.info("Driver connected to juju %s", url)
-        self.monitor.close_called.clear()
-        return self
+        return (await websockets.connect(
+            url,
+            ssl=self._get_ssl(cacert),
+            loop=self.loop,
+            max_size=self.max_frame_size,
+        ), url)
 
     async def close(self):
         if not self.ws:
             return
         self.monitor.close_called.set()
-        await self.monitor.pinger_stopped.wait()
-        await self.monitor.receiver_stopped.wait()
+        await self._pinger_task.stopped.wait()
+        await self._receiver_task.stopped.wait()
         await self.ws.close()
         self.ws = None
 
-    async def recv(self, request_id):
+    async def _recv(self, request_id):
         if not self.is_open:
             raise websockets.exceptions.ConnectionClosed(0, 'websocket closed')
         return await self.messages.get(request_id)
 
-    async def receiver(self):
+    async def _receiver(self):
         try:
             while self.is_open:
                 result = await utils.run_with_interrupt(
@@ -200,10 +229,8 @@ class Connection:
             # make pending listeners aware of the error
             await self.messages.put_all(e)
             raise
-        finally:
-            self.monitor.receiver_stopped.set()
 
-    async def pinger(self):
+    async def _pinger(self):
         '''
         A Controller can time us out if we are silent for too long. This
         is especially true in JaaS, which has a fairly strict timeout.
@@ -219,19 +246,23 @@ class Connection:
                 pass
 
         pinger_facade = client.PingerFacade.from_connection(self)
-        try:
-            while True:
-                await utils.run_with_interrupt(
-                    _do_ping(),
-                    self.monitor.close_called,
-                    loop=self.loop)
-                if self.monitor.close_called.is_set():
-                    break
-        finally:
-            self.monitor.pinger_stopped.set()
-            return
+        while True:
+            await utils.run_with_interrupt(
+                _do_ping(),
+                self.monitor.close_called,
+                loop=self.loop)
+            if self.monitor.close_called.is_set():
+                break
 
     async def rpc(self, msg, encoder=None):
+        '''Make an RPC to the API. The message is encoded as JSON
+        using the given encoder if any.
+        :param msg: Parameters for the call (will be encoded as JSON).
+        :param encoder: Encoder to be used when encoding the message.
+        :return: The result of the call.
+        :raises JujuAPIError: When there's an error returned.
+        :raises JujuError:
+        '''
         self.__request_id__ += 1
         msg['request-id'] = self.__request_id__
         if'params' not in msg:
@@ -239,6 +270,7 @@ class Connection:
         if "version" not in msg:
             msg['version'] = self.facades[msg['type']]
         outgoing = json.dumps(msg, indent=2, cls=encoder)
+        log.debug('connection {} -> {}'.format(id(self), outgoing))
         for attempt in range(3):
             try:
                 await self.ws.send(outgoing)
@@ -252,7 +284,8 @@ class Connection:
                 # be cancelled when the pinger is cancelled by the reconnect,
                 # and we don't want the reconnect to be aborted halfway through
                 await asyncio.wait([self.reconnect()], loop=self.loop)
-        result = await self.recv(msg['request-id'])
+        result = await self._recv(msg['request-id'])
+        log.debug('connection {} <- {}'.format(id(self), result))
 
         if not result:
             return result
@@ -267,6 +300,10 @@ class Connection:
 
         if 'results' in result['response']:
             # Check for errors in a result list.
+            # TODO This loses the results that might have succeeded.
+            # Perhaps JujuError should return all the results including
+            # errors, or perhaps a keyword parameter to the rpc method
+            # could be added to trigger this behaviour.
             errors = []
             for res in result['response']['results']:
                 if res.get('error', {}).get('message'):
@@ -279,18 +316,18 @@ class Connection:
 
         return result
 
-    def http_headers(self):
+    def _http_headers(self):
         """Return dictionary of http headers necessary for making an http
         connection to the endpoint of this Connection.
 
         :return: Dictionary of headers
 
         """
-        if not self.username:
+        if not self.usertag:
             return {}
 
         creds = u'{}:{}'.format(
-            tag.user(self.username),
+            self.usertag,
             self.password or ''
         )
         token = base64.b64encode(creds.encode())
@@ -323,69 +360,49 @@ class Connection:
             "/model/{}".format(self.uuid)
             if self.uuid else ""
         )
-        return conn, self.http_headers(), path
+        return conn, self._http_headers(), path
 
     async def clone(self):
         """Return a new Connection, connected to the same websocket endpoint
         as this one.
 
         """
-        return await Connection.connect(
-            self.endpoint,
-            self.uuid,
-            self.username,
-            self.password,
-            self.cacert,
-            self.macaroons,
-            self.loop,
-            self.max_frame_size,
+        endpoint, kwargs = self.connect_params()
+
+        return await Connection.connect(endpoint, **kwargs)
+
+    def connect_params(self):
+        """Return a tuple of parameters suitable for passing to Connection.connect that
+        can be used to make a new connection to the same controller (and model
+        if specified. The first element in the returned tuple holds the endpoint argument; the other
+        holds a dict of the keyword args.
+        """
+        # TODO if the connect method took all keyword arguments then this could
+        # be simpler and just return a dict rather than a tuple.
+        return (
+            self.endpoint, {
+                'uuid': self.uuid,
+                'username': self.username,
+                'password': self.password,
+                'cacert': self.cacert,
+                'bakery_client': self.bakery_client,
+                'loop': self.loop,
+                'max_frame_size': self.max_frame_size,
+            }
         )
 
     async def controller(self):
         """Return a Connection to the controller at self.endpoint
-
         """
         return await Connection.connect(
             self.endpoint,
-            None,
-            self.username,
-            self.password,
-            self.cacert,
-            self.macaroons,
-            self.loop,
+            username=self.username,
+            password=self.password,
+            cacert=self.cacert,
+            bakery_client=self.bakery_client,
+            loop=self.loop,
+            max_frame_size=self.max_frame_size,
         )
-
-    async def _try_endpoint(self, endpoint, cacert):
-        success = False
-        result = None
-        new_endpoints = []
-
-        self.endpoint = endpoint
-        self.cacert = cacert
-        await self.open()
-        try:
-            result = await self.login()
-            if 'discharge-required-error' in result['response']:
-                log.info('Macaroon discharge required, disconnecting')
-            else:
-                # successful login!
-                log.info('Authenticated')
-                success = True
-        except JujuAPIError as e:
-            if e.error_code != 'redirection required':
-                raise
-            log.info('Controller requested redirect')
-            redirect_info = await self.redirect_info()
-            redir_cacert = redirect_info['ca-cert']
-            new_endpoints = [
-                ("{value}:{port}".format(**s), redir_cacert)
-                for servers in redirect_info['servers']
-                for s in servers if s["scope"] == 'public'
-            ]
-        finally:
-            if not success:
-                await self.close()
-        return success, result, new_endpoints
 
     async def reconnect(self):
         """ Force a reconnection.
@@ -395,147 +412,91 @@ class Connection:
             return
         async with monitor.reconnecting:
             await self.close()
-            await self._connect()
+            await self._connect_with_login([(self.endpoint, self.cacert)])
 
-    async def _connect(self):
-        endpoints = [(self._endpoint, self._cacert)]
-        while endpoints:
-            _endpoint, _cacert = endpoints.pop(0)
-            success, result, new_endpoints = await self._try_endpoint(
-                _endpoint, _cacert)
-            if success:
-                break
-            endpoints.extend(new_endpoints)
-        else:
-            # ran out of endpoints without a successful login
-            raise JujuConnectionError("Couldn't authenticate to {}".format(
-                self._endpoint))
+    async def _connect(self, endpoints):
+        if len(endpoints) == 0:
+            raise Exception('no endpoints to connect to')
+        first_exception = None
+        # TODO try connecting concurrently.
+        for endpoint, cacert in endpoints:
+            try:
+                self.ws, self.addr = await self._open(endpoint, cacert)
+                self.endpoint = endpoint
+                self.cacert = cacert
+                self._receiver_task.start()
+                log.info("Driver connected to juju %s", self.addr)
+                self.monitor.close_called.clear()
+                return
+            except Exception as e:
+                if first_exception is None:
+                    first_exception = e
+        raise first_exception
 
-        response = result['response']
-        self.info = response.copy()
-        self.build_facades(response.get('facades', {}))
-        self.loop.create_task(self.pinger())
-        self.monitor.pinger_stopped.clear()
-
-    @classmethod
-    async def connect(
-            cls, endpoint, uuid, username, password, cacert=None,
-            macaroons=None, loop=None, max_frame_size=None):
+    async def _connect_with_login(self, endpoints):
         """Connect to the websocket.
 
         If uuid is None, the connection will be to the controller. Otherwise it
         will be to the model.
-
+        :return: The login response JSON object.
         """
-        client = cls(endpoint, uuid, username, password, cacert, macaroons,
-                     loop, max_frame_size)
-        await client._connect()
-        return client
+        success = False
+        try:
+            await self._connect(endpoints)
+           # It's possible that we may get several discharge-required errors,
+            # corresponding to different levels of authentication, so retry
+            # a few times.
+            for i in range(0, 4):
+                result = await self.login()
+                macaroonJSON = result.get('discharge-required')
+                if macaroonJSON is None:
+                    self.info = result['response']
+                    success = True
+                    return result
+                # TODO implement macaroon authentication
+                raise NotImplementedError('macaroon authentication not implemented yet')
+        finally:
+            if not success:
+                await self.close()
 
-    @classmethod
-    async def connect_current(cls, loop=None, max_frame_size=None):
-        """Connect to the currently active model.
+    async def _connect_with_redirect(self, endpoints):
+        try:
+            login_result = await self._connect_with_login(endpoints)
+        except JujuAPIError as e:
+            if e.error_code != 'redirection required':
+                raise
+            log.info('Controller requested redirect')
+            redirect_info = await self.redirect_info()
+            redir_cacert = redirect_info['ca-cert']
+            new_endpoints = [
+                ('{value}:{port}'.format(**s), redir_cacert)
+                for servers in redirect_info['servers']
+                for s in servers if s['scope'] == 'public'
+            ]
+            login_result = await self._connect_with_login(new_endpoints)
+        response = login_result['response']
+        self._build_facades(response.get('facades', {}))
+        self._pinger_task.start()
 
-        """
-        jujudata = JujuData()
-
-        controller_name = jujudata.current_controller()
-        if not controller_name:
-            raise JujuConnectionError('No current controller')
-
-        model_name = jujudata.current_model()
-
-        return await cls.connect_model(
-            '{}:{}'.format(controller_name, model_name), loop, max_frame_size)
-
-    @classmethod
-    async def connect_current_controller(cls, loop=None, max_frame_size=None):
-        """Connect to the currently active controller.
-
-        """
-        jujudata = JujuData()
-        controller_name = jujudata.current_controller()
-        if not controller_name:
-            raise JujuConnectionError('No current controller')
-
-        return await cls.connect_controller(controller_name, loop,
-                                            max_frame_size)
-
-    @classmethod
-    async def connect_controller(cls, controller_name, loop=None,
-                                 max_frame_size=None):
-        """Connect to a controller by name.
-
-        """
-        jujudata = JujuData()
-        controller = jujudata.controllers()[controller_name]
-        endpoint = controller['api-endpoints'][0]
-        cacert = controller.get('ca-cert')
-        accounts = jujudata.accounts()[controller_name]
-        username = accounts['user']
-        password = accounts.get('password')
-        macaroons = get_macaroons(controller_name) if not password else None
-
-        return await cls.connect(
-            endpoint, None, username, password, cacert, macaroons, loop,
-            max_frame_size)
-
-    @classmethod
-    async def connect_model(cls, model, loop=None, max_frame_size=None):
-        """Connect to a model by name.
-
-        :param str model: [<controller>:]<model>
-
-        """
-        jujudata = JujuData()
-
-        if ':' in model:
-            # explicit controller given
-            controller_name, model_name = model.split(':')
-        else:
-            # use the current controller if one isn't explicitly given
-            controller_name = jujudata.current_controller()
-            model_name = model
-
-        accounts = jujudata.accounts()[controller_name]
-        username = accounts['user']
-        # model name must include a user prefix, so add it if it doesn't
-        if '/' not in model_name:
-            model_name = '{}/{}'.format(username, model_name)
-
-        controller = jujudata.controllers()[controller_name]
-        endpoint = controller['api-endpoints'][0]
-        cacert = controller.get('ca-cert')
-        password = accounts.get('password')
-        models = jujudata.models()[controller_name]
-        model_uuid = models['models'][model_name]['uuid']
-        macaroons = get_macaroons(controller_name) if not password else None
-
-        return await cls.connect(
-            endpoint, model_uuid, username, password, cacert, macaroons, loop,
-            max_frame_size)
-
-    def build_facades(self, facades):
+    def _build_facades(self, facades):
         self.facades.clear()
         for facade in facades:
             self.facades[facade['name']] = facade['versions'][-1]
 
     async def login(self):
-        username = self.username
-        if username and not username.startswith('user-'):
-            username = 'user-{}'.format(username)
+        params = {}
+        if self.usertag:
+            params['auth-tag'] = self.usertag
+            params['credentials'] = self.password
+        else:
+            params['macaroons'] = _macaroons_for_domain(self.bakery_client.cookies, self.endpoint)
 
-        result = await self.rpc({
+        return await self.rpc({
             "type": "Admin",
             "request": "Login",
             "version": 3,
-            "params": {
-                "auth-tag": username,
-                "credentials": self.password,
-                "nonce": "".join(random.sample(string.printable, 12)),
-                "macaroons": self.macaroons
-            }})
-        return result
+            "params": params,
+        })
 
     async def redirect_info(self):
         try:
@@ -551,34 +512,26 @@ class Connection:
         return result['response']
 
 
-def get_macaroons(controller_name=None):
-    """Decode and return macaroons from default ~/.go-cookies
+class _Task:
+    def __init__(self, task, loop):
+        self.stopped = asyncio.Event(loop=loop)
+        self.stopped.set()
+        self.task = task
+        self.loop = loop
 
-    """
-    cookie_files = []
-    if controller_name:
-        cookie_files.append('~/.local/share/juju/cookies/{}.json'.format(
-            controller_name))
-    cookie_files.append('~/.go-cookies')
-    for cookie_file in cookie_files:
-        cookie_file = Path(cookie_file).expanduser()
-        if cookie_file.exists():
+    def start(self):
+        async def run():
             try:
-                cookies = json.loads(cookie_file.read_text())
-                break
-            except (OSError, ValueError):
-                log.warn("Couldn't load macaroons from %s", cookie_file)
-                return []
-    else:
-        log.warn("Couldn't load macaroons from %s", ' or '.join(cookie_files))
-        return []
+                return await(self.task())
+            finally:
+                self.stopped.set()
+        self.stopped.clear()
+        self.loop.create_task(run())
 
-    base64_macaroons = [
-        c['Value'] for c in cookies
-        if c['Name'].startswith('macaroon-') and c['Value']
-    ]
 
-    return [
-        json.loads(base64.b64decode(value).decode('utf-8'))
-        for value in base64_macaroons
-    ]
+def _macaroons_for_domain(cookies, domain):
+    '''Return any macaroons from the given cookie jar that
+    apply to the given domain name.'''
+    req = urllib.request.Request('https://' + domain + '/')
+    cookies.add_cookie_header(req)
+    return httpbakery.extract_macaroons(req.headers)

--- a/juju/client/connector.py
+++ b/juju/client/connector.py
@@ -1,0 +1,133 @@
+import asyncio
+import logging
+
+import macaroonbakery.httpbakery as httpbakery
+from juju.client.connection import Connection
+from juju.client.jujudata import JujuData
+from juju.errors import JujuConnectionError, JujuError
+
+log = logging.getLogger('connector')
+
+
+class NoConnectionException(Exception):
+    '''Raised by Connector when the connection method is called
+    and there is no current connection.'''
+    pass
+
+class Connector:
+    '''This class abstracts out a reconnectable client that can connect
+    to controllers and models found in the Juju data files.
+    '''
+    def __init__(self, loop=None, max_frame_size=None, bakery_client=None):
+        '''Initialize a connector that will use the given parameters
+        by default when making a new connection'''
+        self.max_frame_size = max_frame_size
+        self.loop = loop or asyncio.get_event_loop()
+        self.bakery_client = bakery_client
+        self._connection = None
+        self.controller_name = None
+        self.model_name = None
+        self.jujudata = JujuData()
+
+    def is_connected(self):
+        '''Report whether there is a currently connected controller or not'''
+        return self._connection is not None
+
+    def connection(self):
+        '''Return the current connection; raises an exception if there
+        is no current connection.'''
+        if not self.is_connected():
+            raise NoConnectionException('not connected')
+        return self._connection
+
+    async def connect(self, *args, **kw):
+        """Connect to an arbitrary Juju model.
+
+        args and kw are passed through to Connection.connect()
+        """
+        kw.setdefault('loop', self.loop)
+        kw.setdefault('max_frame_size', self.max_frame_size)
+        kw.setdefault('bakery_client', self.bakery_client)
+        self._connection = await Connection.connect(*args, **kw)
+
+    async def disconnect(self):
+        """Shut down the watcher task and close websockets.
+        """
+        if self._connection:
+            log.debug('Closing model connection')
+            await self._connection.close()
+            self._connection = None
+
+    async def connect_controller(self, controller_name=None):
+        """Connect to a controller by name. If the name is empty, it
+        connect to the current controller.
+        """
+        if not controller_name:
+            controller_name = self.jujudata.current_controller()
+        if not controller_name:
+            raise JujuConnectionError('No current controller')
+
+        controller = self.jujudata.controllers()[controller_name]
+        # TODO change Connection so we can pass all the endpoints
+        # instead of just the first.
+        endpoint = controller['api-endpoints'][0]
+        accounts = self.jujudata.accounts()[controller_name]
+
+        await self.connect(
+            endpoint=endpoint,
+            uuid=None,
+            username=accounts.get('user'),
+            password=accounts.get('password'),
+            cacert=controller.get('ca-cert'),
+            bakery_client=self.bakery_client_for_controller(controller_name),
+        )
+        self.controller_name = controller_name
+
+    async def connect_model(self, model_name=None):
+        """Connect to a model by name. If either controller or model
+        parts of the name are empty, the current controller and/or model
+        will be used.
+
+        :param str model: <controller>:<model>
+        """
+
+        try:
+            controller_name, model_name = self.jujudata.parse_model(model_name)
+            controller = self.jujudata.controllers().get(controller_name)
+        except JujuError as e:
+            raise JujuConnectionError(e.message) from e
+        if controller is None:
+            raise JujuConnectionError('Controller {} not found'.format(controller_name))
+        # TODO change Connection so we can pass all the endpoints
+        # instead of just the first one.
+        endpoint = controller['api-endpoints'][0]
+        models = self.jujudata.models()[controller_name]
+        account = self.jujudata.accounts()[controller_name]
+
+        # TODO if there's no record for the required model name, connect
+        # to the controller to find out the model's uuid, then connect
+        # to that. This will let connect_model work with models that
+        # haven't necessarily synced with the local juju data,
+        # and also remove the need for base.CleanModel to
+        # patch JujuData.models with a mock.
+        await self.connect(
+            endpoint=endpoint,
+            uuid=models['models'][model_name]['uuid'],
+            username=account.get('user'),
+            password=account.get('password'),
+            cacert=controller.get('ca-cert'),
+            bakery_client=self.bakery_client_for_controller(controller_name),
+        )
+        self.controller_name = controller_name
+        self.model_name = controller_name + ':' + model_name
+
+    def bakery_client_for_controller(self, controller_name):
+        '''Make a copy of the bakery client with a the appropriate controller's
+        cookiejar in it.
+        '''
+        bakery_client = self.bakery_client
+        if bakery_client:
+            bakery_client = bakery_client.clone()
+        else:
+            bakery_client = httpbakery.Client()
+        bakery_client.cookies = self.jujudata.cookies_for_controller(controller_name)

--- a/juju/client/jujudata.py
+++ b/juju/client/jujudata.py
@@ -1,9 +1,11 @@
 import io
 import os
+import pathlib
 
 import juju.client.client as jujuclient
 import yaml
 from juju import tag
+from juju.client.gocookies import GoCookieJar
 from juju.errors import JujuError
 
 
@@ -66,10 +68,10 @@ class JujuData:
         if '/' not in model_name:
             # model name doesn't include a user prefix, so add one
             # by using the current user for the controller.
-            accounts = self.accounts().get('controller_name')
+            accounts = self.accounts().get(controller_name)
             if accounts is None:
-                raise JujuError('No account found for controller {}'.format(controller_name))
-            username = accounts.get['user']
+                raise JujuError('No account found for controller {} '.format(controller_name))
+            username = accounts.get('user')
             if username is None:
                 raise JujuError('No username found for controller {}'.format(controller_name))
             model_name = username + "/" + model_name
@@ -127,3 +129,11 @@ class JujuData:
             data = yaml.safe_load(f)
             self._loaded[filename] = data
             return data.get(key)
+
+    def cookies_for_controller(self, controller_name):
+        f = pathlib.Path(self.path) / 'cookies' / controller_name
+        if not f.exists():
+            f = pathlib.Path('~/.go-cookies').expanduser()
+            # TODO if neither cookie file exists, where should
+            # we create the cookies?
+        return GoCookieJar(str(f))

--- a/juju/machine.py
+++ b/juju/machine.py
@@ -169,6 +169,8 @@ class Machine(model.ModelEntity):
             'scp',
             '-i', os.path.expanduser('~/.local/share/juju/ssh/juju_id_rsa'),
             '-o', 'StrictHostKeyChecking=no',
+            '-q',
+            '-B',
             source, destination
         ]
         cmd += scp_opts.split()

--- a/juju/utils.py
+++ b/juju/utils.py
@@ -46,6 +46,7 @@ async def read_ssh_key(loop):
     can be passed on to a model.
 
     '''
+    loop = loop or asyncio.get_event_loop()
     return await loop.run_in_executor(None, _read_ssh_key)
 
 

--- a/setup.py
+++ b/setup.py
@@ -30,10 +30,11 @@ setup(
     packages=find_packages(
         exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=[
-        'websockets',
+        'macaroonbakery<1.0',
+        'pyRFC3339>=1.0,<2.0',
         'pyyaml',
         'theblues',
-        'pyRFC3339>=1.0,<2.0',
+        'websockets',
     ],
     include_package_data=True,
     maintainer='Juju Ecosystem Engineering',

--- a/tests/base.py
+++ b/tests/base.py
@@ -2,7 +2,7 @@ import subprocess
 import uuid
 
 import mock
-from juju.client.connection import JujuData
+from juju.client.jujudata import JujuData
 from juju.controller import Controller
 
 import pytest
@@ -26,7 +26,7 @@ class CleanController():
 
     async def __aenter__(self):
         self.controller = Controller()
-        await self.controller.connect_current()
+        await self.controller.connect()
         return self.controller
 
     async def __aexit__(self, exc_type, exc, tb):
@@ -47,7 +47,7 @@ class CleanModel():
         juju_data = JujuData()
         self.controller_name = juju_data.current_controller()
         self.user_name = juju_data.accounts()[self.controller_name]['user']
-        await self.controller.connect_controller(self.controller_name)
+        await self.controller.connect(self.controller_name)
 
         self.model_name = 'test-{}'.format(uuid.uuid4())
         self.model = await self.controller.add_model(self.model_name)

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -9,7 +9,7 @@ from .. import base
 @pytest.mark.asyncio
 async def test_user_info(event_loop):
     async with base.CleanModel() as model:
-        controller_conn = await model.connection.controller()
+        controller_conn = await model.connection().controller()
 
         um = client.UserManagerFacade.from_connection(controller_conn)
         result = await um.UserInfo(

--- a/tests/integration/test_errors.py
+++ b/tests/integration/test_errors.py
@@ -40,7 +40,7 @@ async def test_juju_error_in_results_list(event_loop):
     from juju.client import client
 
     async with base.CleanModel() as model:
-        ann_facade = client.AnnotationsFacade.from_connection(model.connection)
+        ann_facade = client.AnnotationsFacade.from_connection(model.connection())
 
         ann = client.EntityAnnotations(
             entity='badtag',
@@ -62,7 +62,7 @@ async def test_juju_error_in_result(event_loop):
     from juju.client import client
 
     async with base.CleanModel() as model:
-        app_facade = client.ApplicationFacade.from_connection(model.connection)
+        app_facade = client.ApplicationFacade.from_connection(model.connection())
 
         with pytest.raises(JujuError):
             return await app_facade.GetCharmURL('foo')

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -123,7 +123,7 @@ async def test_relate(event_loop):
 
 async def _deploy_in_loop(new_loop, model_name):
     new_model = Model(new_loop)
-    await new_model.connect_model(model_name)
+    await new_model.connect(model_name)
     try:
         await new_model.deploy('cs:xenial/ubuntu')
         assert 'ubuntu' in new_model.applications
@@ -208,9 +208,9 @@ async def test_get_machines(event_loop):
 @pytest.mark.asyncio
 async def test_watcher_reconnect(event_loop):
     async with base.CleanModel() as model:
-        await model.connection.ws.close()
+        await model.connection().ws.close()
         await asyncio.sleep(0.1)
-        assert model.connection.is_open
+        assert model.is_connected()
 
 
 @base.bootstrapped

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -69,8 +69,8 @@ class TestModelState(unittest.TestCase):
         from juju.model import Model
         from juju.application import Application
 
-        loop = mock.MagicMock()
-        model = Model(loop=loop)
+        model = Model()
+        model._connector = mock.MagicMock()
         delta = _make_delta('application', 'add', dict(name='foo'))
 
         # test add
@@ -119,7 +119,7 @@ def test_get_series():
 
 class TestContextManager(asynctest.TestCase):
     @asynctest.patch('juju.model.Model.disconnect')
-    @asynctest.patch('juju.model.Model.connect_current')
+    @asynctest.patch('juju.model.Model.connect')
     async def test_normal_use(self, mock_connect, mock_disconnect):
         from juju.model import Model
 
@@ -130,7 +130,7 @@ class TestContextManager(asynctest.TestCase):
         self.assertTrue(mock_disconnect.called)
 
     @asynctest.patch('juju.model.Model.disconnect')
-    @asynctest.patch('juju.model.Model.connect_current')
+    @asynctest.patch('juju.model.Model.connect')
     async def test_exception(self, mock_connect, mock_disconnect):
         from juju.model import Model
 
@@ -144,7 +144,7 @@ class TestContextManager(asynctest.TestCase):
         self.assertTrue(mock_connect.called)
         self.assertTrue(mock_disconnect.called)
 
-    @asynctest.patch('juju.client.connection.JujuData.current_controller')
+    @asynctest.patch('juju.client.jujudata.JujuData.current_controller')
     async def test_no_current_connection(self, mock_current_controller):
         from juju.model import Model
         from juju.errors import JujuConnectionError

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
 
 [testenv:py35]
 # default tox env excludes integration tests
-commands = py.test -ra -v -s -n auto -k 'not integration' {posargs}
+commands = py.test -ravs -n auto -k 'not integration' {posargs}
 
 [testenv:lint]
 envdir = {toxworkdir}/py35


### PR DESCRIPTION
We do a bunch of refactoring in advance of actually adding the bakery authentication. No additional functionality as yet (hence no new tests) but this is a breaking API change in a few ways.

API changes
----

Model and Controller now use the connect method for both connecting to a named model and for connecting to the current model (if the name is empty or None); the connect_current and connect_model methods are removed.

Connection.connect is now a class method that returns a new connected connection.

Various fields in Connection, Model and Controller that are really internal-only are given a leading underscore.

Controller and Model now have connection methods not properties, and they raise an exception if there is no current connection.


Other changes that should not break the API
----

Add a bakery_client argument to Connection.connect so that the client can have control over what interaction methods are used and provide a cookie jar.

Use "-q -B" options to scp so that it doesn't print spurious output when it's used.

Avoid unnecessary explicit inheritance from object.

Add is_connected method to Controller and Model.

Made new Connector class factoring out code in common between Controller and Model.

Factor Connection._connect so that we can do the bakery authentication.

Connection has a new connect_params method that returns parameters suitable for passing to Connection.connect.

Factor out all JujuData knowledge from connection.py.

Factored out commonality from Connection.pinger and Connection.receiver to _Task, making it easier to disable or mock those tasks in tests.