### PR TITLE
Fix race condition in adding relations

### DIFF
--- a/examples/relate.py
+++ b/examples/relate.py
@@ -42,57 +42,60 @@ async def main():
     model = Model()
     await model.connect()
 
-    model.add_observer(MyRemoveObserver())
-    await model.reset(force=True)
-    model.add_observer(MyModelObserver())
+    try:
+        model.add_observer(MyRemoveObserver())
+        await model.reset(force=True)
+        model.add_observer(MyModelObserver())
 
-    ubuntu_app = await model.deploy(
-        'ubuntu',
-        application_name='ubuntu',
-        series='trusty',
-        channel='stable',
-    )
-    ubuntu_app.on_change(asyncio.coroutine(
-        lambda delta, old_app, new_app, model:
-            print('App changed: {}'.format(new_app.entity_id))
-    ))
-    ubuntu_app.on_remove(asyncio.coroutine(
-        lambda delta, old_app, new_app, model:
-            print('App removed: {}'.format(old_app.entity_id))
-    ))
-    ubuntu_app.on_unit_add(asyncio.coroutine(
-        lambda delta, old_unit, new_unit, model:
-            print('Unit added: {}'.format(new_unit.entity_id))
-    ))
-    ubuntu_app.on_unit_remove(asyncio.coroutine(
-        lambda delta, old_unit, new_unit, model:
-            print('Unit removed: {}'.format(old_unit.entity_id))
-    ))
-    unit_a, unit_b = await ubuntu_app.add_units(count=2)
-    unit_a.on_change(asyncio.coroutine(
-        lambda delta, old_unit, new_unit, model:
-            print('Unit changed: {}'.format(new_unit.entity_id))
-    ))
-    await model.deploy(
-        'nrpe',
-        application_name='nrpe',
-        series='trusty',
-        channel='stable',
-        # subordinates must be deployed without units
-        num_units=0,
-    )
-    my_relation = await model.add_relation(
-        'ubuntu',
-        'nrpe',
-    )
-    my_relation.on_remove(asyncio.coroutine(
-        lambda delta, old_rel, new_rel, model:
-            print('Relation removed: {}'.format(old_rel.endpoints))
-    ))
+        ubuntu_app = await model.deploy(
+            'ubuntu',
+            application_name='ubuntu',
+            series='trusty',
+            channel='stable',
+        )
+        ubuntu_app.on_change(asyncio.coroutine(
+            lambda delta, old_app, new_app, model:
+                print('App changed: {}'.format(new_app.entity_id))
+        ))
+        ubuntu_app.on_remove(asyncio.coroutine(
+            lambda delta, old_app, new_app, model:
+                print('App removed: {}'.format(old_app.entity_id))
+        ))
+        ubuntu_app.on_unit_add(asyncio.coroutine(
+            lambda delta, old_unit, new_unit, model:
+                print('Unit added: {}'.format(new_unit.entity_id))
+        ))
+        ubuntu_app.on_unit_remove(asyncio.coroutine(
+            lambda delta, old_unit, new_unit, model:
+                print('Unit removed: {}'.format(old_unit.entity_id))
+        ))
+        unit_a, unit_b = await ubuntu_app.add_units(count=2)
+        unit_a.on_change(asyncio.coroutine(
+            lambda delta, old_unit, new_unit, model:
+                print('Unit changed: {}'.format(new_unit.entity_id))
+        ))
+        await model.deploy(
+            'nrpe',
+            application_name='nrpe',
+            series='trusty',
+            channel='stable',
+            # subordinates must be deployed without units
+            num_units=0,
+        )
+        my_relation = await model.add_relation(
+            'ubuntu',
+            'nrpe',
+        )
+        my_relation.on_remove(asyncio.coroutine(
+            lambda delta, old_rel, new_rel, model:
+                print('Relation removed: {}'.format(old_rel.endpoints))
+        ))
+    finally:
+        await model.disconnect()
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.DEBUG)
+    logging.basicConfig(level=logging.INFO)
     ws_logger = logging.getLogger('websockets.protocol')
     ws_logger.setLevel(logging.INFO)
     loop.run(main())

--- a/juju/application.py
+++ b/juju/application.py
@@ -53,10 +53,7 @@ class Application(model.ModelEntity):
 
     @property
     def relations(self):
-        return [
-            rel for rel in self.model.relations
-            if self.name in {app.name for app in rel.applications}
-        ]
+        return [rel for rel in self.model.relations if rel.matches(self.name)]
 
     def related_applications(self, endpoint_name=None):
         apps = {}

--- a/juju/application.py
+++ b/juju/application.py
@@ -52,6 +52,27 @@ class Application(model.ModelEntity):
         ]
 
     @property
