### PR TITLE
Wrap machine agent status workaround in version check

### DIFF
--- a/juju/client/overrides.py
+++ b/juju/client/overrides.py
@@ -138,14 +138,24 @@ class Number(_definitions.Number):
     def __str__(self):
         return self.serialize()
 
+    @property
+    def _cmp(self):
+        return (self.major, self.minor, self.tag, self.patch, self.build)
+
     def __eq__(self, other):
-        return (
-            isinstance(other, type(self)) and
-            other.major == self.major and
-            other.minor == self.minor and
-            other.tag == self.tag and
-            other.patch == self.patch and
-            other.build == self.build)
+        return isinstance(other, type(self)) and self._cmp == other._cmp
+
+    def __lt__(self, other):
+        return self._cmp < other._cmp
+
+    def __le__(self, other):
+        return self._cmp <= other._cmp
+
+    def __gt__(self, other):
+        return self._cmp > other._cmp
+
+    def __ge__(self, other):
+        return self._cmp >= other._cmp
 
     @classmethod
     def from_json(cls, data):

--- a/juju/machine.py
+++ b/juju/machine.py
@@ -14,7 +14,8 @@ log = logging.getLogger(__name__)
 class Machine(model.ModelEntity):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.on_change(self._workaround_1695335)
+        if self.model.info.agent_version < client.Number.from_json('2.2.3'):
+            self.on_change(self._workaround_1695335)
 
     async def _workaround_1695335(self, delta, old, new, model):
         """

--- a/tests/integration/test_machine.py
+++ b/tests/integration/test_machine.py
@@ -32,9 +32,7 @@ async def test_status(event_loop):
             model.block_until(
                 lambda: (machine.status == 'running' and
                          machine.status_message.lower() == 'running' and
-                         machine.agent_status == 'started' and
-                         machine.agent_version is not None and
-                         machine.agent_version.major >= 2)),
+                         machine.agent_status == 'started')),
             timeout=480)
 
 


### PR DESCRIPTION
Resolves #189

Note: This regresses the machine.agent_version due to https://bugs.launchpad.net/juju/+bug/1775248 but that info can be retrieved manually via model.full_status()