### PR TITLE
Schemagen is no longer required

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 BIN := .tox/py3/bin
 PY := $(BIN)/python
 PIP := $(BIN)/pip
-SCHEMAGEN := $(shell which schemagen)
 VERSION=$(shell cat VERSION)
 
 clean:
@@ -14,9 +13,6 @@ clean:
 	tox -r --notest
 
 client: .tox
-ifndef SCHEMAGEN
-	$(error "schemagen is not available, please install from https://github.com/juju/schemagen")
-endif
 	$(PY) -m juju.client.facade -s "juju/client/schemas*" -o juju/client/
 
 test:

--- a/docs/upstream-updates/index.rst
+++ b/docs/upstream-updates/index.rst
@@ -13,24 +13,30 @@ Rarely, you may also have to add or update an override.
 Creating a Schema File
 ----------------------
 
-First, you will need to fetch SchemaGen_ and a copy of the Juju source.
-Once your copy of the Juju source is at the version you want to update to
-(probably the `develop` branch, or a release tag) and you have updated
-and reinstalled SchemaGen to reflect those changes, you just need to send
-the output into a file in the libjuju repository:
+Firstly, you'll need to checkout the Juju_ project and correctly have it
+setup according to it's documentation. Juju_ has the ability to generate
+the schema and stores it in version control (git). Copying that file from
+Juju_ to libjuju repository to make sure it can be picked up for
+construction of the libjuju client.
+
+From inside Juju_:
 
 .. code:: bash
 
-  schemagen > juju/client/schemas-juju-2.2-rc1.json
+  make rebuild-schema
 
 The version number you use in the filename should match the upstream
 version of Juju.  You should then also move the `latest` pointer to
 the new file:
 
+From inside libjuju:
+
 .. code:: bash
 
+  cp ${GOPATH}/src/github.com/juju/juju/apiserver/facades/schema.json \
+      juju/client/schemas-juju-2.6.4.json
   rm juju/client/schemas-juju-latest.json
-  ln -s schemas-juju-2.2-rc1.json juju/client/schemas-juju-latest.json
+  ln -s schemas-juju-2.6.4.json juju/client/schemas-juju-latest.json
 
 
 Generating the Python Code
@@ -111,4 +117,4 @@ the attributes of the override classes into the matching generated class,
 leaving the rest of the generated class untouched.
 
 
-.. _SchemaGen: https://github.com/juju/schemagen
+.. _Juju: https://github.com/juju/juju

--- a/docs/upstream-updates/index.rst
+++ b/docs/upstream-updates/index.rst
@@ -7,17 +7,17 @@ to reflect changes in upstream Juju consists of two steps:
 * Creating a new `schemas-juju-<version>.json` file from the Juju code-base
 * Generating the libjuju Python code from that schema
 
-Rarely, you may also have to add or update an override.
+Additionally changes, although rare may be also required to add or
+update an override.
 
 
 Creating a Schema File
 ----------------------
 
-Firstly, you'll need to checkout the Juju_ project and correctly have it
-setup according to it's documentation. Juju_ has the ability to generate
-the schema and stores it in version control (git). Copying that file from
-Juju_ to libjuju repository to make sure it can be picked up for
-construction of the libjuju client.
+Firstly, checkout the Juju_ project and correctly set it up according to
+it's documentation. Juju_ has the ability to generate the schema and stores
+it in version control (git). Copy that file from Juju_ to libjuju repository
+to make sure it can be picked up for construction of the libjuju client.
 
 From inside Juju_:
 
@@ -25,9 +25,10 @@ From inside Juju_:
 
   make rebuild-schema
 
-The version number you use in the filename should match the upstream
-version of Juju.  You should then also move the `latest` pointer to
-the new file:
+The version number used in the filename should match the upstream
+version of Juju. To ensure that the client picks up the new change, the
+`latest` pointer (schemas-juju-latest.json) should be pointed to the
+versioned file:
 
 From inside libjuju:
 
@@ -42,16 +43,16 @@ From inside libjuju:
 Generating the Python Code
 --------------------------
 
-Once you have a new schema file, you can update the Python code
-using the `client` make target:
+Creating a new client requires the building of the Python code from
+the schema and doing so is a make target:
 
 .. code:: bash
 
   make client
 
-You should expect to see updates to the `juju/client/_definitions.py` file,
-as well as one or more of the `juju/client/_clientX.py` files, depending on
-which facades were touched.
+Changes to `juju/client/_definitions.py` and `juju/client/_clientX.py`
+files are expected, along with any facades files, depending what was
+changed in Juju_.
 
 
 Integrating into the Object Layer


### PR DESCRIPTION
Schemagen is no longer required because Juju itself has incorporated
the schema generation into the workflow of Juju. This should make it
a lot easier to build upon pylibjuju if it's always up to date with
Juju.

Work to do this has already been completed, see:

 1. https://github.com/juju/juju/pull/10336
 2. https://github.com/juju/juju/pull/10338

This should support 2.6 and onwards. Older releases can be done
the old way, but it requires you to have schemagen installed in the
old positions. The error messages might be more cryptic because of
that.