### PR TITLE
Explicitly close event loop

### DIFF
--- a/juju/loop.py
+++ b/juju/loop.py
@@ -40,3 +40,4 @@ def run(*steps):
     finally:
         if added:
             loop.remove_signal_handler(signal.SIGINT)
+        loop.close()


### PR DESCRIPTION
Explicitly close the event loop created in juju.loop. I think this
may have been optional in earlier version of Python but I don't have
any science to support that. The Python docs show examples of an
explicit close in all examples here:
https://docs.python.org/3/library/asyncio-eventloop.html#event-loop-examples
This closes #219