+    def relations(self):
+        return [
+            rel for rel in self.model.relations
+            if self.name in {app.name for app in rel.applications}
+        ]
+
+    def related_applications(self, endpoint_name=None):
+        apps = {}
+        for rel in self.relations:
+            if rel.is_peer:
+                local_ep, remote_ep = rel.endpoints[0]
+            else:
+                def is_us(ep):
+                    return ep.application.name == self.name
+                local_ep, remote_ep = sorted(rel.endpoints, key=is_us)
+            if endpoint_name is not None and endpoint_name != local_ep.name:
+                continue
+            apps[remote_ep.application.name] = remote_ep.application
+        return apps
+
+    @property
     def status(self):
         """Get the application status, as set by the charm's leader.
 

--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -246,13 +246,14 @@ class Connection:
                 pass
 
         pinger_facade = client.PingerFacade.from_connection(self)
-        while True:
-            await utils.run_with_interrupt(
-                _do_ping(),
-                self.monitor.close_called,
-                loop=self.loop)
-            if self.monitor.close_called.is_set():
-                break
+        while self.monitor.status == Monitor.CONNECTED:
+            try:
+                await utils.run_with_interrupt(
+                    _do_ping(),
+                    self.monitor.close_called,
+                    loop=self.loop)
+            except websockets.ConnectionClosed:
+                pass
 
     async def rpc(self, msg, encoder=None):
         '''Make an RPC to the API. The message is encoded as JSON

--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -452,7 +452,7 @@ class Connection:
         success = False
         try:
             await self._connect(endpoints)
-           # It's possible that we may get several discharge-required errors,
+            # It's possible that we may get several discharge-required errors,
             # corresponding to different levels of authentication, so retry
             # a few times.
             for i in range(0, 4):

--- a/juju/client/connector.py
+++ b/juju/client/connector.py
@@ -14,6 +14,7 @@ class NoConnectionException(Exception):
     and there is no current connection.'''
     pass
 
+
 class Connector:
     '''This class abstracts out a reconnectable client that can connect
     to controllers and models found in the Juju data files.

--- a/juju/client/jujudata.py
+++ b/juju/client/jujudata.py
@@ -63,7 +63,7 @@ class JujuData:
         if not controller_name:
             controller_name = self.current_controller()
         if not model_name:
-            model_name = self.current_model(controller_name)
+            model_name = self.current_model(controller_name).split(':')[1]
 
         if '/' not in model_name:
             # model name doesn't include a user prefix, so add one

--- a/juju/model.py
+++ b/juju/model.py
@@ -713,7 +713,10 @@ class Model:
                             # closed on request, go ahead and shutdown
                             break
                     if self._watch_stopping.is_set():
-                        await allwatcher.Stop()
+                        try:
+                            await allwatcher.Stop()
+                        except websockets.ConnectionClosed:
+                            pass  # can't stop on a closed conn
                         break
                     for delta in results.deltas:
                         delta = get_entity_delta(delta)

--- a/juju/model.py
+++ b/juju/model.py
@@ -449,6 +449,20 @@ class Model:
         await self._connector.connect_model(model_name)
         await self._after_connect()
 
+    async def connect_model(self, model_name):
+        """
+        .. deprecated:: 0.6.2
+           Use connect instead.
+        """
+        return await self.connect(model_name)
+
+    async def connect_current(self):
+        """
+        .. deprecated:: 0.6.2
+           Use connect instead.
+        """
+        return await self.connect()
+
     async def _connect_direct(self, *args, **kwargs):
         await self.disconnect()
         await self._connector.connect(*args, **kwargs)

--- a/juju/relation.py
+++ b/juju/relation.py
@@ -5,7 +5,89 @@ from . import model
 log = logging.getLogger(__name__)
 
 
+class Endpoint:
+    def __init__(self, model, data):
+        self.model = model
+        self.data = data
+
+    def __repr__(self):
+        return '<Endpoint {}:{}>'.format(self.application.name, self.name)
+
+    @property
+    def application(self):
+        return self.model.applications[self.data['application-name']]
+
+    @property
+    def name(self):
+        return self.data['relation']['name']
+
+    @property
+    def interface(self):
+        return self.data['relation']['interface']
+
+    @property
+    def role(self):
+        return self.data['relation']['role']
+
+    @property
+    def scope(self):
+        return self.data['relation']['scope']
+
+
 class Relation(model.ModelEntity):
+    def __repr__(self):
+        return '<Relation id={} {}>'.format(self.entity_id, self.key)
+
+    @property
+    def endpoints(self):
+        return [Endpoint(self.model, data)
+                for data in self.safe_data['endpoints']]
+
+    @property
+    def provides(self):
+        """
+        The endpoint on the provides side of this relation, or None.
+        """
+        for endpoint in self.endpoints:
+            if endpoint.role == 'provider':
+                return endpoint
+        return None
+
+    @property
+    def requires(self):
+        """
+        The endpoint on the requires side of this relation, or None.
+        """
+        for endpoint in self.endpoints:
+            if endpoint.role == 'requirer':
+                return endpoint
+        return None
+
+    @property
+    def peers(self):
+        """
+        The peers endpoint of this relation, or None.
+        """
+        for endpoint in self.endpoints:
+            if endpoint.role == 'peer':
+                return endpoint
+        return None
+
+    @property
+    def is_subordinate(self):
+        return any(ep.scope == 'container' for ep in self.endpoints)
+
+    @property
+    def is_peer(self):
+        return any(ep.role == 'peer' for ep in self.endpoints)
+
+    @property
+    def applications(self):
+        """
+        All applications involved in this relation.
+        """
+        return [ep.application for ep in self.endpoints]
+
     async def destroy(self):
         raise NotImplementedError()
         # TODO: destroy a relation

--- a/juju/relation.py
+++ b/juju/relation.py
@@ -81,6 +81,36 @@ class Relation(model.ModelEntity):
     def is_peer(self):
         return any(ep.role == 'peer' for ep in self.endpoints)
 
+    def matches(self, *specs):
+        """
+        Check if this relation matches relationship specs.
+
+        Relation specs are strings that would be given to Juju to establish a
+        relation, and should be in the form ``<application>[:<endpoint_name>]``
+        where the ``:<endpoint_name>`` suffix is optional.  If the suffix is
+        omitted, this relation will match on any endpoint as long as the given
+        application is involved.
+
+        In other words, this relation will match a spec if that spec could have
+        created this relation.
+
+        :return: True if all specs match.
+        """
+        for spec in specs:
+            if ':' in spec:
+                app_name, endpoint_name = spec.split(':')
+            else:
+                app_name, endpoint_name = spec, None
+            for endpoint in self.endpoints:
+                if app_name == endpoint.application.name and \
+                   endpoint_name in (endpoint.name, None):
+                    # found a match for this spec, so move to next one
+                    break
+            else:
+                # no match for this spec
+                return False
+        return True
+
     @property
     def applications(self):
         """

