### PR TITLE
Handle deltas of unknown types.

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -851,9 +851,12 @@ class Model:
                             pass  # can't stop on a closed conn
                         break
                     for delta in results.deltas:
-                        delta = get_entity_delta(delta)
-                        old_obj, new_obj = self.state.apply_delta(delta)
-                        await self._notify_observers(delta, old_obj, new_obj)
+                        try:
+                            delta = get_entity_delta(delta)
+                            old_obj, new_obj = self.state.apply_delta(delta)
+                            await self._notify_observers(delta, old_obj, new_obj)
+                        except KeyError as e:
+                            log.debug("unknown delta type: %s", e.args[0])
                     self._watch_received.set()
             except CancelledError:
                 pass


### PR DESCRIPTION
Juju 2.6 introduces a Delta type for 'charm'. This is because Juju is using the multiwatcher to populate an internal cache. There are likely to be new additions as well.

This branch makes libjuju more robust to unknown types. It will log at debug when it sees one, but otherwise ignores them.

Against a 2.6-beta1 controller and master `tox -e integration -- -k test_full_status` blocks forever.

With this patch it passes.
