### PR TITLE
Fix issue #335: Allow provisioning with non-"ubuntu" user

### DIFF
--- a/juju/provisioner.py
+++ b/juju/provisioner.py
@@ -155,28 +155,21 @@ class SSHProvisioner:
             if the authentication fails
         """
 
-        # TODO: Test this on an image without the ubuntu user setup.
-
-        auth_user = self.user
         ssh = None
         try:
             # Run w/o allocating a pty, so we fail if sudo prompts for a passwd
             ssh = self._get_ssh_client(
                 self.host,
-                "ubuntu",
+                self.user,
                 self.private_key_path,
             )
-
             stdout, stderr = self._run_command(ssh, "sudo -n true", pty=False)
         except paramiko.ssh_exception.AuthenticationException as e:
+            sys.stderr.write(e)
             raise e
-        else:
-            auth_user = "ubuntu"
         finally:
             if ssh:
                 ssh.close()
-
-        # if the above fails, run the init script as the authenticated user
 
         # Infer the public key
         public_key = None
@@ -195,7 +188,7 @@ class SSHProvisioner:
         try:
             ssh = self._get_ssh_client(
                 self.host,
-                auth_user,
+                self.user,
                 self.private_key_path,
             )
 

--- a/juju/provisioner.py
+++ b/juju/provisioner.py
@@ -165,7 +165,6 @@ class SSHProvisioner:
             )
             stdout, stderr = self._run_command(ssh, "sudo -n true", pty=False)
         except paramiko.ssh_exception.AuthenticationException as e:
-            sys.stderr.write(e)
             raise e
         finally:
             if ssh:

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -16,7 +16,6 @@ from juju.model import Model, ModelObserver
 from juju.utils import block_until, run_with_interrupt
 import random
 import string
-import sys
 from .. import base
 
 MB = 1
@@ -396,6 +395,7 @@ async def test_add_manual_machine_ssh_root(event_loop):
         container.delete(wait=True)
 
         profile.delete()
+
 
 @base.bootstrapped
 @pytest.mark.asyncio

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -14,7 +14,9 @@ from juju.client.client import ApplicationFacade, ConfigValue
 from juju.errors import JujuError
 from juju.model import Model, ModelObserver
 from juju.utils import block_until, run_with_interrupt
-
+import random
+import string
+import sys
 from .. import base
 
 MB = 1
@@ -163,6 +165,10 @@ async def test_add_machine(event_loop):
 @base.bootstrapped
 @pytest.mark.asyncio
 async def test_add_manual_machine_ssh(event_loop):
+    """Test manual machine provisioning with a non-root user
+
+    Tests manual machine provisioning using a randomized username with sudo access.
+    """
 
     # Verify controller is localhost
     async with base.CleanController() as controller:
@@ -185,16 +191,28 @@ async def test_add_manual_machine_ssh(event_loop):
             uuid.uuid4().hex[-4:]
         )
 
+        # Create a randomized user name
+        test_user = ''.join(random.choice(string.ascii_lowercase) for i in range(10))
+
         # create profile w/cloud-init and juju ssh key
         public_key = ""
         with open(public_key_path, "r") as f:
             public_key = f.readline()
 
+        cloud_init = """
+        #cloud-config
+        users:
+        - name: {}
+          ssh_pwauth: False
+          ssh_authorized_keys:
+            - {}
+          sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+          groups: adm, sudoers
+        """.format(test_user, public_key)
+
         profile = client.profiles.create(
             test_name,
-            config={'user.user-data': '#cloud-config\n'
-                                      'ssh_authorized_keys:\n'
-                                      '- {}'.format(public_key)},
+            config={'user.user-data': cloud_init},
             devices={
                 'root': {'path': '/', 'pool': 'default', 'type': 'disk'},
                 'eth0': {
@@ -244,13 +262,11 @@ async def test_add_manual_machine_ssh(event_loop):
             try:
                 # add a new manual machine
                 machine1 = await model.add_machine(spec='ssh:{}@{}:{}'.format(
-                    "ubuntu",
+                    test_user,
                     host['address'],
                     private_key_path,
                 ))
             except paramiko.ssh_exception.NoValidConnectionsError:
-                if attempt == 3:
-                    raise
                 # retry the ssh connection a few times if it fails
                 time.sleep(attempt * 5)
             else:
@@ -268,6 +284,118 @@ async def test_add_manual_machine_ssh(event_loop):
 
         profile.delete()
 
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_add_manual_machine_ssh_root(event_loop):
+    """Test manual machine provisioning with the root user"""
+
+    # Verify controller is localhost
+    async with base.CleanController() as controller:
+        cloud = await controller.get_cloud()
+        if cloud != "localhost":
+            pytest.skip('Skipping because test requires lxd.')
+
+    async with base.CleanModel() as model:
+        private_key_path = os.path.expanduser(
+            "~/.local/share/juju/ssh/juju_id_rsa"
+        )
+        public_key_path = os.path.expanduser(
+            "~/.local/share/juju/ssh/juju_id_rsa.pub"
+        )
+
+        # connect using the local unix socket
+        client = pylxd.Client()
+
+        test_name = "test-{}-add-manual-machine-ssh".format(
+            uuid.uuid4().hex[-4:]
+        )
+
+        # create profile w/cloud-init and juju ssh key
+        public_key = ""
+        with open(public_key_path, "r") as f:
+            public_key = f.readline()
+
+        cloud_init = """
+        #cloud-config
+        users:
+        - name: root
+          ssh_authorized_keys:
+            - {}
+        """.format(public_key)
+
+        profile = client.profiles.create(
+            test_name,
+            config={'user.user-data': cloud_init},
+            devices={
+                'root': {'path': '/', 'pool': 'default', 'type': 'disk'},
+                'eth0': {
+                    'nictype': 'bridged',
+                    'parent': 'lxdbr0',
+                    'type': 'nic'
+                }
+            }
+        )
+
+        # create lxc machine
+        config = {
+            'name': test_name,
+            'source': {
+                'type': 'image',
+                'alias': 'xenial',
+                'mode': 'pull',
+                'protocol': 'simplestreams',
+                'server': 'https://cloud-images.ubuntu.com/releases',
+            },
+            'profiles': [test_name],
+        }
+        container = client.containers.create(config, wait=True)
+        container.start(wait=True)
+
+        def wait_for_network(container, timeout=30):
+            """Wait for eth0 to have an ipv4 address."""
+            starttime = time.time()
+            while(time.time() < starttime + timeout):
+                time.sleep(1)
+                if 'eth0' in container.state().network:
+                    addresses = container.state().network['eth0']['addresses']
+                    if len(addresses) > 0:
+                        if addresses[0]['family'] == 'inet':
+                            return addresses[0]
+            return None
+
+        host = wait_for_network(container)
+        assert host, 'Failed to get address for machine'
+
+        # HACK: We need to give sshd a chance to bind to the interface,
+        # and pylxd's container.execute seems to be broken and fails and/or
+        # hangs trying to properly check if the service is up.
+        time.sleep(5)
+
+        for attempt in range(1, 4):
+            try:
+                # add a new manual machine
+                machine1 = await model.add_machine(spec='ssh:{}@{}:{}'.format(
+                    "root",
+                    host['address'],
+                    private_key_path,
+                ))
+            except (paramiko.ssh_exception.NoValidConnectionsError, paramiko.ssh_exception.AuthenticationException):
+                time.sleep(attempt * 5)
+            else:
+                break
+
+        assert len(model.machines) == 1
+
+        res = await machine1.destroy(force=True)
+
+        assert res is None
+        assert len(model.machines) == 0
+
+        container.stop(wait=True)
+        container.delete(wait=True)
+
+        profile.delete()
 
 @base.bootstrapped
 @pytest.mark.asyncio


### PR DESCRIPTION
This patch fixes an issue with the SSH provisioner, which previously
always assumed there was an "ubuntu" user with sudo access available on
the target machine.

The provisioner will now honor the username passed to
`model.add_machine`.

Added an additional integration test for testing the root user, as well
as modifying the existing integration test to use a randomized username
w/sudo access.