### PR TITLE
make libjuju work with bakery authentication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,13 @@ before_install:
   - sudo snap install juju-wait --classic || true
 install: pip install tox-travis
 env:
-  - SNAP_CMD="sudo snap install juju --classic --stable"
-  - SNAP_CMD="sudo snap install juju --classic --edge"
+  global: >
+    TEST_AGENTS='{"agents":[{"url":"https://api.staging.jujucharms.com/identity","username":"libjuju-ci@yellow"}],"key":{"private":"88OOCxIHQNguRG7zFg2y2Hx5Ob0SeVKKBRnjyehverc=","public":"fDn20+5FGyN2hYO7z0rFUyoHGUnfrleslUNtoYsjNSs="}}'
+  matrix:
+    - JUJU_CHANNEL=stable
+    - JUJU_CHANNEL=edge
 script:
-  - (eval "$SNAP_CMD")
+  - sudo snap install juju --classic --$JUJU_CHANNEL
   - sudo ln -s /snap/bin/juju /usr/bin/juju || true
-  - sudo -E sudo -u $USER -E bash -c "/snap/bin/juju bootstrap localhost test"
+  - sudo -E sudo -u $USER -E /snap/bin/juju bootstrap localhost test --config 'identity-url=https://api.staging.jujucharms.com/identity' --config 'allow-model-access=true'
   - tox -e py35,integration

--- a/juju/client/connector.py
+++ b/juju/client/connector.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import copy
 
 import macaroonbakery.httpbakery as httpbakery
 from juju.client.connection import Connection
@@ -78,7 +79,7 @@ class Connector:
         # TODO change Connection so we can pass all the endpoints
         # instead of just the first.
         endpoint = controller['api-endpoints'][0]
