### PR TITLE
Revert non-functional switch to Py3.6, just specify Py3 instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 .\#*
 dist/
 dev/
+.pytest_cache

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-BIN := .tox/py35/bin
-PY := $(BIN)/python3.5
+BIN := .tox/py3/bin
+PY := $(BIN)/python
 PIP := $(BIN)/pip
 SCHEMAGEN := $(shell which schemagen)
 VERSION=$(shell cat VERSION)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = lint,py36
+envlist = lint,py3
 skipsdist=True
 
 [testenv]
@@ -22,19 +22,19 @@ deps =
     asynctest
     ipdb
 
-[testenv:py35]
+[testenv:py3]
 # default tox env excludes integration tests
 commands = py.test --tb native -ra -v -s -n auto -k 'not integration' {posargs}
 
 [testenv:lint]
-envdir = {toxworkdir}/py36
+envdir = {toxworkdir}/py3
 commands =
     flake8 --ignore E501 {posargs} juju tests
 deps =
     flake8
 
 [testenv:integration]
-envdir = {toxworkdir}/py36
+envdir = {toxworkdir}/py3
 
 [flake8]
 exclude = juju/client/_*


### PR DESCRIPTION
It was still pulling in 3.5.2 for me anyway, probably due to that being the default for `basepython=python3` on my system.  Just use `py3` instead so it matches `python3`.