### PR TITLE
JujuData abstract base class

### DIFF
--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -95,7 +95,7 @@ class Connection:
     @classmethod
     async def connect(
             cls,
-            endpoint,
+            endpoint=None,
             uuid=None,
             username=None,
             password=None,
@@ -124,6 +124,8 @@ class Connection:
         :param max_frame_size The maximum websocket frame size to allow.
         """
         self = cls()
+        if endpoint is None:
+            raise ValueError('no endpoint provided')
         self.uuid = uuid
         if bakery_client is None:
             bakery_client = httpbakery.Client()

--- a/juju/client/connector.py
+++ b/juju/client/connector.py
@@ -3,7 +3,7 @@ import logging
 
 import macaroonbakery.httpbakery as httpbakery
 from juju.client.connection import Connection
-from juju.client.jujudata import JujuData
+from juju.client.jujudata import FileJujuData
 from juju.errors import JujuConnectionError, JujuError
 
 log = logging.getLogger('connector')
@@ -19,7 +19,13 @@ class Connector:
     '''This class abstracts out a reconnectable client that can connect
     to controllers and models found in the Juju data files.
     '''
-    def __init__(self, loop=None, max_frame_size=None, bakery_client=None):
+    def __init__(
+        self,
+        loop=None,
+        max_frame_size=None,
+        bakery_client=None,
+        jujudata=None,
+    ):
         '''Initialize a connector that will use the given parameters
         by default when making a new connection'''
         self.max_frame_size = max_frame_size
@@ -28,7 +34,7 @@ class Connector:
         self._connection = None
         self.controller_name = None
         self.model_name = None
-        self.jujudata = JujuData()
+        self.jujudata = jujudata or FileJujuData()
 
     def is_connected(self):
         '''Report whether there is a currently connected controller or not'''
@@ -110,7 +116,7 @@ class Connector:
         # to that. This will let connect_model work with models that
         # haven't necessarily synced with the local juju data,
         # and also remove the need for base.CleanModel to
-        # patch JujuData.models with a mock.
+        # subclass JujuData.
         await self.connect(
             endpoint=endpoint,
             uuid=models['models'][model_name]['uuid'],

--- a/juju/controller.py
+++ b/juju/controller.py
@@ -185,7 +185,7 @@ class Controller(object):
             region
         )
 
-        model = Model()
+        model = Model(jujudata=self._connector.jujudata)
         kwargs = self.connection().connect_params()
         kwargs['uuid'] = model_info.uuid
         await model._connect_direct(**kwargs)

--- a/juju/model.py
+++ b/juju/model.py
@@ -391,22 +391,32 @@ class Model:
     """
     The main API for interacting with a Juju model.
     """
-    def __init__(self, loop=None, max_frame_size=None, bakery_client=None):
+    def __init__(
+        self,
+        loop=None,
+        max_frame_size=None,
+        bakery_client=None,
+        jujudata=None,
+    ):
         """Instantiate a new Model.
 
         The connect method will need to be called before this
         object can be used for anything interesting.
+
+        If jujudata is None, jujudata.FileJujuData will be used.
 
         :param loop: an asyncio event loop
         :param max_frame_size: See
             `juju.client.connection.Connection.MAX_FRAME_SIZE`
         :param bakery_client httpbakery.Client: The bakery client to use
             for macaroon authorization.
+        :param jujudata JujuData: The source for current controller information.
         """
         self._connector = connector.Connector(
             loop=loop,
             max_frame_size=max_frame_size,
             bakery_client=bakery_client,
+            jujudata=jujudata,
         )
         self._observers = weakref.WeakValueDictionary()
         self.state = ModelState(self)

--- a/setup.py
+++ b/setup.py
@@ -30,11 +30,11 @@ setup(
     packages=find_packages(
         exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     install_requires=[
-        'macaroonbakery<1.0',
+        'macaroonbakery>=1.1,<2.0',
         'pyRFC3339>=1.0,<2.0',
-        'pyyaml',
-        'theblues',
-        'websockets',
+        'pyyaml>=3.0,<4.0',
+        'theblues>=0.3.8,<1.0',
+        'websockets>=4.0,<5.0',
     ],
     include_package_data=True,
     maintainer='Juju Ecosystem Engineering',

--- a/tests/base.py
+++ b/tests/base.py
@@ -3,7 +3,7 @@ import subprocess
 import uuid
 
 import mock
-from juju.client.jujudata import JujuData
+from juju.client.jujudata import FileJujuData
 from juju.controller import Controller
 
 import pytest
@@ -25,73 +25,77 @@ test_run_nonce = uuid.uuid4().hex[-4:]
 
 class CleanController():
     def __init__(self):
-        self.controller = None
+        self._controller = None
 
     async def __aenter__(self):
-        self.controller = Controller()
-        await self.controller.connect()
-        return self.controller
+        self._controller = Controller()
+        await self._controller.connect()
+        return self._controller
 
     async def __aexit__(self, exc_type, exc, tb):
-        await self.controller.disconnect()
+        await self._controller.disconnect()
 
 
 class CleanModel():
     def __init__(self):
-        self.user_name = None
-        self.controller = None
-        self.controller_name = None
-        self.model = None
-        self.model_name = None
-        self.model_uuid = None
+        self._controller = None
+        self._model = None
+        self._model_uuid = None
 
     async def __aenter__(self):
         model_nonce = uuid.uuid4().hex[-4:]
         frame = inspect.stack()[1]
         test_name = frame.function.replace('_', '-')
-        self.controller = Controller()
-        juju_data = JujuData()
-        self.controller_name = juju_data.current_controller()
-        self.user_name = juju_data.accounts()[self.controller_name]['user']
-        await self.controller.connect(self.controller_name)
+        self._controller = Controller()
+        juju_data = TestJujuData()
+        controller_name = juju_data.current_controller()
+        user_name = juju_data.accounts()[controller_name]['user']
+        await self._controller.connect(controller_name)
 
-        self.model_name = 'test-{}-{}-{}'.format(test_run_nonce,
-                                                 test_name,
-                                                 model_nonce)
-        self.model = await self.controller.add_model(self.model_name)
+        model_name = 'test-{}-{}-{}'.format(
+            test_run_nonce,
+            test_name,
+            model_nonce,
+        )
+        self._model = await self._controller.add_model(model_name)
+
+        # Change the JujuData instance so that it will return the new
+        # model as the current model name, so that we'll connect
+        # to it by default.
+        juju_data.__model_name = user_name + "/" + model_name
+        juju_data.__controller_name = controller_name
+        juju_data.__model_uuid = self._model.info.uuid
 
         # save the model UUID in case test closes model
-        self.model_uuid = self.model.info.uuid
+        self._model_uuid = self._model.info.uuid
 
-        # Ensure that we connect to the new model by default.  This also
-        # prevents failures if test was started with no current model.
-        self._patch_cm = mock.patch.object(JujuData, 'current_model',
-                                           return_value=self.model_name)
-        self._patch_cm.start()
-
-        # Ensure that the models data includes this model, since it doesn't
-        # get added to the client store by Controller.add_model().
-        self._orig_models = JujuData().models
-        self._patch_models = mock.patch.object(JujuData, 'models',
-                                               side_effect=self._models)
-        self._patch_models.start()
-
-        return self.model
-
-    def _models(self):
-        result = self._orig_models()
-        models = result[self.controller_name]['models']
-        full_model_name = '{}/{}'.format(self.user_name, self.model_name)
-        if full_model_name not in models:
-            models[full_model_name] = {'uuid': self.model_uuid}
-        return result
+        return self._model
 
     async def __aexit__(self, exc_type, exc, tb):
-        self._patch_models.stop()
-        self._patch_cm.stop()
-        await self.model.disconnect()
-        await self.controller.destroy_model(self.model_uuid)
-        await self.controller.disconnect()
+        await self._model.disconnect()
+        await self._controller.destroy_model(self._model_uuid)
+        await self._controller.disconnect()
+
+
+class TestJujuData(FileJujuData):
+    def __init__(self):
+        self.__controller_name = None
+        self.__model_name = None
+        self.__model_uuid = None
+        super().__init__()
+
+    def current_model(self):
+        return self.__model_name or super().current_model()
+
+    def models(self):
+        all_models = super().models()
+        if self.__model_name is None:
+            return all_models
+        all_models.setdefault(self.__controller_name, {})
+        all_models[self.__controller_name].setdefault('models', {})
+        cmodels = all_models[self.__controller_name]['models']
+        cmodels[self.__model_name] = {'uuid': self.__model_uuid}
+        return all_models
 
 
 class AsyncMock(mock.MagicMock):

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -151,8 +151,8 @@ async def test_relate(event_loop):
         assert isinstance(my_relation, Relation)
 
 
-async def _deploy_in_loop(new_loop, model_name):
-    new_model = Model(new_loop)
+async def _deploy_in_loop(new_loop, model_name, jujudata):
+    new_model = Model(new_loop, jujudata=jujudata)
     await new_model.connect(model_name)
     try:
         await new_model.deploy('cs:xenial/ubuntu')
@@ -170,7 +170,7 @@ async def test_explicit_loop_threaded(event_loop):
         with ThreadPoolExecutor(1) as executor:
             f = executor.submit(
                 new_loop.run_until_complete,
-                _deploy_in_loop(new_loop, model_name))
+                _deploy_in_loop(new_loop, model_name, model._connector.jujudata))
             f.result()
         await model._wait_for_new('application', 'ubuntu')
         assert 'ubuntu' in model.applications

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -4,6 +4,8 @@ import mock
 
 import asynctest
 
+from juju.client.jujudata import FileJujuData
+
 
 def _make_delta(entity, type_, data=None):
     from juju.client.client import Delta
@@ -144,15 +146,16 @@ class TestContextManager(asynctest.TestCase):
         self.assertTrue(mock_connect.called)
         self.assertTrue(mock_disconnect.called)
 
-    @asynctest.patch('juju.client.jujudata.JujuData.current_controller')
-    async def test_no_current_connection(self, mock_current_controller):
+    async def test_no_current_connection(self):
         from juju.model import Model
         from juju.errors import JujuConnectionError
 
-        mock_current_controller.return_value = ""
+        class NoControllerJujuData(FileJujuData):
+            def current_controller(self):
+                return ""
 
         with self.assertRaises(JujuConnectionError):
-            async with Model():
+            async with Model(jujudata=NoControllerJujuData()):
                 pass
 
 


### PR DESCRIPTION
This means we won't have to mock the JujuData methods
in order to be able to connect with different credentials
(for example when connecting with macaroon authentication).

It would be nice if the base class method semantics weren't
tied so closely to the underlying data format, and instead
reflected the (very few) operations that we actually need,
which would make it easier to modify its behaviour, but
this should be OK to begin with.
