### PR TITLE
Expose a machines series

### DIFF
--- a/juju/machine.py
+++ b/juju/machine.py
@@ -262,3 +262,10 @@ class Machine(model.ModelEntity):
             if addresses:
                 return addresses[0]['value']
         return None
+
+    @property
+    def series(self):
+        """Returns the series of the current machine
+
+        """
+        return self.safe_data['series']


### PR DESCRIPTION
It is useful to be able to assert that the application currently
deployed in the model is running the operating system series
required. This allows that to be checked by adding a series property
to a Machine.