### PR TITLE
Add app.reset_config(list).

### DIFF
--- a/juju/application.py
+++ b/juju/application.py
@@ -295,12 +295,10 @@ class Application(model.ModelEntity):
         )
         return await self.ann_facade.Set([ann])
 
-    async def set_config(self, config, to_default=False):
+    async def set_config(self, config):
         """Set configuration options for this application.
 
         :param config: Dict of configuration to set
-        :param bool to_default: Set application options to default values
-
         """
         app_facade = client.ApplicationFacade.from_connection(self.connection)
 
@@ -308,6 +306,19 @@ class Application(model.ModelEntity):
             'Setting config for %s: %s', self.name, config)
 
         return await app_facade.Set(self.name, config)
+
+    async def reset_config(self, to_default):
+        """
+        Restore application config to default values.
+
+        :param list to_default: A list of config options to be reset to their default value.
+        """
+        app_facade = client.ApplicationFacade.from_connection(self.connection)
+
+        log.debug(
+            'Restoring default config for %s: %s', self.name, to_default)
+
+        return await app_facade.Unset(self.name, to_default)
 
     async def set_constraints(self, constraints):
         """Set machine constraints for this application.

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -29,6 +29,11 @@ async def test_action(event_loop):
         config = await ubuntu_app.get_config()
         assert config['tuning-level']['value'] == 'fast'
 
+        # Restore config back to default
+        await ubuntu_app.reset_config(['tuning-level'])
+        config = await ubuntu_app.get_config()
+        assert config['tuning-level']['value'] == 'safest'
+
         # update and check app constraints
         await ubuntu_app.set_constraints({'mem': 512 * MB})
         constraints = await ubuntu_app.get_constraints()


### PR DESCRIPTION
This change adds app.reset_config(list) to restore a list of
application config options back to their default values. The
unimplemented to_default option has also been removed from
app.set_config. This closes issue #175.