### PR TITLE
Increase the timeout for charmstore connections

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -2162,7 +2162,7 @@ class CharmStore:
     """
     def __init__(self, loop):
         self.loop = loop
-        self._cs = theblues.charmstore.CharmStore(timeout=5)
+        self._cs = theblues.charmstore.CharmStore(timeout=20)
 
     def __getattr__(self, name):
         """

--- a/juju/model.py
+++ b/juju/model.py
@@ -2160,9 +2160,9 @@ class CharmStore:
     """
     Async wrapper around theblues.charmstore.CharmStore
     """
-    def __init__(self, loop):
+    def __init__(self, loop, cs_timeout=20):
         self.loop = loop
-        self._cs = theblues.charmstore.CharmStore(timeout=20)
+        self._cs = theblues.charmstore.CharmStore(timeout=cs_timeout)
 
     def __getattr__(self, name):
         """


### PR DESCRIPTION
The charm store often does not respond in 5s. Increase the timeout
to 20s. Charm store issue being tracked in https://github.com/CanonicalLtd/jujucharms.com/issues/551
. Closes issue #261 