--- a/juju/utils.py
+++ b/juju/utils.py
@@ -92,6 +92,10 @@ async def run_with_interrupt(task, event, loop=None):
                                        return_when=asyncio.FIRST_COMPLETED)
     for f in pending:
         f.cancel()
+    exception = [f.exception() for f in done
+                 if f is not event_task and f.exception()]
+    if exception:
+        raise exception[0]
     result = [f.result() for f in done if f is not event_task]
     if result:
         return result[0]

--- a/juju/utils.py
+++ b/juju/utils.py
@@ -72,6 +72,16 @@ class IdQueue:
             await queue.put(value)
 
 
+async def block_until(*conditions, timeout=None, wait_period=0.5, loop=None):
+    """Return only after all conditions are true.
+
+    """
+    async def _block():
+        while not all(c() for c in conditions):
+            await asyncio.sleep(wait_period, loop=loop)
+    await asyncio.wait_for(_block(), timeout, loop=loop)
+
+
 async def run_with_interrupt(task, event, loop=None):
     """
     Awaits a task while allowing it to be interrupted by an `asyncio.Event`.

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -10,6 +10,7 @@ from juju.utils import run_with_interrupt
 import pytest
 
 from .. import base
+from juju.utils import block_until
 
 MB = 1
 GB = 1024
@@ -238,8 +239,7 @@ async def test_get_machines(event_loop):
 async def test_watcher_reconnect(event_loop):
     async with base.CleanModel() as model:
         await model.connection().ws.close()
-        await asyncio.sleep(0.1)
-        assert model.is_connected()
+        await block_until(model.is_connected, timeout=3)
 
 
 @base.bootstrapped

--- a/tests/unit/test_gocookies.py
+++ b/tests/unit/test_gocookies.py
@@ -204,7 +204,7 @@ class TestGoCookieJar(unittest.TestCase):
         ]'''
         jar = self.load_jar(content)
         got_expires = tuple(jar)[0].expires
-        want_expires = pyrfc3339.parse('2345-11-15T18:16:08Z').timestamp()
+        want_expires = int(pyrfc3339.parse('2345-11-15T18:16:08Z').timestamp())
         self.assertEqual(got_expires, want_expires)
 
     def load_jar(self, content):


### PR DESCRIPTION
Using `Model._wait_for_new` without an `entity_id` can block indefinitely if the object is already in the model.  This could happen with relations because the` AddRelation` API call might not return execution until after the `_watch` task picks up the delta which is before the call to `Model._wait_for_new`.  Unfortunately, the API result doesn't include the relation ID, so we just have to watch the model for the relation with the right key.

This came up in conjure-up/conjure-up#1264

Fixes #191