### PR TITLE
Fix bundles with subordinates for Juju <2.5

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -2059,7 +2059,7 @@ class BundleHandler:
 
     async def deploy(self, charm, series, application, options, constraints,
                      storage, endpoint_bindings, resources,
-                     devices=None, num_units=1, placement=None):
+                     devices=None, num_units=None, placement=None):
         """
         :param charm string:
             Charm holds the URL of the charm to be used to deploy this

--- a/tests/bundle/mini-bundle.yaml
+++ b/tests/bundle/mini-bundle.yaml
@@ -1,3 +1,9 @@
+series: xenial
 applications:
-  myapp:
-    charm: cs:xenial/ubuntu-0
+  dummy-sink:
+    charm: cs:~juju-qa/dummy-sink
+    num_units: 1
+  dummy-subordinate:
+    charm: cs:~juju-qa/dummy-subordinate
+relations:
+  - ['dummy-sink', 'dummy-subordinate']

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -26,17 +26,37 @@ SSH_KEY = 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsYMJGNGG74HAJha3n2CFmWYsOOaORn
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_local_bundle(event_loop):
+async def test_deploy_local_bundle_dir(event_loop):
+    tests_dir = Path(__file__).absolute().parent.parent
+    bundle_path = tests_dir / 'bundle'
+
+    async with base.CleanModel() as model:
+        await model.deploy(str(bundle_path))
+
+        wordpress = model.applications.get('wordpress')
+        mysql = model.applications.get('mysql')
+        assert wordpress and mysql
+        await block_until(lambda: (len(wordpress.units) == 1 and
+                                   len(mysql.units) == 1),
+                          timeout=60*2)
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_deploy_local_bundle_file(event_loop):
     tests_dir = Path(__file__).absolute().parent.parent
     bundle_path = tests_dir / 'bundle'
     mini_bundle_file_path = bundle_path / 'mini-bundle.yaml'
 
     async with base.CleanModel() as model:
-        await model.deploy(str(bundle_path))
         await model.deploy(str(mini_bundle_file_path))
 
-        for app in ('wordpress', 'mysql', 'myapp'):
-            assert app in model.applications
+        dummy_sink = model.applications.get('dummy-sink')
+        dummy_subordinate = model.applications.get('dummy-subordinate')
+        assert dummy_sink and dummy_subordinate
+        await block_until(lambda: (len(dummy_sink.units) == 1 and
+                                   len(dummy_subordinate.units) == 1),
+                          timeout=60*2)
 
 
 @base.bootstrapped

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -38,7 +38,7 @@ async def test_deploy_local_bundle_dir(event_loop):
         assert wordpress and mysql
         await block_until(lambda: (len(wordpress.units) == 1 and
                                    len(mysql.units) == 1),
-                          timeout=60*2)
+                          timeout=60 * 2)
 
 
 @base.bootstrapped
@@ -56,7 +56,7 @@ async def test_deploy_local_bundle_file(event_loop):
         assert dummy_sink and dummy_subordinate
         await block_until(lambda: (len(dummy_sink.units) == 1 and
                                    len(dummy_subordinate.units) == 1),
-                          timeout=60*2)
+                          timeout=60 * 2)
 
 
 @base.bootstrapped


### PR DESCRIPTION
The support for 2.5 introduced a regression for subordinate applications in bundles for older versions of Juju, due to the incorrect default method arg value.

This also improves the tests to prevent this from happening again.

Fixes #276