### PR TITLE
Fix spurious intermittent failure in test_machines.py::test_status

### DIFF
--- a/tests/integration/test_machine.py
+++ b/tests/integration/test_machine.py
@@ -26,17 +26,16 @@ async def test_status(event_loop):
         assert machine.agent_status == 'pending'
         assert not machine.agent_version
 
+        # there is some inconsistency in the capitalization of status_message
+        # between different providers
         await asyncio.wait_for(
-            model.block_until(lambda: (machine.status == 'running' and
-                                       machine.agent_status == 'started' and
-                                       machine.agent_version is not None)),
+            model.block_until(
+                lambda: (machine.status == 'running' and
+                         machine.status_message.lower() == 'running' and
+                         machine.agent_status == 'started' and
+                         machine.agent_version is not None and
+                         machine.agent_version.major >= 2)),
             timeout=480)
-
-        assert machine.status == 'running'
-        # there is some inconsistency in the message case between providers
-        assert machine.status_message.lower() == 'running'
-        assert machine.agent_status == 'started'
-        assert machine.agent_version.major >= 2
 
 
 @base.bootstrapped


### PR DESCRIPTION
Not sure why the agent_status seems to revert sometimes to 'pending' but the additional checks were basically redundant anyway.