-        accounts = self.jujudata.accounts()[controller_name]
+        accounts = self.jujudata.accounts().get(controller_name, {})
 
         await self.connect(
             endpoint=endpoint,
@@ -109,7 +110,7 @@ class Connector:
         # instead of just the first one.
         endpoint = controller['api-endpoints'][0]
         models = self.jujudata.models()[controller_name]
-        account = self.jujudata.accounts()[controller_name]
+        account = self.jujudata.accounts().get(controller_name, {})
 
         # TODO if there's no record for the required model name, connect
         # to the controller to find out the model's uuid, then connect
@@ -134,7 +135,8 @@ class Connector:
         '''
         bakery_client = self.bakery_client
         if bakery_client:
-            bakery_client = bakery_client.clone()
+            bakery_client = copy.copy(bakery_client)
         else:
             bakery_client = httpbakery.Client()
         bakery_client.cookies = self.jujudata.cookies_for_controller(controller_name)
+        return bakery_client

--- a/juju/controller.py
+++ b/juju/controller.py
@@ -3,13 +3,12 @@ import logging
 
 from . import errors, tag, utils
 from .client import client, connector
-from .model import Model
 from .user import User
 
 log = logging.getLogger(__name__)
 
 
-class Controller(object):
+class Controller:
     def __init__(
         self,
         loop=None,
@@ -37,6 +36,13 @@ class Controller(object):
             bakery_client=bakery_client,
             jujudata=jujudata,
         )
+
+    async def __aenter__(self):
+        await self.connect()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.disconnect()
 
     @property
     def loop(self):
@@ -67,6 +73,10 @@ class Controller(object):
                 # A UUID implies a model connection, not a controller connection.
                 raise ValueError('model UUID specified when connecting to controller')
             await self._connector.connect(**kwargs)
+
+    async def _connect_direct(self, **kwargs):
+        await self.disconnect()
+        await self._connector.connect(**kwargs)
 
     def is_connected(self):
         """Reports whether the Controller is currently connected."""
@@ -184,7 +194,7 @@ class Controller(object):
             owner,
             region
         )
-
+        from juju.model import Model
         model = Model(jujudata=self._connector.jujudata)
         kwargs = self.connection().connect_params()
         kwargs['uuid'] = model_info.uuid
@@ -385,6 +395,7 @@ class Controller(object):
         else:
             uuid = model
 
+        from juju.model import Model
         model = Model()
         kwargs = self.connection().connect_params()
         kwargs['uuid'] = uuid
@@ -425,27 +436,63 @@ class Controller(object):
         return [User(self, r.result) for r in response.results]
 
     async def grant(self, username, acl='login'):
-        """Set access level of the given user on the controller
-
+        """Grant access level of the given user on the controller.
+        Note that if the user already has higher permissions than the
+        provided ACL, this will do nothing (see revoke for a way to
+        remove permissions).
         :param str username: Username
         :param str acl: Access control ('login', 'add-model' or 'superuser')
-
         """
         controller_facade = client.ControllerFacade.from_connection(
             self.connection())
         user = tag.user(username)
-        await self.revoke(username)
         changes = client.ModifyControllerAccess(acl, 'grant', user)
         return await controller_facade.ModifyControllerAccess([changes])
 
-    async def revoke(self, username):
-        """Removes all access from a controller
+    async def revoke(self, username, acl='login'):
+        """Removes some or all access of a user to from a controller
+        If 'login' access is revoked, the user will no longer have any
+        permissions on the controller. Revoking a higher privilege from
+        a user without that privilege will have no effect.
 
         :param str username: username
-
+        :param str acl: Access to remove ('login', 'add-model' or 'superuser')
         """
         controller_facade = client.ControllerFacade.from_connection(
             self.connection())
         user = tag.user(username)
         changes = client.ModifyControllerAccess('login', 'revoke', user)
         return await controller_facade.ModifyControllerAccess([changes])
+
+    async def grant_model(self, username, model_uuid, acl='read'):
+        """Grant a user access to a model. Note that if the user
+        already has higher permissions than the provided ACL,
+        this will do nothing (see revoke_model for a way to remove permissions).
+
+        :param str username: Username
+        :param str model_uuid: The UUID of the model to change.
+        :param str acl: Access control ('read, 'write' or 'admin')
+        """
+        model_facade = client.ModelManagerFacade.from_connection(
+            self.connection())
+        user = tag.user(username)
+        model = tag.model(model_uuid)
+        changes = client.ModifyModelAccess(acl, 'grant', model, user)
+        return await model_facade.ModifyModelAccess([changes])
+
+    async def revoke_model(self, username, model_uuid, acl='read'):
+        """Revoke some or all of a user's access to a model.
+        If 'read' access is revoked, the user will no longer have any
+        permissions on the model. Revoking a higher privilege from
+        a user without that privilege will have no effect.
+
+        :param str username: Username to revoke
+        :param str model_uuid: The UUID of the model to change.
+        :param str acl: Access control ('read, 'write' or 'admin')
+        """
+        model_facade = client.ModelManagerFacade.from_connection(
+            self.connection())
+        user = tag.user(username)
+        model = tag.model(self.info.uuid)
+        changes = client.ModifyModelAccess(acl, 'revoke', model, user)
+        return await model_facade.ModifyModelAccess([changes])

--- a/juju/model.py
+++ b/juju/model.py
@@ -440,8 +440,18 @@ class Model:
         if the Model is disconnected"""
         return self._connector.connection()
 
+    async def get_controller(self):
+        """Return a Controller instance for the currently connected model.
+        :return Controller:
+        """
+        from juju.controller import Controller
+        controller = Controller(jujudata=self._connector.jujudata)
+        kwargs = self.connection().connect_params()
+        kwargs.pop('uuid')
+        await controller._connect_direct(**kwargs)
+        return controller
+
     async def __aenter__(self):
-        # TODO is this actually useful to have?
         await self.connect()
         return self
 
@@ -1354,22 +1364,6 @@ class Model:
         """
         raise NotImplementedError()
 
-    async def grant(self, username, acl='read'):
-        """Grant a user access to this model.
-
-        :param str username: Username
-        :param str acl: Access control ('read' or 'write')
-
-        """
-        controller_conn = await self.connection().controller()
-        model_facade = client.ModelManagerFacade.from_connection(
-            controller_conn)
-        user = tag.user(username)
-        model = tag.model(self.info.uuid)
-        changes = client.ModifyModelAccess(acl, 'grant', model, user)
-        await self.revoke(username)
-        return await model_facade.ModifyModelAccess([changes])
-
     def import_ssh_key(self, identity):
         """Add a public SSH key from a trusted indentity source to this model.
 
@@ -1503,20 +1497,6 @@ class Model:
 
         """
         raise NotImplementedError()
-
-    async def revoke(self, username):
-        """Revoke a user's access to this model.
-
-        :param str username: Username to revoke
-
-        """
-        controller_conn = await self.connection().controller()
-        model_facade = client.ModelManagerFacade.from_connection(
-            controller_conn)
-        user = tag.user(username)
-        model = tag.model(self.info.uuid)
-        changes = client.ModifyModelAccess('read', 'revoke', model, user)
-        return await model_facade.ModifyModelAccess([changes])
 
     def run(self, command, timeout=None):
         """Run command on all machines in this model.

--- a/tests/base.py
+++ b/tests/base.py
@@ -37,17 +37,21 @@ class CleanController():
 
 
 class CleanModel():
-    def __init__(self):
+    def __init__(self, bakery_client=None):
         self._controller = None
         self._model = None
         self._model_uuid = None
+        self._bakery_client = bakery_client
 
     async def __aenter__(self):
         model_nonce = uuid.uuid4().hex[-4:]
         frame = inspect.stack()[1]
         test_name = frame.function.replace('_', '-')
         jujudata = TestJujuData()
-        self._controller = Controller(jujudata=jujudata)
+        self._controller = Controller(
+            jujudata=jujudata,
+            bakery_client=self._bakery_client,
+        )
         controller_name = jujudata.current_controller()
         user_name = jujudata.accounts()[controller_name]['user']
         await self._controller.connect(controller_name)

--- a/tests/base.py
+++ b/tests/base.py
@@ -91,8 +91,8 @@ class TestJujuData(FileJujuData):
         self.__model_name = model_name
         self.__model_uuid = model_uuid
 
-    def current_model(self):
-        return self.__model_name or super().current_model()
+    def current_model(self, *args, **kwargs):
+        return self.__model_name or super().current_model(*args, **kwargs)
 
     def models(self):
         all_models = super().models()

--- a/tests/integration/test_macaroon_auth.py
+++ b/tests/integration/test_macaroon_auth.py
@@ -1,0 +1,117 @@
+import logging
+import os
+
+import macaroonbakery.bakery as bakery
+import macaroonbakery.httpbakery as httpbakery
+import macaroonbakery.httpbakery.agent as agent
+from juju.client import client
+from juju.errors import JujuAPIError
+from juju.model import Model
+
+import pytest
+
+from .. import base
+
+log = logging.getLogger(__name__)
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_macaroon_auth(event_loop):
+    try:
+       auth_info, username = agent_auth_info()
+    except NoAgentInfo:
+       return
+    # Create a bakery client can do agent authentication.
+    client = httpbakery.Client(
+        key=auth_info.key,
+        interaction_methods=[agent.AgentInteractor(auth_info)],
+    )
+
+    async with base.CleanModel() as m:
+        async with await m.get_controller() as c:
+            await c.grant_model(username, m.info.uuid, 'admin')
+        async with Model(
+            jujudata=NoAccountsJujuData(m._connector.jujudata),
+            bakery_client=client,
+        ) as m1:
+            pass
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_macaroon_auth_with_bad_key(event_loop):
+    try:
+       auth_info, username = agent_auth_info()
+    except NoAgentInfo:
+       return
+    # Use a random key rather than the correct key.
+    auth_info = auth_info._replace(key=bakery.generate_key())
+    # Create a bakery client can do agent authentication.
+    client = httpbakery.Client(
+        key=auth_info.key,
+        interaction_methods=[agent.AgentInteractor(auth_info)],
+    )
+
+    async with base.CleanModel() as m:
+        async with await m.get_controller() as c:
+            await c.grant_model(username, m.info.uuid, 'admin')
+        try:
+            async with Model(
+                jujudata=NoAccountsJujuData(m._connector.jujudata),
+                bakery_client=client,
+            ):
+                pass
+        except httpbakery.BakeryException:
+            # We're expecting this because we're using the
+            # wrong key.
+            pass
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_macaroon_auth_with_unauthorized_user(event_loop):
+    try:
+       auth_info, username = agent_auth_info()
+    except NoAgentInfo:
+       return
+    # Create a bakery client can do agent authentication.
+    client = httpbakery.Client(
+        key=auth_info.key,
+        interaction_methods=[agent.AgentInteractor(auth_info)],
+    )
+    async with base.CleanModel() as m:
+        # Note: no grant of rights to the agent user.
+        try:
+            async with Model(
+                jujudata=NoAccountsJujuData(m._connector.jujudata),
+                bakery_client=client,
+            ) as m1:
+                pass
+        except JujuAPIError:
+            # We're expecting this because we're using the
+            # wrong user name.
+            pass
+
+class NoAgentInfo(Exception):
+    pass
+
+def agent_auth_info():
+    agent_data = os.environ.get('TEST_AGENTS')
+    if agent_data is None:
+        log.warning('skipping macaroon_auth because no TEST_AGENTS environment variable is set')
+        raise NoAgentInfo()
+    auth_info = agent.read_auth_info(agent_data)
+    if len(auth_info.agents) != 1:
+        raise Exception('TEST_AGENTS agent data requires exactly one agent')
+    return auth_info, auth_info.agents[0].username
+
+class NoAccountsJujuData:
+    def __init__(self, jujudata):
+        self.__jujudata = jujudata
+
+    def __getattr__(self, name):
+        return getattr(self.__jujudata, name)
+
+    def accounts(self):
+        return {}


### PR DESCRIPTION
This isn't complete - we're still not writing cookies acquired
during the authentication process back to the cookie jars,
but we'll add that in another PR.

The integration tests rely on the fact that an agent user
has been added to the staging identity manager.
Its key is included in the commit, because it doesn't
grant any rights that aren't easily acquired elsewhere.

We also move the Model.grant method to Controller.grant_model
because it made two extra connections to the controller, which is
not really we want it doing behind the user's back, and we add a Model.controller
method to make it easy to get a controller connection from the Model.

