### PR TITLE
Backwards compatibility fixes

### DIFF
--- a/docs/narrative/controller.rst
+++ b/docs/narrative/controller.rst
@@ -6,9 +6,9 @@ these endpoints.
 
 Connecting to the controller endpoint is useful if you want to programmatically
 create a new model. If the model you want to use already exists, you can
-connect directly to it (see :doc:`model`).
+connect directly to it (see py:doc:`model`).
 
-For api docs, see :class:`juju.controller.Controller`.
+For API docs, see py:class:`juju.controller.Controller`.
 
 
 Connecting to the Current Controller
@@ -33,68 +33,60 @@ Connect to a controller by name.
   from juju.controller import Controller
 
   controller = Controller()
-  await controller.connect_controller('mycontroller')
+  await controller.connect('mycontroller')
 
 
-Connecting with Username/Password Authentication
-------------------------------------------------
+Connecting with Authentication
+------------------------------
+You can control what user you are connecting with by specifying either a
+username/password pair, or a macaroon or bakery client that can provide
+a macaroon.
+
+
+.. code:: python
+
+  controller = Controller()
+  await controller.connect(username='admin',
+                           password='f53f08cfc32a2e257fe5393271d89d62')
+
+  # or with a macaroon
+  await controller.connect(macaroons=[
+      {
+          "Name": "macaroon-218d87053ad19626bcd5a0eef0bc9ba8bd4fbd80a968f52a5fd430b2aa8660df",
+          "Value": "W3siY2F2ZWF0cyI6 ... jBkZiJ9XQ==",
+          "Domain": "10.130.48.27",
+          "Path": "/auth",
+          "Secure": false,
+          "HostOnly": true,
+          "Expires": "2018-03-07T22:07:23Z",
+      },
+  ])
+
+  # or with a bakery client
+  from macaroonbakery.httpbakery import Client
+  from http.cookiejar import FileCookieJar
+
+  bakery_client=Client()
+  bakery_client.cookies = FileCookieJar('cookies.txt')
+  controller = Controller()
+  await controller.connect(bakery_client=bakery_client)
+  
+
+
+Connecting with an Explicit Endpoint
+------------------------------------
 The most flexible, but also most verbose, way to connect is using the API
-endpoint url and credentials directly. This method does NOT require the Juju
-CLI client to be installed.
+endpoint url and credentials directly. This method does NOT require the
+Juju CLI client to be installed.
 
 .. code:: python
 
-  from juju.controller import Controller
-
   controller = Controller()
-
-  controller_endpoint = '10.0.4.171:17070'
-  username = 'admin'
-  password = 'f53f08cfc32a2e257fe5393271d89d62'
-
-  # Left out for brevity, but if you have a cert string you should pass it in.
-  # You can copy the cert from the output of The `juju show-controller`
-  # command.
-  cacert = None
-
   await controller.connect(
-      controller_endpoint,
-      username,
-      password,
-      cacert,
-  )
-
-
-Connecting with Macaroon Authentication
----------------------------------------
-To connect to a shared controller, you'll need
-to use macaroon authentication. The simplest example is shown below, and uses
-already-discharged macaroons from the local filesystem. This will work if you
-have the Juju CLI installed.
-
-.. note::
-
-  The library does not yet contain support for fetching and discharging
-  macaroons. Until it does, if you want to use macaroon auth, you'll need
-  to supply already-discharged macaroons yourself.
-
-.. code:: python
-
-  from juju.client.connection import get_macaroons()
-  from juju.controller import Controller
-
-  controller = Controller()
-
-  controller_endpoint = '10.0.4.171:17070'
-  username = None
-  password = None
-  cacert = None
-  macaroons = get_macaroons()
-
-  await controller.connect(
-      controller_endpoint,
-      username,
-      password,
-      cacert,
-      macaroons,
+      endpoint='10.0.4.171:17070',
+      username='admin',
+      password='f53f08cfc32a2e257fe5393271d89d62',
+      cacert=None,  # Left out for brevity, but if you have a cert string you
+                    # should pass it in. You can get the cert from the output
+                    # of The `juju show-controller` command.
   )

--- a/docs/narrative/model.rst
+++ b/docs/narrative/model.rst
@@ -4,7 +4,7 @@ A Juju controller provides websocket endpoints for each of its
 models. In order to do anything useful with a model, the juju lib must
 connect to one of these endpoints. There are several ways to do this.
 
