### PR TITLE
Add support for Application get_actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__/
 dist/
 dev/
 .pytest_cache
+pytestdebug.log

--- a/juju/application.py
+++ b/juju/application.py
@@ -232,19 +232,20 @@ class Application(model.ModelEntity):
         """Get actions defined for this application.
 
         :param bool schema: Return the full action schema
-
+        :return dict: The charms actions, empty dict if none are defined.
         """
-        app_tag = "application-{}".format(self.name)
-        entity = [{"tag": app_tag}]
+        actions = {}
+        entity = [{"tag": self.tag}]
         action_facade = client.ActionFacade.from_connection(self.connection)
         results = (
             await action_facade.ApplicationsCharmsActions(entity)).results
-        # There should only be one element in results so this is probably OTT
         for result in results:
-            if result.application_tag == app_tag:
-                return result.actions
-        else:
-            return None
+            if result.application_tag == self.tag and result.actions:
+                actions = result.actions
+                break
+        if not schema:
+            actions = {k: v['description'] for k, v in actions.items()}
+        return actions
 
     def get_resources(self, details=False):
         """Return resources for this application.

--- a/juju/application.py
+++ b/juju/application.py
@@ -228,13 +228,23 @@ class Application(model.ModelEntity):
         result = (await app_facade.Get(self.name)).constraints
         return vars(result) if result else result
 
-    def get_actions(self, schema=False):
+    async def get_actions(self, schema=False):
         """Get actions defined for this application.
 
         :param bool schema: Return the full action schema
 
         """
-        raise NotImplementedError()
+        app_tag = "application-{}".format(self.name)
+        entity = [{"tag": app_tag}]
+        action_facade = client.ActionFacade.from_connection(self.connection)
+        results = (
+            await action_facade.ApplicationsCharmsActions(entity)).results
+        # There should only be one element in results so this is probably OTT
+        for result in results:
+            if result.application_tag == app_tag:
+                return result.actions
+        else:
+            return None
 
     def get_resources(self, details=False):
         """Return resources for this application.

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -12,9 +12,9 @@ MB = 1
 async def test_action(event_loop):
     async with base.CleanModel() as model:
         ubuntu_app = await model.deploy(
-            'mysql',
+            'percona-cluster',
             application_name='mysql',
-            series='trusty',
+            series='xenial',
             channel='stable',
             config={
                 'tuning-level': 'safest',
@@ -33,6 +33,10 @@ async def test_action(event_loop):
         await ubuntu_app.set_constraints({'mem': 512 * MB})
         constraints = await ubuntu_app.get_constraints()
         assert constraints['mem'] == 512 * MB
+
+        # check action definitions
+        actions = await ubuntu_app.get_actions()
+        assert 'backup' in actions.keys()
 
 
 @base.bootstrapped

--- a/tests/integration/test_controller.py
+++ b/tests/integration/test_controller.py
@@ -6,7 +6,6 @@ from juju.client.connection import Connection
 from juju.client.jujudata import FileJujuData
 from juju.controller import Controller
 from juju.errors import JujuAPIError
-from juju.model import Model
 
 import pytest
 


### PR DESCRIPTION
Currently juju.application.get_actions raises an NotImplementedError
exception. This pr implements it. Oddly, ApplicationsCharmsActions
takes a list of application tags so it returns a list containing
one element. get_actions double checks that the tags match before
returning the actions. If a charm has no actions
ApplicationsCharmsActions still returns an
ApplicationsCharmsActionsResults object but the actions attribute
is None. 

The test_application functional tests have also been switched to
use cs:xenial/percona-cluster rather than cs:trusty/mysql as mysql
has no actions defined.

This PR also contains two small unrelated fixes.

* Remove unused Model import in tests/integration/test_controller.py
* gitignore pytestdebug.log

closes #226