### PR TITLE
Add retry for connection if all endpoints fail

### DIFF
--- a/juju/provisioner.py
+++ b/juju/provisioner.py
@@ -252,8 +252,8 @@ class SSHProvisioner:
                 cores = line.split(":")[1].strip()
 
                 if physical_id not in recorded.keys():
-                        info['cpu-cores'] += cores
-                        recorded[physical_id] = True
+                    info['cpu-cores'] += cores
+                    recorded[physical_id] = True
 
         return info
 

--- a/tests/integration/test_connection.py
+++ b/tests/integration/test_connection.py
@@ -200,16 +200,16 @@ class RedirectServer:
                                                 port=self.port,
                                                 ssl=self.ssl_context,
                                                 loop=self.loop):
-                            self.stopped.clear()
-                            self.running.set()
-                            logger.debug('server: started')
-                            while not self._stop.is_set():
-                                await run_with_interrupt(
-                                    asyncio.sleep(1, loop=self.loop),
-                                    self._stop,
-                                    loop=self.loop)
-                                logger.debug('server: tick')
-                            logger.debug('server: stopping')
+                        self.stopped.clear()
+                        self.running.set()
+                        logger.debug('server: started')
+                        while not self._stop.is_set():
+                            await run_with_interrupt(
+                                asyncio.sleep(1, loop=self.loop),
+                                self._stop,
+                                loop=self.loop)
+                            logger.debug('server: tick')
+                        logger.debug('server: stopping')
                 except asyncio.CancelledError:
                     break
                 finally:

--- a/tests/integration/test_controller.py
+++ b/tests/integration/test_controller.py
@@ -119,9 +119,9 @@ async def test_grant_revoke(event_loop):
         fresh = await controller.get_user(username)  # fetch fresh copy
         assert fresh.access == 'superuser'
         await user.revoke()
-        assert user.access is ''
+        assert user.access == ''
         fresh = await controller.get_user(username)  # fetch fresh copy
-        assert fresh.access is ''
+        assert fresh.access == ''
 
 
 @base.bootstrapped


### PR DESCRIPTION
Sometimes, particularly during reconnects, the first attempt to connect will fail on all endpoints due to network delays or controller issues.

This adds a retry (default 3 attempts) to try all of the endpoints again.