-For api docs, see :class:`juju.model.Model`.
+For api docs, see py:class:`juju.model.Model`.
 
 
 Connecting to the Current Model
@@ -14,10 +14,8 @@ Connect to the currently active Juju model (the one returned by
 
 .. code:: python
 
-  from juju.model import Model
-
   model = Model()
-  await model.connect_current()
+  await model.connect()
 
 
 Connecting to a Named Model
@@ -28,88 +26,74 @@ This only works if you have the Juju CLI client installed.
 
 .. code:: python
 
-  # $ juju switch
-  # juju-2.0.1:admin/libjuju
+  model = Model()
+  await model.connect('juju-2.0.1:admin/libjuju')
 
-  from juju.model import Model
+
+Connecting with Authentication
+------------------------------
+You can control what user you are connecting with by specifying either a
+username/password pair, or a macaroon or bakery client that can provide
+a macaroon.
+
+
+.. code:: python
 
   model = Model()
-  await model.connect_model('juju-2.0.1:admin/libjuju')
+  await model.connect(username='admin',
+                      password='f53f08cfc32a2e257fe5393271d89d62')
+
+  # or with a macaroon
+  await model.connect(macaroons=[
+      {
+          "Name": "macaroon-218d87053ad19626bcd5a0eef0bc9ba8bd4fbd80a968f52a5fd430b2aa8660df",
+          "Value": "W3siY2F2ZWF0cyI6 ... jBkZiJ9XQ==",
+          "Domain": "10.130.48.27",
+          "Path": "/auth",
+          "Secure": false,
+          "HostOnly": true,
+          "Expires": "2018-03-07T22:07:23Z",
+      },
+  ])
+
+  # or with a bakery client
+  from macaroonbakery.httpbakery import Client
+  from http.cookiejar import FileCookieJar
+
+  bakery_client=Client()
+  bakery_client.cookies = FileCookieJar('cookies.txt')
+  model = Model()
+  await model.connect(bakery_client=bakery_client)
+  
 
 
-Connecting with Username/Password Authentication
-------------------------------------------------
+Connecting with an Explicit Endpoint
+------------------------------------
 The most flexible, but also most verbose, way to connect is using the API
-endpoint url and credentials directly. This method does NOT require the Juju
-CLI client to be installed.
+endpoint url, model UUID, and credentials directly. This method does NOT
+require the Juju CLI client to be installed.
 
 .. code:: python
 
   from juju.model import Model
 
   model = Model()
-
-  controller_endpoint = '10.0.4.171:17070'
-  model_uuid = 'e8399ac7-078c-4817-8e5e-32316d55b083'
-  username = 'admin'
-  password = 'f53f08cfc32a2e257fe5393271d89d62'
-
-  # Left out for brevity, but if you have a cert string you should pass it in.
-  # You can copy the cert from the output of The `juju show-controller`
-  # command.
-  cacert = None
-
   await model.connect(
-      controller_endpoint,
-      model_uuid,
-      username,
-      password,
-      cacert,
-  )
-
-
-Connecting with Macaroon Authentication
----------------------------------------
-To connect to a shared model, or a model an a shared controller, you'll need
-to use macaroon authentication. The simplest example is shown below, and uses
-already-discharged macaroons from the local filesystem. This will work if you
-have the Juju CLI installed.
-
-.. note::
-
-  The library does not yet contain support for fetching and discharging
-  macaroons. Until it does, if you want to use macaroon auth, you'll need
-  to supply already-discharged macaroons yourself.
-
-.. code:: python
-
-  from juju.client.connection import get_macaroons()
-  from juju.model import Model
-
-  model = Model()
-
-  controller_endpoint = '10.0.4.171:17070'
-  model_uuid = 'e8399ac7-078c-4817-8e5e-32316d55b083'
-  username = None
-  password = None
-  cacert = None
-  macaroons = get_macaroons()
-
-  await model.connect(
-      controller_endpoint,
-      model_uuid,
-      username,
-      password,
-      cacert,
-      macaroons,
+      endpoint='10.0.4.171:17070',
+      uuid='e8399ac7-078c-4817-8e5e-32316d55b083',
+      username='admin',
+      password='f53f08cfc32a2e257fe5393271d89d62',
+      cacert=None,  # Left out for brevity, but if you have a cert string you
+                    # should pass it in. You can get the cert from the output
+                    # of The `juju show-controller` command.
   )
 
 
 Creating and Destroying a Model
 -------------------------------
 Example of creating a new model and then destroying it. See
-:meth:`juju.controller.Controller.add_model` and
-:meth:`juju.controller.Controller.destroy_model` for more info.
+py:method:`juju.controller.Controller.add_model` and
+py:method:`juju.controller.Controller.destroy_model` for more info.
 
 .. code:: python
 
@@ -134,8 +118,8 @@ Example of creating a new model and then destroying it. See
 Adding Machines and Containers
 ------------------------------
 To add a machine or container, connect to a model and then call its
-:meth:`~juju.model.Model.add_machine` method. A
-:class:`~juju.machine.Machine` instance is returned. The machine id
+py:method:`~juju.model.Model.add_machine` method. A
+py:class:`~juju.machine.Machine` instance is returned. The machine id
 can be used to deploy a charm to a specific machine or container.
 
 .. code:: python
@@ -192,7 +176,7 @@ Reacting to Changes in a Model
 ------------------------------
 To watch for and respond to changes in a model, register an observer with the
 model. The easiest way to do this is by creating a
-:class:`juju.model.ModelObserver` subclass.
+py:class:`juju.model.ModelObserver` subclass.
 
 .. code:: python
 
@@ -283,7 +267,7 @@ to the entity and type of change that you wish to handle.
           # specific handler method is not defined.
 
 
-Any :class:`juju.model.ModelEntity` object can be observed directly by
+Any py:class:`juju.model.ModelEntity` object can be observed directly by
 registering callbacks on the object itself.
 
 .. code:: python

--- a/examples/action.py
+++ b/examples/action.py
@@ -7,7 +7,6 @@ This example:
 4. Waits for the action results to come back, then exits.
 
 """
-import asyncio
 import logging
 
 from juju import loop
@@ -27,8 +26,8 @@ async def run_action(unit):
 
 async def main():
     model = Model()
+    # connect to current model with current user, per Juju CLI
     await model.connect()
-    await model.reset(force=True)
 
     app = await model.deploy(
         'git',

--- a/examples/add_model.py
+++ b/examples/add_model.py
@@ -19,6 +19,7 @@ LOG = getLogger(__name__)
 async def main():
     controller = Controller()
     print("Connecting to controller")
+    # connect to current controller with current user, per Juju CLI
     await controller.connect()
 
     try:

--- a/examples/config.py
+++ b/examples/config.py
@@ -6,7 +6,6 @@ This example:
 3. Deploys a charm and prints its config and constraints
 
 """
-import asyncio
 import logging
 
 from juju.model import Model
@@ -19,8 +18,8 @@ MB = 1
 
 async def main():
     model = Model()
+    # connect to current model with current user, per Juju CLI
     await model.connect()
-    await model.reset(force=True)
 
     ubuntu_app = await model.deploy(
         'mysql',
@@ -47,7 +46,7 @@ async def main():
 
     await model.disconnect()
 
-    
+
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)
     ws_logger = logging.getLogger('websockets.protocol')

--- a/examples/controller.py
+++ b/examples/controller.py
@@ -8,7 +8,6 @@ This example:
 5. Destroys the model
 
 """
-import asyncio
 import logging
 
 from juju.controller import Controller
@@ -17,6 +16,7 @@ from juju import loop
 
 async def main():
     controller = Controller()
+    # connect to current controller with current user, per Juju CLI
     await controller.connect()
     model = await controller.add_model(
         'my-test-model',

--- a/examples/credential.py
+++ b/examples/credential.py
@@ -7,6 +7,7 @@ async def main(cloud_name, credential_name):
     controller = Controller()
     model = None
     print('Connecting to controller')
+    # connect to current controller with current user, per Juju CLI
     await controller.connect()
     try:
         print('Adding model')

--- a/examples/deploy.py
+++ b/examples/deploy.py
@@ -13,6 +13,7 @@ from juju.model import Model
 async def main():
     model = Model()
     print('Connecting to model')
+    # connect to current model with current user, per Juju CLI
     await model.connect()
 
     try:

--- a/examples/future.py
+++ b/examples/future.py
@@ -2,7 +2,6 @@
 This example doesn't work - it demonstrates features that don't exist yet.
 
 """
-import asyncio
 import logging
 
 from juju.model import Model
@@ -11,8 +10,8 @@ from juju import loop
 
 async def main():
     model = Model()
+    # connect to current model with current user, per Juju CLI
     await model.connect()
-    await model.reset(force=True)
 
     goal_state = Model.from_yaml('bundle-like-thing')
     ubuntu_app = await model.deploy(

--- a/examples/livemodel.py
+++ b/examples/livemodel.py
@@ -6,8 +6,6 @@ This example:
 3. Runs forever (kill with Ctrl-C)
 
 """
-import asyncio
-
 from juju.model import Model
 from juju import loop
 
@@ -21,6 +19,7 @@ async def on_model_change(delta, old, new, model):
 
 async def watch_model():
     model = Model()
+    # connect to current model with current user, per Juju CLI
     await model.connect()
 
     model.add_observer(on_model_change)

--- a/examples/relate.py
+++ b/examples/relate.py
@@ -40,6 +40,7 @@ class MyModelObserver(ModelObserver):
 
 async def main():
     model = Model()
+    # connect to current model with current user, per Juju CLI
     await model.connect()
 
     try:

--- a/examples/unitrun.py
+++ b/examples/unitrun.py
@@ -7,7 +7,6 @@ This example:
 4. Waits for the action results to come back, then exits.
 
 """
-import asyncio
 import logging
 
 from juju.model import Model
@@ -24,8 +23,8 @@ async def run_command(unit):
 
 async def main():
     model = Model()
+    # connect to current model with current user, per Juju CLI
     await model.connect()
-    await model.reset(force=True)
 
     app = await model.deploy(
         'ubuntu-0',

--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -109,20 +109,22 @@ class Connection:
 
         If uuid is None, the connection will be to the controller. Otherwise it
         will be to the model.
-        :param str endpoint The hostname:port of the controller to connect to.
-        :param str uuid The model UUID to connect to (None for a
+
+        :param str endpoint: The hostname:port of the controller to connect to.
+        :param str uuid: The model UUID to connect to (None for a
             controller-only connection).
-        :param str username The username for controller-local users (or None
+        :param str username: The username for controller-local users (or None
             to use macaroon-based login.)
-        :param str password The password for controller-local users.
-        :param str cacert The CA certificate of the controller (PEM formatted).
-        :param httpbakery.Client bakery_client The macaroon bakery client to
+        :param str password: The password for controller-local users.
+        :param str cacert: The CA certificate of the controller
+            (PEM formatted).
+        :param httpbakery.Client bakery_client: The macaroon bakery client to
             to use when performing macaroon-based login. Macaroon tokens
             acquired when logging will be saved to bakery_client.cookies.
             If this is None, a default bakery_client will be used.
-        :param loop asyncio.BaseEventLoop The event loop to use for async
+        :param asyncio.BaseEventLoop loop: The event loop to use for async
             operations.
-        :param max_frame_size The maximum websocket frame size to allow.
+        :param int max_frame_size: The maximum websocket frame size to allow.
         """
         self = cls()
         if endpoint is None:

--- a/juju/client/gocookies.py
+++ b/juju/client/gocookies.py
@@ -15,7 +15,7 @@ class GoCookieJar(cookiejar.FileCookieJar):
         to implement the actual cookie loading'''
         data = json.load(f) or []
         now = time.time()
-        for cookie in map(_new_py_cookie, data):
+        for cookie in map(go_to_py_cookie, data):
             if not ignore_expires and cookie.is_expired(now):
                 continue
             self.set_cookie(cookie)
@@ -37,12 +37,12 @@ class GoCookieJar(cookiejar.FileCookieJar):
                 continue
             if not ignore_expires and cookie.is_expired(now):
                 continue
-            go_cookies.append(_new_go_cookie(cookie))
+            go_cookies.append(py_to_go_cookie(cookie))
         with open(filename, "w") as f:
             f.write(json.dumps(go_cookies))
 
 
-def _new_py_cookie(go_cookie):
+def go_to_py_cookie(go_cookie):
     '''Convert a Go-style JSON-unmarshaled cookie into a Python cookie'''
     expires = None
     if go_cookie.get('Expires') is not None:
@@ -75,7 +75,7 @@ def _new_py_cookie(go_cookie):
     )
 
 
-def _new_go_cookie(py_cookie):
+def py_to_go_cookie(py_cookie):
     '''Convert a python cookie to the JSON-marshalable Go-style cookie form.'''
     # TODO (perhaps):
     #   HttpOnly

--- a/juju/controller.py
+++ b/juju/controller.py
@@ -332,7 +332,7 @@ class Controller:
            Use :meth:`.list_models` instead.
         """
         controller_facade = client.ControllerFacade.from_connection(
-            self.connection)
+            self.connection())
         for attempt in (1, 2, 3):
             try:
                 return await controller_facade.AllModels()

--- a/juju/controller.py
+++ b/juju/controller.py
@@ -76,6 +76,20 @@ class Controller:
                 raise ValueError('model UUID specified when connecting to controller')
             await self._connector.connect(**kwargs)
 
+    async def connect_current(self):
+        """
+        .. deprecated:: 0.7.3
+           Use :meth:`.connect()` instead.
+        """
+        return await self.connect()
+
+    async def connect_controller(self, controller_name):
+        """
+        .. deprecated:: 0.7.3
+           Use :meth:`.connect(controller_name)` instead.
+        """
+        return await self.connect(controller_name)
+
     async def _connect_direct(self, **kwargs):
         await self.disconnect()
         await self._connector.connect(**kwargs)

--- a/juju/controller.py
+++ b/juju/controller.py
@@ -3,11 +3,8 @@ import json
 import logging
 from pathlib import Path
 
-import macaroonbakery.httpbakery as httpbakery
-
 from . import errors, tag, utils
 from .client import client, connector
-from .client.gocookies import GoCookieJar, _new_py_cookie
 from .user import User
 
 log = logging.getLogger(__name__)
@@ -53,53 +50,85 @@ class Controller:
     def loop(self):
         return self._connector.loop
 
-    async def connect(self, controller_name=None, *args, **kwargs):
+    async def connect(self, *args, **kwargs):
         """Connect to a Juju controller.
 
-        If any arguments are specified other than controller_name,
-        then controller_name must be None and an explicit
-        connection will be made using Connection.connect
-        using those parameters (the 'uuid' parameter must
-        be absent or None).
+        This supports two calling conventions:
 
-        Otherwise, if controller_name is None, connect to the
-        current controller.
+        The controller and (optionally) authentication information can be
+        taken from the data files created by the Juju CLI.  This convention
+        will be used if a ``controller_name`` is specified, or if the
+        ``endpoint`` is not.
 
-        Otherwise, controller_name must specify the name
-        of a known controller.
+        Otherwise, both the ``endpoint`` and authentication information
+        (``username`` and ``password``, or ``bakery_client`` and/or
+        ``macaroons``) are required.
 
-        For backwards compatibility, positional args can also be used,
-        in which case ``controller_name`` should actually be the endpoint.
-        This usage is deprecated, however, in favor of explicitly named
-        keyword params.
+        If a single positional argument is given, it will be assumed to be
+        the ``controller_name``.  Otherwise, the first positional argument,
+        if any, must be the ``endpoint``.
+
+        Available parameters are:
+
+        :param str controller_name:  Name of controller registered with the
+            Juju CLI.
+        :param str endpoint: The hostname:port of the controller to connect to.
+        :param str username: The username for controller-local users (or None
+            to use macaroon-based login.)
+        :param str password: The password for controller-local users.
+        :param str cacert: The CA certificate of the controller
+            (PEM formatted).
+        :param httpbakery.Client bakery_client: The macaroon bakery client to
+            to use when performing macaroon-based login. Macaroon tokens
+            acquired when logging will be saved to bakery_client.cookies.
+            If this is None, a default bakery_client will be used.
+        :param list macaroons: List of macaroons to load into the
+            ``bakery_client``.
+        :param asyncio.BaseEventLoop loop: The event loop to use for async
+            operations.
+        :param int max_frame_size: The maximum websocket frame size to allow.
         """
         await self.disconnect()
-        if args:
-            # backwards compatibility for positional params
-            if len(args) < 2:
-                raise TypeError('connect() missing required positional params')
-            kwargs.update({
-                'endpoint': controller_name,
-                'username': args[0],
-                'password': args[1],
-            })
-            if len(args) > 2:
-                kwargs['cacert'] = args[2]
-            if len(args) > 3:
-                kwargs['bakery_client'] = httpbakery.Client()
-                kwargs['bakery_client'].cookies = jar = GoCookieJar()
-                for macaroon in args[3]:
-                    jar.set_cookie(_new_py_cookie(macaroon))
-            controller_name = None
-
-        if not kwargs:
-            await self._connector.connect_controller(controller_name)
+        if 'endpoint' not in kwargs and len(args) < 2:
+            if args and 'model_name' in kwargs:
+                raise TypeError('connect() got multiple values for '
+                                'controller_name')
+            elif args:
+                controller_name = args[0]
+            else:
+                controller_name = kwargs.pop('controller_name', None)
+            await self._connector.connect_controller(controller_name, **kwargs)
         else:
-            if controller_name is not None:
-                raise ValueError('controller name may not be specified with other connect parameters')
-            if kwargs.get('uuid') is not None:
-                # A UUID implies a model connection, not a controller connection.
-                raise ValueError('model UUID specified when connecting to controller')
+            if 'controller_name' in kwargs:
+                raise TypeError('connect() got values for both '
+                                'controller_name and endpoint')
+            if args and 'endpoint' in kwargs:
+                raise TypeError('connect() got multiple values for endpoint')
+            has_userpass = (len(args) >= 3 or
+                            {'username', 'password'}.issubset(kwargs))
+            has_macaroons = (len(args) >= 5 or not
+                             {'bakery_client', 'macaroons'}.isdisjoint(kwargs))
+            if not (has_userpass or has_macaroons):
+                raise TypeError('connect() missing auth params')
+            arg_names = [
+                'endpoint',
+                'username',
+                'password',
+                'cacert',
+                'bakery_client',
+                'macaroons',
+                'loop',
+                'max_frame_size',
+            ]
+            for i, arg in enumerate(args):
+                kwargs[arg_names[i]] = arg
+            if 'endpoint' not in kwargs:
+                raise ValueError('endpoint is required '
+                                 'if controller_name not given')
+            if not ({'username', 'password'}.issubset(kwargs) or
+                    {'bakery_client', 'macaroons'}.intersection(kwargs)):
+                raise ValueError('Authentication parameters are required '
+                                 'if controller_name not given')
             await self._connector.connect(**kwargs)
 
     async def connect_current(self):

--- a/tests/unit/test_controller.py
+++ b/tests/unit/test_controller.py
@@ -11,37 +11,79 @@ from .. import base
 
 class TestControllerConnect(asynctest.TestCase):
     @asynctest.patch('juju.client.connector.Connector.connect_controller')
-    async def test_controller_connect_no_args(self, mock_connect_controller):
+    async def test_no_args(self, mock_connect_controller):
         c = Controller()
         await c.connect()
         mock_connect_controller.assert_called_once_with(None)
 
     @asynctest.patch('juju.client.connector.Connector.connect_controller')
-    async def test_controller_connect_with_controller_name(
-        self, mock_connect_controller
-    ):
+    async def test_with_controller_name(self, mock_connect_controller):
         c = Controller()
         await c.connect(controller_name='foo')
         mock_connect_controller.assert_called_once_with('foo')
 
-    @asynctest.patch('juju.client.connector.Connector.connect_controller')
-    async def test_controller_connect_with_endpoint_and_uuid(
-        self,
-        mock_connect_controller,
-    ):
+    @asynctest.patch('juju.client.connector.Connector.connect')
+    async def test_with_endpoint_and_no_auth(self, mock_connect):
         c = Controller()
-        with self.assertRaises(ValueError):
-            await c.connect(endpoint='0.1.2.3:4566', uuid='some-uuid')
-        self.assertEqual(mock_connect_controller.call_count, 0)
+        with self.assertRaises(TypeError):
+            await c.connect(endpoint='0.1.2.3:4566')
+        self.assertEqual(mock_connect.call_count, 0)
 
     @asynctest.patch('juju.client.connector.Connector.connect')
-    async def test_controller_connect_with_endpoint_and_no_uuid(
-        self,
-        mock_connect,
-    ):
+    async def test_with_endpoint_and_userpass(self, mock_connect):
         c = Controller()
-        await c.connect(endpoint='0.1.2.3:4566')
-        mock_connect.assert_called_once_with(endpoint='0.1.2.3:4566')
+        with self.assertRaises(TypeError):
+            await c.connect(endpoint='0.1.2.3:4566', username='dummy')
+        await c.connect(endpoint='0.1.2.3:4566',
+                        username='user',
+                        password='pass')
+        mock_connect.assert_called_once_with(endpoint='0.1.2.3:4566',
+                                             username='user',
+                                             password='pass')
+
+    @asynctest.patch('juju.client.connector.Connector.connect')
+    async def test_with_endpoint_and_bakery_client(self, mock_connect):
+        c = Controller()
+        await c.connect(endpoint='0.1.2.3:4566', bakery_client='bakery')
+        mock_connect.assert_called_once_with(endpoint='0.1.2.3:4566',
+                                             bakery_client='bakery')
+
+    @asynctest.patch('juju.client.connector.Connector.connect')
+    async def test_with_endpoint_and_macaroons(self, mock_connect):
+        c = Controller()
+        await c.connect(endpoint='0.1.2.3:4566',
+                        macaroons=['macaroon'])
+        mock_connect.assert_called_with(endpoint='0.1.2.3:4566',
+                                        macaroons=['macaroon'])
+        await c.connect(endpoint='0.1.2.3:4566',
+                        bakery_client='bakery',
+                        macaroons=['macaroon'])
+        mock_connect.assert_called_with(endpoint='0.1.2.3:4566',
+                                        bakery_client='bakery',
+                                        macaroons=['macaroon'])
+
+    @asynctest.patch('juju.client.connector.Connector.connect_controller')
+    @asynctest.patch('juju.client.connector.Connector.connect')
+    async def test_with_posargs(self, mock_connect, mock_connect_controller):
+        c = Controller()
+        await c.connect('foo')
+        mock_connect_controller.assert_called_once_with('foo')
+        with self.assertRaises(TypeError):
+            await c.connect('endpoint', 'user')
+        await c.connect('endpoint', 'user', 'pass')
+        mock_connect.assert_called_once_with(endpoint='endpoint',
+                                             username='user',
+                                             password='pass')
+        await c.connect('endpoint', 'user', 'pass', 'cacert', 'bakery',
+                        'macaroons', 'loop', 'max_frame_size')
+        mock_connect.assert_called_with(endpoint='endpoint',
+                                        username='user',
+                                        password='pass',
+                                        cacert='cacert',
+                                        bakery_client='bakery',
+                                        macaroons='macaroons',
+                                        loop='loop',
+                                        max_frame_size='max_frame_size')
 
     @asynctest.patch('juju.client.client.CloudFacade')
     async def test_file_cred(self, mock_cf):

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -5,6 +5,7 @@ import mock
 import asynctest
 
 from juju.client.jujudata import FileJujuData
+from juju.model import Model
 
 
 def _make_delta(entity, type_, data=None):
@@ -159,44 +160,105 @@ class TestContextManager(asynctest.TestCase):
                 pass
 
 
+@asynctest.patch('juju.model.Model._after_connect')
 class TestModelConnect(asynctest.TestCase):
     @asynctest.patch('juju.client.connector.Connector.connect_model')
-    @asynctest.patch('juju.model.Model._after_connect')
-    async def test_model_connect_no_args(self, mock_after_connect, mock_connect_model):
-        from juju.model import Model
+    async def test_no_args(self, mock_connect_model, _):
         m = Model()
         await m.connect()
         mock_connect_model.assert_called_once_with(None)
 
     @asynctest.patch('juju.client.connector.Connector.connect_model')
-    @asynctest.patch('juju.model.Model._after_connect')
-    async def test_model_connect_with_model_name(self, mock_after_connect, mock_connect_model):
-        from juju.model import Model
+    async def test_with_model_name(self, mock_connect_model, _):
         m = Model()
         await m.connect(model_name='foo')
         mock_connect_model.assert_called_once_with('foo')
 
     @asynctest.patch('juju.client.connector.Connector.connect_model')
-    @asynctest.patch('juju.model.Model._after_connect')
-    async def test_model_connect_with_endpoint_but_no_uuid(
-        self,
-        mock_after_connect,
-        mock_connect_model,
-    ):
-        from juju.model import Model
+    async def test_with_endpoint_but_no_uuid(self, mock_connect_model, _):
         m = Model()
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             await m.connect(endpoint='0.1.2.3:4566')
         self.assertEqual(mock_connect_model.call_count, 0)
 
     @asynctest.patch('juju.client.connector.Connector.connect')
-    @asynctest.patch('juju.model.Model._after_connect')
-    async def test_model_connect_with_endpoint_and_uuid(
-        self,
-        mock_after_connect,
-        mock_connect,
-    ):
-        from juju.model import Model
+    async def test_with_endpoint_and_uuid_no_auth(self, mock_connect, _):
         m = Model()
-        await m.connect(endpoint='0.1.2.3:4566', uuid='some-uuid')
-        mock_connect.assert_called_once_with(endpoint='0.1.2.3:4566', uuid='some-uuid')
+        with self.assertRaises(TypeError):
+            await m.connect(endpoint='0.1.2.3:4566', uuid='some-uuid')
+        self.assertEqual(mock_connect.call_count, 0)
+
+    @asynctest.patch('juju.client.connector.Connector.connect')
+    async def test_with_endpoint_and_uuid_with_userpass(self, mock_connect, _):
+        m = Model()
+        with self.assertRaises(TypeError):
+            await m.connect(endpoint='0.1.2.3:4566',
+                            uuid='some-uuid',
+                            username='user')
+        await m.connect(endpoint='0.1.2.3:4566',
+                        uuid='some-uuid',
+                        username='user',
+                        password='pass')
+        mock_connect.assert_called_once_with(endpoint='0.1.2.3:4566',
+                                             uuid='some-uuid',
+                                             username='user',
+                                             password='pass')
+
+    @asynctest.patch('juju.client.connector.Connector.connect')
+    async def test_with_endpoint_and_uuid_with_bakery(self, mock_connect, _):
+        m = Model()
+        await m.connect(endpoint='0.1.2.3:4566',
+                        uuid='some-uuid',
+                        bakery_client='bakery')
+        mock_connect.assert_called_once_with(endpoint='0.1.2.3:4566',
+                                             uuid='some-uuid',
+                                             bakery_client='bakery')
+
+    @asynctest.patch('juju.client.connector.Connector.connect')
+    async def test_with_endpoint_and_uuid_with_macaroon(self, mock_connect, _):
+        m = Model()
+        with self.assertRaises(TypeError):
+            await m.connect(endpoint='0.1.2.3:4566',
+                            uuid='some-uuid',
+                            username='user')
+        await m.connect(endpoint='0.1.2.3:4566',
+                        uuid='some-uuid',
+                        macaroons=['macaroon'])
+        mock_connect.assert_called_with(endpoint='0.1.2.3:4566',
+                                        uuid='some-uuid',
+                                        macaroons=['macaroon'])
+        await m.connect(endpoint='0.1.2.3:4566',
+                        uuid='some-uuid',
+                        bakery_client='bakery',
+                        macaroons=['macaroon'])
+        mock_connect.assert_called_with(endpoint='0.1.2.3:4566',
+                                        uuid='some-uuid',
+                                        bakery_client='bakery',
+                                        macaroons=['macaroon'])
+
+    @asynctest.patch('juju.client.connector.Connector.connect_model')
+    @asynctest.patch('juju.client.connector.Connector.connect')
+    async def test_with_posargs(self, mock_connect, mock_connect_model, _):
+        m = Model()
+        await m.connect('foo')
+        mock_connect_model.assert_called_once_with('foo')
+        with self.assertRaises(TypeError):
+            await m.connect('endpoint', 'uuid')
+        with self.assertRaises(TypeError):
+            await m.connect('endpoint', 'uuid', 'user')
+        await m.connect('endpoint', 'uuid', 'user', 'pass')
+        mock_connect.assert_called_once_with(endpoint='endpoint',
+                                             uuid='uuid',
+                                             username='user',
+                                             password='pass')
+        await m.connect('endpoint', 'uuid', 'user', 'pass', 'cacert', 'bakery',
+                        'macaroons', 'loop', 'max_frame_size')
+        mock_connect.assert_called_with(endpoint='endpoint',
+                                        uuid='uuid',
+                                        username='user',
+                                        password='pass',
+                                        cacert='cacert',
+                                        bakery_client='bakery',
+                                        macaroons='macaroons',
+                                        loop='loop',
+                                        max_frame_size='max_frame_size')


### PR DESCRIPTION
Fixes #212 with the following:

* Fix `Controller.get_models`
* Re-add positional params to `Controller.connect`
* Re-add deprecated connect methods to `Controller`