### PR TITLE
Make Model and Controller connect methods backwardly compatible

### DIFF
--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -376,9 +376,7 @@ class Connection:
         as this one.
 
         """
-        endpoint, kwargs = self.connect_params()
-
-        return await Connection.connect(endpoint, **kwargs)
+        return await Connection.connect(**self.connect_params())
 
     def connect_params(self):
         """Return a tuple of parameters suitable for passing to Connection.connect that
@@ -386,19 +384,16 @@ class Connection:
         if specified. The first element in the returned tuple holds the endpoint argument; the other
         holds a dict of the keyword args.
         """
-        # TODO if the connect method took all keyword arguments then this could
-        # be simpler and just return a dict rather than a tuple.
-        return (
-            self.endpoint, {
-                'uuid': self.uuid,
-                'username': self.username,
-                'password': self.password,
-                'cacert': self.cacert,
-                'bakery_client': self.bakery_client,
-                'loop': self.loop,
-                'max_frame_size': self.max_frame_size,
-            }
-        )
+        return {
+            'endpoint': self.endpoint,
+            'uuid': self.uuid,
+            'username': self.username,
+            'password': self.password,
+            'cacert': self.cacert,
+            'bakery_client': self.bakery_client,
+            'loop': self.loop,
+            'max_frame_size': self.max_frame_size,
+        }
 
     async def controller(self):
         """Return a Connection to the controller at self.endpoint

--- a/juju/client/connector.py
+++ b/juju/client/connector.py
@@ -41,15 +41,15 @@ class Connector:
             raise NoConnectionException('not connected')
         return self._connection
 
-    async def connect(self, *args, **kw):
+    async def connect(self, **kwargs):
         """Connect to an arbitrary Juju model.
 
-        args and kw are passed through to Connection.connect()
+        kwargs are passed through to Connection.connect()
         """
-        kw.setdefault('loop', self.loop)
-        kw.setdefault('max_frame_size', self.max_frame_size)
-        kw.setdefault('bakery_client', self.bakery_client)
-        self._connection = await Connection.connect(*args, **kw)
+        kwargs.setdefault('loop', self.loop)
+        kwargs.setdefault('max_frame_size', self.max_frame_size)
+        kwargs.setdefault('bakery_client', self.bakery_client)
+        self._connection = await Connection.connect(**kwargs)
 
     async def disconnect(self):
         """Shut down the watcher task and close websockets.

--- a/tests/integration/test_connection.py
+++ b/tests/integration/test_connection.py
@@ -57,8 +57,8 @@ async def test_full_status(event_loop):
 @pytest.mark.asyncio
 async def test_reconnect(event_loop):
     async with base.CleanModel() as model:
-        endpoint, kwargs = model.connection().connect_params()
-        conn = await Connection.connect(endpoint, **kwargs)
+        kwargs = model.connection().connect_params()
+        conn = await Connection.connect(**kwargs)
         try:
             await asyncio.sleep(0.1)
             assert conn.is_open

--- a/tests/integration/test_controller.py
+++ b/tests/integration/test_controller.py
@@ -62,10 +62,10 @@ async def test_change_user_password(event_loop):
         # Check that we can connect with the new password.
         new_connection = None
         try:
-            endpoint, kwargs = controller.connection().connect_params()
+            kwargs = controller.connection().connect_params()
             kwargs['username'] = username
             kwargs['password'] = 'password'
-            new_connection = await Connection.connect(endpoint, **kwargs)
+            new_connection = await Connection.connect(**kwargs)
         except JujuAPIError:
             raise AssertionError('Unable to connect with new password')
         finally:

--- a/tests/unit/test_controller.py
+++ b/tests/unit/test_controller.py
@@ -1,0 +1,38 @@
+import asynctest
+
+
+class TestControllerConnect(asynctest.TestCase):
+    @asynctest.patch('juju.client.connector.Connector.connect_controller')
+    async def test_controller_connect_no_args(self, mock_connect_controller):
+        from juju.controller import Controller
+        c = Controller()
+        await c.connect()
+        mock_connect_controller.assert_called_once_with(None)
+
+    @asynctest.patch('juju.client.connector.Connector.connect_controller')
+    async def test_controller_connect_with_controller_name(self, mock_connect_controller):
+        from juju.controller import Controller
+        c = Controller()
+        await c.connect(controller_name='foo')
+        mock_connect_controller.assert_called_once_with('foo')
+
+    @asynctest.patch('juju.client.connector.Connector.connect_controller')
+    async def test_controller_connect_with_endpoint_and_uuid(
+        self,
+        mock_connect_controller,
+    ):
+        from juju.controller import Controller
+        c = Controller()
+        with self.assertRaises(ValueError):
+            await c.connect(endpoint='0.1.2.3:4566', uuid='some-uuid')
+        self.assertEqual(mock_connect_controller.call_count, 0)
+
+    @asynctest.patch('juju.client.connector.Connector.connect')
+    async def test_controller_connect_with_endpoint_and_no_uuid(
+        self,
+        mock_connect,
+    ):
+        from juju.controller import Controller
+        c = Controller()
+        await c.connect(endpoint='0.1.2.3:4566')
+        mock_connect.assert_called_once_with(endpoint='0.1.2.3:4566')

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ skipsdist=True
 basepython=python3
 usedevelop=True
 # for testing with other python versions
-commands = py.test -ra -v -s -n auto {posargs}
+commands = py.test -ra -v -s --tb native -n auto {posargs}
 passenv =
     HOME
 deps =
@@ -24,7 +24,7 @@ deps =
 
 [testenv:py35]
 # default tox env excludes integration tests
-commands = py.test -ravs -n auto -k 'not integration' {posargs}
+commands = py.test --tb native -ra -v -s -n auto -k 'not integration' {posargs}
 
 [testenv:lint]
 envdir = {toxworkdir}/py35


### PR DESCRIPTION
API users are using connect to directly connect using known parameters.
Make Model.connect and Controller.connect into a do-it-all methods
that can connect using directly specified endpoints etc as well
as by specifying a model or controller name.

Fixes #195.