### PR TITLE
Handle juju not installed in is_bootstrapped.

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -12,10 +12,13 @@ import pytest
 
 
 def is_bootstrapped():
-    result = subprocess.run(['juju', 'switch'], stdout=subprocess.PIPE)
-    return (
-        result.returncode == 0 and
-        len(result.stdout.decode().strip()) > 0)
+    try:
+        result = subprocess.run(['juju', 'switch'], stdout=subprocess.PIPE)
+        return (
+            result.returncode == 0 and
+            len(result.stdout.decode().strip()) > 0)
+    except FileNotFoundError:
+        return False
 
 
 bootstrapped = pytest.mark.skipif(


### PR DESCRIPTION
Catch the exception raised if juju is not installed in
is_bootstrapped and return False. Closes issue #246.