### PR TITLE
Handle RedirectError payloads returned by Login RPCs

### DIFF
--- a/juju/errors.py
+++ b/juju/errors.py
@@ -20,6 +20,7 @@ class JujuAPIError(JujuError):
         self.error_code = result.get('error-code')
         self.response = result['response']
         self.request_id = result['request-id']
+        self.error_info = result['error-info'] if 'error-info' in result else None
         super().__init__(self.message)
 
 
@@ -33,8 +34,9 @@ class JujuAuthError(JujuConnectionError):
 
 class JujuRedirectException(Exception):
     """Exception indicating that a redirection was requested"""
-    def __init__(self, redirect_info):
+    def __init__(self, redirect_info, follow_redirect=True):
         self.redirect_info = redirect_info
+        self.follow_redirect = follow_redirect
 
     @property
     def ca_cert(self):
@@ -45,5 +47,5 @@ class JujuRedirectException(Exception):
         return [
             ('{value}:{port}'.format(**s), self.ca_cert)
             for servers in self.redirect_info['servers']
-            for s in servers if s['scope'] == 'public'
+            for s in servers if s['scope'] == 'public' or not self.follow_redirect
         ]

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -3,6 +3,7 @@ import json
 from collections import deque
 
 import mock
+from juju.errors import JujuRedirectException
 from juju.client.connection import Connection
 from websockets.exceptions import ConnectionClosed
 
@@ -62,4 +63,105 @@ async def test_out_of_order(event_loop):
         assert actual_responses == expected_responses
     finally:
         if con:
+            await con.close()
+
+
+@pytest.mark.asyncio
+async def test_bubble_redirect_exception(event_loop):
+    ca_cert = """
+-----BEGIN CERTIFICATE-----
+SOMECERT
+-----END CERTIFICATE-----"""
+    ws = WebsocketMock([
+        {
+            'request-id': 1,
+            'error': 'redirection to alternative server required',
+            'error-code': 'redirection required',
+            'error-info': {
+                'ca-cert': ca_cert,
+                'servers': [[
+                    {
+                        'port': 17070,
+                        'scope': 'local-cloud',
+                        'type': 'ipv4',
+                        'value': '42.42.42.42',
+                    },
+                    {
+                        'port': 4242,
+                        'scope': 'public',
+                        'type': 'ipv4',
+                        'value': '42.42.42.42',
+                    },
+                ]],
+            },
+            'response': {},
+        },
+    ])
+    with pytest.raises(JujuRedirectException) as caught_ex:
+        with mock.patch('websockets.connect', base.AsyncMock(return_value=ws)):
+            await Connection.connect('0.1.2.3:999')
+
+    redir_error = caught_ex.value
+    assert redir_error.follow_redirect is False
+    assert redir_error.ca_cert == ca_cert
+    assert redir_error.endpoints == [
+        ('42.42.42.42:17070', ca_cert),
+        ('42.42.42.42:4242', ca_cert),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_follow_redirect(event_loop):
+    ca_cert = """
+-----BEGIN CERTIFICATE-----
+SOMECERT
+-----END CERTIFICATE-----"""
+    wsForCont1 = WebsocketMock([
+        {
+            'request-id': 1,
+            'error': 'redirection to alternative server required',
+            'error-code': 'redirection required',
+            'response': {},
+        },
+        {
+            'request-id': 2,
+            'response': {
+                'ca-cert': ca_cert,
+                'servers': [[
+                    {
+                        'port': 17070,
+                        'scope': 'local-cloud',
+                        'type': 'ipv4',
+                        'value': '42.42.42.42',
+                    },
+                    {
+                        'port': 4242,
+                        'scope': 'public',
+                        'type': 'ipv4',
+                        'value': '42.42.42.42',
+                    },
+                ]],
+            },
+        },
+    ])
+    minimal_facades = [{'name': 'Pinger', 'versions': [1]}]
+    wsForCont2 = WebsocketMock([
+        {'request-id': 1},
+        {'request-id': 2},
+        {'request-id': 3, 'response': {'result': minimal_facades}},
+    ])
+
+    con = None
+    try:
+        with \
+            mock.patch('websockets.connect',
+                       base.AsyncMock(side_effect=[wsForCont1, wsForCont2])
+                       ), \
+            mock.patch('juju.client.connection.Connection._get_ssl'), \
+            mock.patch('juju.client.connection.Connection._pinger',
+                       base.AsyncMock()):
+            con = await Connection.connect('0.1.2.3:999')
+    finally:
+        if con:
+            assert con.connect_params()['endpoint'] == "42.42.42.42:4242"
             await con.close()


### PR DESCRIPTION
This PR updates the juju python library to support handling of RedirectError payloads (introduced by https://github.com/juju/juju/pull/10069) when invoking Login RPCs.

So far we have two specific use-cases for redirects:
- JAAS-like redirects (Login fails with CodeRedirect and no payload; client makes an extra RPC to get the redirect details) which the client library should automatically follow.
- Login RPCs fail with CodeRedirect **and** contain details about the controller the model migrated to (hence no extra RPC is required). For UX purposes (see linked PR for the reasoning behind this) we want to show an error to the user instead of transparently redirecting them to the new controller.

To ensure that both cases work as described above, the `JujuRedirectException` type is augmented with a `follow_redirect` attribute that is set to true for JAAS-like redirects. The dialing code has been updated to intercept redirect exceptions and either re-raise them or auto-connect to the new controller depending on the `follow_redirect` value.