### PR TITLE
Define an unused juju-zfs lxd storage pool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ before_script:
   - sudo lxd init --auto || true
   - sudo -E sudo -u $USER -E bash -c 'lxc config set core.https_address "[::]"'
   - sudo -E sudo -u $USER -E bash -c 'for i in 5 10 15 30; do [[ "$(lxc query --wait /1.0 | jq .environment.addresses)" != "[]" ]] && break; sleep $i; done'
+  - sudo -E sudo -u $USER -E bash -c 'sudo mkdir /var/snap/lxd/common/lxd/storage-pools/juju-zfs'
+  - sudo -E sudo -u $USER -E bash -c 'sudo lxc storage create juju-zfs dir source=/var/snap/lxd/common/lxd/storage-pools/juju-zfs' # Horrible workaround to LP Bug #1738614
 script:
   - sudo -E sudo -u $USER -E juju bootstrap localhost test --config 'identity-url=https://api.staging.jujucharms.com/identity' --config 'allow-model-access=true'
   - tox -e py3,integration,serial


### PR DESCRIPTION
Defining a juju-zfs storage pool appears to work around bug
https://bugs.launchpad.net/juju/+bug/1738614

From what I can tell the recent changes to make the test suite
use a directory backed lxd are correct. The underlying issue
is actually triggered by creating multiple models simultaneously.
If I run the test suite on a large machine with 8 workers then 
multiple tests will fail with the zfs pool error. When the tests run
through travis there are only two workers and the error rate drops.

Pre-creating a zfs storage pool (that is not used by the tests) 
appears to remove the error completely. I have run the test suite
with 8 workers and it completed without issue.

For mor einformation on why juju occasional fails with this error please
see https://bugs.launchpad.net/juju/+bug/1738614
