### PR TITLE
Convert seconds to nanoseconds for juju.unit.run

### DIFF
--- a/juju/unit.py
+++ b/juju/unit.py
@@ -122,7 +122,7 @@ class Unit(model.ModelEntity):
         """Run command on this unit.
 
         :param str command: The command to run
-        :param int timeout: Time to wait before command is considered failed
+        :param int timeout: Time, in seconds, to wait before command is considered failed
         :returns: A :class:`juju.action.Action` instance.
 
         """
@@ -130,6 +130,10 @@ class Unit(model.ModelEntity):
 
         log.debug(
             'Running `%s` on %s', command, self.name)
+
+        if timeout:
+            # Convert seconds to nanoseconds
+            timeout = timeout * 1000000000
 
         res = await action.Run(
             [],

--- a/tests/integration/test_unit.py
+++ b/tests/integration/test_unit.py
@@ -25,6 +25,18 @@ async def test_run(event_loop):
             assert 'Stdout' in action.results
             break
 
+        for unit in app.units:
+            action = await unit.run('sleep 1', timeout=0.5)
+            assert isinstance(action, Action)
+            assert action.status == 'failed'
+            break
+
+        for unit in app.units:
+            action = await unit.run('sleep 0.5', timeout=2)
+            assert isinstance(action, Action)
+            assert action.status == 'completed'
+            break
+
 
 @base.bootstrapped
 @pytest.mark.asyncio


### PR DESCRIPTION
The juju.unit.run docstring does not specify what units the timeout
value should be in. This led to issue #225. Having looked into it,
juju is expecting it to be in nanoseconds. I don't think
nanoseconds is particularly intuitive so I have updated the function
to take the timeout in seconds and convert it internally to
nanoseconds.

I appreciate this is a breaking change for anyone currently specifying
the timeout in nanoseconds so I would quite understand if this change
is nack'd in which case I will submit a subsequent pr which simply
updates the doc string. Closes #225.