### PR TITLE
Bundle changes

### DIFF
--- a/juju/bundle.py
+++ b/juju/bundle.py
@@ -8,7 +8,6 @@ import yaml
 from toposort import toposort_flatten
 
 from .client import client
-from .constraints import normalize_key
 from .constraints import parse as parse_constraints
 from .errors import JujuError
 
@@ -51,8 +50,7 @@ class BundleHandler:
                            ConsumeOfferChange,
                            ExposeChange,
                            ScaleChange,
-                           SetAnnotationsChange,
-                          ]
+                           SetAnnotationsChange]
         self.change_types = {}
         for change_cls in change_type_cls:
             self.change_types[change_cls.method()] = change_cls
@@ -444,16 +442,16 @@ class AddApplicationChange(ChangeInfo):
                 self.num_units = params[9]
 
         elif isinstance(params, dict):
-            self.charm = params.charm
-            self.series = params.series
-            self.application = params.application
-            self.options = params.options
-            self.constraints = params.contstraints
-            self.storage = params.storage
-            self.devices = params.devices
-            self.endpoint_bindings = params.get("endpoint-bindings")
-            self.resources = params.resources
-            self.num_units = params.get("num-units")
+            self.charm = params["charm"]
+            self.series = params["series"]
+            self.application = params["application"]
+            self.options = params["options"]
+            self.constraints = params["constraints"]
+            self.storage = params["storage"]
+            self.devices = params["devices"]
+            self.endpoint_bindings = params["endpoint-bindings"]
+            self.resources = params["resources"]
+            self.num_units = params["num-units"]
         else:
             raise Exception("unexpected params type")
 
@@ -473,9 +471,10 @@ class AddApplicationChange(ChangeInfo):
             units_info = " with {num_units} unit{plural}".format(num_units=self.num_units,
                                                                  plural=plural)
         return "deploy application {application}{units_info}{series} using {charm}".format(application=self.application,
-                                                                                          units_info=units_info,
-                                                                                          series=series,
-                                                                                          charm=self.charm)
+                                                                                           units_info=units_info,
+                                                                                           series=series,
+                                                                                           charm=self.charm)
+
 
 class AddCharmChange(ChangeInfo):
     """
@@ -497,10 +496,10 @@ class AddCharmChange(ChangeInfo):
             else:
                 self.channel = None
         elif isinstance(params, dict):
-            self.charm = params.charm
-            self.series = params.series
-            if "channel" in params and params.channel != "":
-                self.channel = params.channel
+            self.charm = params["charm"]
+            self.series = params["series"]
+            if "channel" in params and params["channel"] != "":
+                self.channel = params["channel"]
             else:
                 self.channel = None
         else:
@@ -529,23 +528,23 @@ class AddMachineChange(ChangeInfo):
     :series: holds the optional machine OS series.
     :constraints: holds the optional machine constraints.
     :container_type: optionally holds the type of the container (for instance
-	    "lxc" or kvm"). It is not specified for top level machines.
+        "lxc" or kvm"). It is not specified for top level machines.
     :parent_id: holds the id of the parent machine.
     """
     def __init__(self, change_id, requires, params=None):
         super(AddMachineChange, self).__init__(change_id, requires)
         # this one is weird, as it returns a set of parameters inside a list.
         if isinstance(params, list):
-            add_machine_options = params[0]
-            self.series = add_machine_options.get("series")
-            self.constraints = add_machine_options.get("constraints")
-            self.container_type = add_machine_options.get("containerType")
-            self.parent_id = add_machine_options.get("parentId")
+            options = params[0] or {}
+            self.series = options.get("series")
+            self.constraints = options.get("constraints")
+            self.container_type = options.get("containerType")
+            self.parent_id = options.get("parentId")
         elif isinstance(params, dict):
-            self.series = params.series
-            self.constraints = params.contstraints
-            self.container_type = params.get("container-type")
-            self.parent_id = params.get("parent-id")
+            self.series = params["series"]
+            self.constraints = params["constraints"]
+            self.container_type = params["container-type"]
+            self.parent_id = params["parent-id"]
         else:
             raise Exception("unexpected params type")
 
@@ -567,11 +566,11 @@ class AddRelationChange(ChangeInfo):
     applications.
 
     Endpoint1 and Endpoint2 hold relation endpoints in the
-	"application:interface" form, where the application is either a
-	placeholder pointing to an application change or in the case of a model
-	that already has this application deployed, the name of the
-	application, and the interface is optional. Examples are
-	"$deploy-42:web", "$deploy-42", "mysql:db".
+    "application:interface" form, where the application is either a
+    placeholder pointing to an application change or in the case of a model
+    that already has this application deployed, the name of the
+    application, and the interface is optional. Examples are
+    "$deploy-42:web", "$deploy-42", "mysql:db".
     """
     def __init__(self, change_id, requires, params=None):
         super(AddRelationChange, self).__init__(change_id, requires)
@@ -580,8 +579,8 @@ class AddRelationChange(ChangeInfo):
             self.endpoint1 = params[0]
             self.endpoint2 = params[1]
         elif isinstance(params, dict):
-            self.endpoint1 = params.endpoint1
-            self.endpoint2 = params.endpoint2
+            self.endpoint1 = params["endpoint1"]
+            self.endpoint2 = params["endpoint2"]
         else:
             raise Exception("unexpected params type")
 
@@ -601,7 +600,7 @@ class AddUnitChange(ChangeInfo):
     :application: holds the application placeholder name for which a unit is
         added.
     :to: holds the optional location where to add the unit, as a placeholder
-	    pointing to another unit change or to a machine change.
+        pointing to another unit change or to a machine change.
     """
     def __init__(self, change_id, requires, params=None):
         super(AddUnitChange, self).__init__(change_id, requires)
@@ -610,8 +609,8 @@ class AddUnitChange(ChangeInfo):
             self.application = params[0]
             self.to = params[1]
         elif isinstance(params, dict):
-            self.application = params.application
-            self.to = params.to
+            self.application = params["application"]
+            self.to = params["to"]
         else:
             raise Exception("unexpected params type")
 
@@ -642,9 +641,9 @@ class CreateOfferChange(ChangeInfo):
             self.endpoints = params[1]
             self.offer_name = params[2]
         elif isinstance(params, dict):
-            self.application = params.application
-            self.endpoints = params.endpoints
-            self.offer_name = params.get("offer-name")
+            self.application = params["application"]
+            self.endpoints = params["endpoints"]
+            self.offer_name = params["offer-name"]
         else:
             raise Exception("unexpected params type")
 
@@ -672,8 +671,8 @@ class ConsumeOfferChange(ChangeInfo):
             self.url = params[0]
             self.application_name = params[1]
         elif isinstance(params, dict):
-            self.url = params.url
-            self.application_name = params.application_name
+            self.url = params["url"]
+            self.application_name = params["application_name"]
         else:
             raise Exception("unexpected params type")
 
@@ -699,7 +698,7 @@ class ExposeChange(ChangeInfo):
         if isinstance(params, list):
             self.application = params[0]
         elif isinstance(params, dict):
-            self.application = params.application
+            self.application = params["application"]
         else:
             raise Exception("unexpected params type")
 
@@ -725,8 +724,8 @@ class ScaleChange(ChangeInfo):
             self.application = params[0]
             self.scale = params[1]
         elif isinstance(params, dict):
-            self.application = params.application
-            self.scale = params.scale
+            self.application = params["application"]
+            self.scale = params["scale"]
         else:
             raise Exception("unexpected params type")
 
@@ -757,9 +756,9 @@ class SetAnnotationsChange(ChangeInfo):
             self.entity_type = params[1]
             self.annotations = params[2]
         elif isinstance(params, dict):
-            self.id = params.id
-            self.entity_type = params.get("entity-type")
-            self.annotations = params.annotations
+            self.id = params["id"]
+            self.entity_type = params["entity-type"]
+            self.annotations = params["annotations"]
         else:
             raise Exception("unexpected params type")
 

--- a/juju/bundle.py
+++ b/juju/bundle.py
@@ -41,9 +41,12 @@ class BundleHandler:
             model.connection())
         self.ann_facade = client.AnnotationsFacade.from_connection(
             model.connection())
-        self.param_types = {
-            'addCharm': AddCharmChange,
-            'addMachines': AddMachineChange,
+
+        # ChangeTypes are a series of types that the BundleHandler can translate
+        # correctly from the API changes response.
+        self.change_types = {
+            AddCharmChange.method: AddCharmChange,
+            AddMachineChange.method: AddMachineChange,
         }
 
     async def _validate_bundle(self, bundle):
@@ -136,7 +139,7 @@ class BundleHandler:
         changes = ChangeSet(self.plan.changes)
         for step in changes.sorted():
             method = getattr(self, step.method)
-            change_cls = self.param_types.get(step.method)
+            change_cls = self.change_types.get(step.method)
             if change_cls is None:
                 # TODO: Remove this method calling, once we've implemented all
                 # the changes.
@@ -461,6 +464,10 @@ class AddCharmChange(ChangeInfo):
         params = params or {}
         self.params = {normalize_key(k): params[k] for k in params.keys()}
 
+    @staticmethod
+    def method():
+        return "addCharm"
+
     def description(self):
         series = ""
         channel = ""
@@ -507,6 +514,10 @@ class AddMachineChange(ChangeInfo):
         super(AddMachineChange, self).__init__(change_id, requires)
         params = params or {}
         self.params = {normalize_key(k): params[k] for k in params.keys()}
+
+    @staticmethod
+    def method():
+        return "addMachines"
 
     def description(self):
         machine = "new machine"

--- a/juju/bundle.py
+++ b/juju/bundle.py
@@ -150,7 +150,7 @@ class BundleHandler:
             # Explicitly call out what methods we work with, so it makes it
             # very easy to understand what happens with the execution.
             change = change_cls(step.id_, step.requires, step.args)
-            log.info(change.description())
+            log.info("Applying change: {}".format(change))
             if step.method == AddApplicationChange.method():
                 result = await self.handleAddApplication(change)
             elif step.method == AddCharmChange.method():
@@ -425,7 +425,7 @@ class AddApplicationChange(ChangeInfo):
              'num-units': 'num_units'}
 
     """
-    AddCharmChange holds a change for deploying a Juju application.
+    AddApplicationChange holds a change for deploying a Juju application.
 
     :charm: holds the URL of the charm to be used to deploy this application.
     :series: holds the series of the application to be deployed if the charm
@@ -476,7 +476,7 @@ class AddApplicationChange(ChangeInfo):
     def method():
         return "deploy"
 
-    def description(self):
+    def __str__(self):
         series = ""
         if self.series != "":
             series = " on {}".format(self.series)
@@ -525,7 +525,7 @@ class AddCharmChange(ChangeInfo):
     def method():
         return "addCharm"
 
-    def description(self):
+    def __str__(self):
         series = ""
         channel = ""
         if self.series != "":
@@ -570,7 +570,7 @@ class AddMachineChange(ChangeInfo):
     def method():
         return "addMachines"
 
-    def description(self):
+    def __str__(self):
         machine = "new machine"
         if self.container_type is not None and self.container_type != "":
             machine = "{container_type} container on {machine}".format(container_type=self.container_type,
@@ -607,7 +607,7 @@ class AddRelationChange(ChangeInfo):
     def method():
         return "addRelation"
 
-    def description(self):
+    def __str__(self):
         return "add relation {endpoint1} - {endpoint2}".format(endpoint1=self.endpoint1,
                                                                endpoint2=self.endpoint2)
 
@@ -638,7 +638,7 @@ class AddUnitChange(ChangeInfo):
     def method():
         return "addUnit"
 
-    def description(self):
+    def __str__(self):
         return "add {application} unit to {to}".format(application=self.application,
                                                        to=self.to)
 
@@ -672,7 +672,7 @@ class CreateOfferChange(ChangeInfo):
     def method():
         return "createOffer"
 
-    def description(self):
+    def __str__(self):
         return "create offer {offer_name} using {application}:{endpoints}".format(offer_name=self.offer_name,
                                                                                   application=self.application,
                                                                                   endpoints=self.endpoints.join(","))
@@ -702,7 +702,7 @@ class ConsumeOfferChange(ChangeInfo):
     def method():
         return "consumeOffer"
 
-    def description(self):
+    def __str__(self):
         return "consume offer {application_name} at {url}".format(application_name=self.application_name,
                                                                   url=self.url)
 
@@ -729,7 +729,7 @@ class ExposeChange(ChangeInfo):
     def method():
         return "expose"
 
-    def description(self):
+    def __str__(self):
         return "expose {application}".format(application=self.application)
 
 
@@ -757,7 +757,7 @@ class ScaleChange(ChangeInfo):
     def method():
         return "scale"
 
-    def description(self):
+    def __str__(self):
         return "scale {application} to {scale} units".format(application=self.application,
                                                              scale=self.scale)
 
@@ -791,5 +791,5 @@ class SetAnnotationsChange(ChangeInfo):
     def method():
         return "setAnnotations"
 
-    def description(self):
+    def __str__(self):
         return "set annotations for {id}".format(id=self.id)

--- a/juju/bundle.py
+++ b/juju/bundle.py
@@ -41,6 +41,7 @@ class BundleHandler:
         self.ann_facade = client.AnnotationsFacade.from_connection(
             model.connection())
 
+        # This describes all the change types that the BundleHandler supports.
         change_type_cls = [AddApplicationChange,
                            AddCharmChange,
                            AddMachineChange,
@@ -358,10 +359,18 @@ class AddCharmChange(ChangeInfo):
 
     """AddCharmChange holds a change for adding a charm to the environment.
 
-    :charm: URL of the charm to be added.
-    :series: series of the charm to be added if the charm default is
-        not sufficient.
-    :channel: preferred channel for obtaining the charm.
+    :change_id: id of the change that will be used to identify the current
+        change
+    :requires: is a slice of dependencies that are required to happen.
+    :params: holds the change parameters from the api response. Currently the
+        params could either be a list or a dict. The later being the newer
+        return results.
+
+    Params holds the following values:
+        :charm: URL of the charm to be added.
+        :series: series of the charm to be added if the charm default is
+           not sufficient.
+        :channel: preferred channel for obtaining the charm.
     """
     def __init__(self, change_id, requires, params=None):
         super(AddCharmChange, self).__init__(change_id, requires)
@@ -421,11 +430,19 @@ class AddMachineChange(ChangeInfo):
 
     """AddMachineChange holds a change for adding a machine or container.
 
-    :series: optional machine OS series.
-    :constraints: optional machine constraints.
-    :container_type: optionally type of the container (for instance
-        "lxc" or kvm"). It is not specified for top level machines.
-    :parent_id: id of the parent machine.
+    :change_id: id of the change that will be used to identify the current
+        change
+    :requires: is a slice of dependencies that are required to happen.
+    :params: holds the change parameters from the api response. Currently the
+        params could either be a list or a dict. The later being the newer
+        return results.
+
+    Params holds the following values:
+        :series: optional machine OS series.
+        :constraints: optional machine constraints.
+        :container_type: optionally type of the container (for instance
+            "lxc" or kvm"). It is not specified for top level machines.
+        :parent_id: id of the parent machine.
     """
     def __init__(self, change_id, requires, params=None):
         super(AddMachineChange, self).__init__(change_id, requires)
@@ -498,12 +515,20 @@ class AddRelationChange(ChangeInfo):
     """AddRelationChange holds a change for adding a relation between two
     applications.
 
-    Endpoint1 and Endpoint2 hold relation endpoints in the
-    "application:interface" form, where the application is either a
-    placeholder pointing to an application change or in the case of a model
-    that already has this application deployed, the name of the
-    application, and the interface is optional. Examples are
-    "$deploy-42:web", "$deploy-42", "mysql:db".
+    :change_id: id of the change that will be used to identify the current
+        change
+    :requires: is a slice of dependencies that are required to happen.
+    :params: holds the change parameters from the api response. Currently the
+        params could either be a list or a dict. The later being the newer
+        return results.
+
+    Params holds the following values:
+        Endpoint1 and Endpoint2 hold relation endpoints in the
+        "application:interface" form, where the application is either a
+        placeholder pointing to an application change or in the case of a model
+        that already has this application deployed, the name of the
+        application, and the interface is optional. Examples are
+        "$deploy-42:web", "$deploy-42", "mysql:db".
     """
     def __init__(self, change_id, requires, params=None):
         super(AddRelationChange, self).__init__(change_id, requires)
@@ -545,10 +570,18 @@ class AddUnitChange(ChangeInfo):
              'to': 'to'}
     """AddUnitChange holds a change for adding an application unit.
 
-    :application: application placeholder name for which a unit is
-        added.
-    :to: optional location where to add the unit, as a placeholder
-        pointing to another unit change or to a machine change.
+    :change_id: id of the change that will be used to identify the current
+        change
+    :requires: is a slice of dependencies that are required to happen.
+    :params: holds the change parameters from the api response. Currently the
+        params could either be a list or a dict. The later being the newer
+        return results.
+
+    Params holds the following values:
+        :application: application placeholder name for which a unit is
+            added.
+        :to: optional location where to add the unit, as a placeholder
+            pointing to another unit change or to a machine change.
     """
     def __init__(self, change_id, requires, params=None):
         super(AddUnitChange, self).__init__(change_id, requires)
@@ -604,10 +637,19 @@ class CreateOfferChange(ChangeInfo):
     """CreateOfferChange holds a change for creating a new application endpoint
     offer.
 
-    :application: is the name of the application to create an offer for.
-        added.
-    :endpoint: is a list of application endpoint to expose as part of an offer.
-    :offer_name: describes the offer name.
+    :change_id: id of the change that will be used to identify the current
+        change
+    :requires: is a slice of dependencies that are required to happen.
+    :params: holds the change parameters from the api response. Currently the
+        params could either be a list or a dict. The later being the newer
+        return results.
+
+    Params holds the following values:
+        :application: is the name of the application to create an offer for.
+            added.
+        :endpoint: is a list of application endpoint to expose as part of an
+            offer.
+        :offer_name: describes the offer name.
     """
     def __init__(self, change_id, requires, params=None):
         super(CreateOfferChange, self).__init__(change_id, requires)
@@ -649,8 +691,16 @@ class ConsumeOfferChange(ChangeInfo):
              'application-name': 'application_name'}
     """CreateOfferChange holds a change for consuming a offer.
 
-    :url: contains the location of the offer
-    :application_name: describes the application name on offer.
+    :change_id: id of the change that will be used to identify the current
+        change
+    :requires: is a slice of dependencies that are required to happen.
+    :params: holds the change parameters from the api response. Currently the
+        params could either be a list or a dict. The later being the newer
+        return results.
+
+    Params holds the following values:
+        :url: contains the location of the offer
+        :application_name: describes the application name on offer.
     """
     def __init__(self, change_id, requires, params=None):
         super(ConsumeOfferChange, self).__init__(change_id, requires)
@@ -689,8 +739,16 @@ class ExposeChange(ChangeInfo):
     _toPy = {'application': 'application'}
     """ExposeChange holds a change for exposing an application.
 
-    :application: placeholder name of the application that must be
-        exposed.
+    :change_id: id of the change that will be used to identify the current
+        change
+    :requires: is a slice of dependencies that are required to happen.
+    :params: holds the change parameters from the api response. Currently the
+        params could either be a list or a dict. The later being the newer
+        return results.
+
+    Params holds the following values:
+        :application: placeholder name of the application that must be
+            exposed.
     """
     def __init__(self, change_id, requires, params=None):
         super(ExposeChange, self).__init__(change_id, requires)
@@ -729,8 +787,16 @@ class ScaleChange(ChangeInfo):
     """
     ScaleChange holds a change for scaling an application.
 
-    :application: placeholder name of the application to be scaled.
-    :scale: is the new scale value to use.
+    :change_id: id of the change that will be used to identify the current
+        change
+    :requires: is a slice of dependencies that are required to happen.
+    :params: holds the change parameters from the api response. Currently the
+        params could either be a list or a dict. The later being the newer
+        return results.
+
+    Params holds the following values:
+        :application: placeholder name of the application to be scaled.
+        :scale: is the new scale value to use.
     """
     def __init__(self, change_id, requires, params=None):
         super(ScaleChange, self).__init__(change_id, requires)
@@ -771,10 +837,18 @@ class SetAnnotationsChange(ChangeInfo):
     """SetAnnotationsChange holds a change for setting application and machine
     annotations.
 
-    :id: is the placeholder for the application or machine change corresponding
-        to the entity to be annotated.
-    :entity_type: type of the entity, "application" or "machine".
-    :ennotations: annotations as key/value pairs.
+    :change_id: id of the change that will be used to identify the current
+        change
+    :requires: is a slice of dependencies that are required to happen.
+    :params: holds the change parameters from the api response. Currently the
+        params could either be a list or a dict. The later being the newer
+        return results.
+
+    Params holds the following values:
+        :id: is the placeholder for the application or machine change
+            corresponding to the entity to be annotated.
+        :entity_type: type of the entity, "application" or "machine".
+        :ennotations: annotations as key/value pairs.
     """
     def __init__(self, change_id, requires, params=None):
         super(SetAnnotationsChange, self).__init__(change_id, requires)

--- a/juju/bundle.py
+++ b/juju/bundle.py
@@ -391,13 +391,39 @@ class ChangeSet:
 
 
 class ChangeInfo:
+    _toPy = {}
 
     def __init__(self, change_id, requires):
         self.change_id = change_id
         self.requires = requires
 
+    @classmethod
+    def from_dict(cls, self, data):
+        """
+        from_dict converts a data bag into fields on a class instance.
+        If a value is missing from the data, then None is assigned to the field
+        instance value.
+        """
+        d = (data or {})
+        for k, v in cls._toPy.items():
+            if k in d:
+                setattr(self, v, d[k])
+            else:
+                setattr(self, v, None)
+
 
 class AddApplicationChange(ChangeInfo):
+    _toPy = {'charm': 'charm',
+             'series': 'series',
+             'application': 'application',
+             'options': 'options',
+             'constraints': 'constraints',
+             'storage': 'storage',
+             'devices': 'devices',
+             'endpoint-bindings': 'endpoint_bindings',
+             'resources': 'resources',
+             'num-units': 'num_units'}
+
     """
     AddCharmChange holds a change for deploying a Juju application.
 
@@ -442,16 +468,7 @@ class AddApplicationChange(ChangeInfo):
                 self.num_units = params[9]
 
         elif isinstance(params, dict):
-            self.charm = params["charm"]
-            self.series = params["series"]
-            self.application = params["application"]
-            self.options = params["options"]
-            self.constraints = params["constraints"]
-            self.storage = params["storage"]
-            self.devices = params["devices"]
-            self.endpoint_bindings = params["endpoint-bindings"]
-            self.resources = params["resources"]
-            self.num_units = params["num-units"]
+            AddApplicationChange.from_dict(self, params)
         else:
             raise Exception("unexpected params type")
 
@@ -477,6 +494,10 @@ class AddApplicationChange(ChangeInfo):
 
 
 class AddCharmChange(ChangeInfo):
+    _toPy = {'charm': 'charm',
+             'series': 'series',
+             'channel': 'channel'}
+
     """
     AddCharmChange holds a change for adding a charm to the environment.
 
@@ -496,12 +517,7 @@ class AddCharmChange(ChangeInfo):
             else:
                 self.channel = None
         elif isinstance(params, dict):
-            self.charm = params["charm"]
-            self.series = params["series"]
-            if "channel" in params and params["channel"] != "":
-                self.channel = params["channel"]
-            else:
-                self.channel = None
+            AddCharmChange.from_dict(self, params)
         else:
             raise Exception("unexpected params type")
 
@@ -522,6 +538,11 @@ class AddCharmChange(ChangeInfo):
 
 
 class AddMachineChange(ChangeInfo):
+    _toPy = {'series': 'series',
+             'constraints': 'constraints',
+             'container-type': 'container_type',
+             'parent-id': 'parent_id'}
+
     """
     AddMachineChange holds a change for adding a machine or container.
 
@@ -541,10 +562,7 @@ class AddMachineChange(ChangeInfo):
             self.container_type = options.get("containerType")
             self.parent_id = options.get("parentId")
         elif isinstance(params, dict):
-            self.series = params["series"]
-            self.constraints = params["constraints"]
-            self.container_type = params["container-type"]
-            self.parent_id = params["parent-id"]
+            AddMachineChange.from_dict(self, params)
         else:
             raise Exception("unexpected params type")
 
@@ -561,6 +579,8 @@ class AddMachineChange(ChangeInfo):
 
 
 class AddRelationChange(ChangeInfo):
+    _toPy = {'endpoint1': 'endpoint1',
+             'endpoint2': 'endpoint2'}
     """
     AddRelationChange holds a change for adding a relation between two
     applications.
@@ -579,8 +599,7 @@ class AddRelationChange(ChangeInfo):
             self.endpoint1 = params[0]
             self.endpoint2 = params[1]
         elif isinstance(params, dict):
-            self.endpoint1 = params["endpoint1"]
-            self.endpoint2 = params["endpoint2"]
+            AddRelationChange.from_dict(self, params)
         else:
             raise Exception("unexpected params type")
 
@@ -594,6 +613,8 @@ class AddRelationChange(ChangeInfo):
 
 
 class AddUnitChange(ChangeInfo):
+    _toPy = {'application': 'application',
+             'to': 'to'}
     """
     AddUnitChange holds a change for adding an application unit.
 
@@ -609,8 +630,7 @@ class AddUnitChange(ChangeInfo):
             self.application = params[0]
             self.to = params[1]
         elif isinstance(params, dict):
-            self.application = params["application"]
-            self.to = params["to"]
+            AddUnitChange.from_dict(self, params)
         else:
             raise Exception("unexpected params type")
 
@@ -624,6 +644,9 @@ class AddUnitChange(ChangeInfo):
 
 
 class CreateOfferChange(ChangeInfo):
+    _toPy = {'application': 'application',
+             'endpoints': 'endpoints',
+             'offer-name': 'offer_name'}
     """
     CreateOfferChange holds a change for creating a new application endpoint
     offer.
@@ -641,9 +664,7 @@ class CreateOfferChange(ChangeInfo):
             self.endpoints = params[1]
             self.offer_name = params[2]
         elif isinstance(params, dict):
-            self.application = params["application"]
-            self.endpoints = params["endpoints"]
-            self.offer_name = params["offer-name"]
+            CreateOfferChange.from_dict(self, params)
         else:
             raise Exception("unexpected params type")
 
@@ -658,6 +679,8 @@ class CreateOfferChange(ChangeInfo):
 
 
 class ConsumeOfferChange(ChangeInfo):
+    _toPy = {'url': 'url',
+             'application-name': 'application_name'}
     """
     CreateOfferChange holds a change for consuming a offer.
 
@@ -671,8 +694,7 @@ class ConsumeOfferChange(ChangeInfo):
             self.url = params[0]
             self.application_name = params[1]
         elif isinstance(params, dict):
-            self.url = params["url"]
-            self.application_name = params["application_name"]
+            ConsumeOfferChange.from_dict(self, params)
         else:
             raise Exception("unexpected params type")
 
@@ -686,6 +708,7 @@ class ConsumeOfferChange(ChangeInfo):
 
 
 class ExposeChange(ChangeInfo):
+    _toPy = {'application': 'application'}
     """
     ExposeChange holds a change for exposing an application.
 
@@ -698,7 +721,7 @@ class ExposeChange(ChangeInfo):
         if isinstance(params, list):
             self.application = params[0]
         elif isinstance(params, dict):
-            self.application = params["application"]
+            ExposeChange.from_dict(self, params)
         else:
             raise Exception("unexpected params type")
 
@@ -711,6 +734,8 @@ class ExposeChange(ChangeInfo):
 
 
 class ScaleChange(ChangeInfo):
+    _toPy = {'application': 'application',
+             'scale': 'scale'}
     """
     ScaleChange holds a change for scaling an application.
 
@@ -724,8 +749,7 @@ class ScaleChange(ChangeInfo):
             self.application = params[0]
             self.scale = params[1]
         elif isinstance(params, dict):
-            self.application = params["application"]
-            self.scale = params["scale"]
+            ScaleChange.from_dict(self, params)
         else:
             raise Exception("unexpected params type")
 
@@ -739,6 +763,9 @@ class ScaleChange(ChangeInfo):
 
 
 class SetAnnotationsChange(ChangeInfo):
+    _toPy = {'id': 'id',
+             'entity-type': 'entity_type',
+             'annotations': 'annotations'}
     """
     SetAnnotationsChange holds a change for setting application and machine
     annotations.
@@ -756,9 +783,7 @@ class SetAnnotationsChange(ChangeInfo):
             self.entity_type = params[1]
             self.annotations = params[2]
         elif isinstance(params, dict):
-            self.id = params["id"]
-            self.entity_type = params["entity-type"]
-            self.annotations = params["annotations"]
+            SetAnnotationsChange.from_dict(self, params)
         else:
             raise Exception("unexpected params type")
 

--- a/juju/bundle.py
+++ b/juju/bundle.py
@@ -461,19 +461,22 @@ class AddMachineChange(ChangeInfo):
         # Fix up values, as necessary.
         params = {}
         if self.parent_id is not None:
-            if params['parent_id'].startswith('$addUnit'):
-                unit = context.resolve(params['parent_id'])[0]
+            if self.parent_id.startswith('$addUnit'):
+                unit = context.resolve(self.parent_id)[0]
                 params['parent_id'] = unit.machine.entity_id
             else:
-                params['parent_id'] = context.resolve(params['parent_id'])
+                params['parent_id'] = context.resolve(self.parent_id)
 
         params['constraints'] = parse_constraints(self.constraints)
         params['jobs'] = params.get('jobs', ['JobHostUnits'])
+        params['series'] = self.series
 
         if self.container_type == 'lxc':
             log.warning('Juju 2.0 does not support lxc containers. '
                         'Converting containers to lxd.')
             params['container_type'] = 'lxd'
+        else:
+            params['container_type'] = self.container_type
 
         # Submit the request.
         params = client.AddMachineParams(**params)

--- a/juju/client/facade.py
+++ b/juju/client/facade.py
@@ -593,6 +593,15 @@ class Type:
     def connect(self, connection):
         self.connection = connection
 
+    def __repr__(self):
+        return "{}({})".format(self.__class__, self.__dict__)
+
+    def __eq__(self, other):
+        if not isinstance(other, Type):
+            return NotImplemented
+
+        return self.__dict__ == other.__dict__
+
     async def rpc(self, msg):
         result = await self.connection.rpc(msg, encoder=TypeEncoder)
         return result

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -497,7 +497,7 @@ class TestCreateOfferChangeRun:
         context.model = model
 
         result = await change.run(context)
-        assert result == None
+        assert result is None
 
         model.create_offer.assert_called_once()
         model.create_offer.assert_called_with("endpoints",
@@ -548,7 +548,7 @@ class TestConsumeOfferChangeRun:
         context.model = model
 
         result = await change.run(context)
-        assert result == None
+        assert result is None
 
         model.consume.assert_called_once()
         model.consume.assert_called_with("url",
@@ -595,7 +595,7 @@ class TestExposeChangeRun:
         context.model = model
 
         result = await change.run(context)
-        assert result == None
+        assert result is None
 
         model.applications["application1"].expose.assert_called_once()
 
@@ -645,7 +645,7 @@ class TestScaleChangeRun:
         context.model = model
 
         result = await change.run(context)
-        assert result == None
+        assert result is None
 
         model.applications["application1"].scale.assert_called_once()
         model.applications["application1"].scale.assert_called_with(scale=1)

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -123,6 +123,26 @@ class TestAddApplicationChange(unittest.TestCase):
                           "devices": "devices",
                           "num_units": "num_units"}, change.__dict__)
 
+    def test_dict_params_missing_data(self):
+        change = AddApplicationChange(1, [], params={"charm": "charm",
+                                                     "series": "series",
+                                                     "application": "application",
+                                                     "options": "options",
+                                                     "constraints": "constraints",
+                                                     "storage": "storage"})
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "charm": "charm",
+                          "series": "series",
+                          "application": "application",
+                          "options": "options",
+                          "constraints": "constraints",
+                          "storage": "storage",
+                          "endpoint_bindings": None,
+                          "resources": None,
+                          "devices": None,
+                          "num_units": None}, change.__dict__)
+
 
 class TestAddCharmChange(unittest.TestCase):
 
@@ -158,6 +178,15 @@ class TestAddCharmChange(unittest.TestCase):
                           "series": "series",
                           "channel": "channel"}, change.__dict__)
 
+    def test_dict_params_missing_data(self):
+        change = AddCharmChange(1, [], params={"charm": "charm",
+                                               "series": "series"})
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "charm": "charm",
+                          "series": "series",
+                          "channel": None}, change.__dict__)
+
 
 class TestAddMachineChange(unittest.TestCase):
 
@@ -188,6 +217,17 @@ class TestAddMachineChange(unittest.TestCase):
                           "container_type": "container_type",
                           "parent_id": "parent_id"}, change.__dict__)
 
+    def test_dict_params_missing_data(self):
+        change = AddMachineChange(1, [], params={"series": "series",
+                                                 "constraints": "constraints",
+                                                 "container-type": "container_type"})
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "series": "series",
+                          "constraints": "constraints",
+                          "container_type": "container_type",
+                          "parent_id": None}, change.__dict__)
+
 
 class TestAddRelationChange(unittest.TestCase):
 
@@ -209,6 +249,13 @@ class TestAddRelationChange(unittest.TestCase):
                           "endpoint1": "endpoint1",
                           "endpoint2": "endpoint2"}, change.__dict__)
 
+    def test_dict_params_missing_data(self):
+        change = AddRelationChange(1, [], params={"endpoint1": "endpoint1"})
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "endpoint1": "endpoint1",
+                          "endpoint2": None}, change.__dict__)
+
 
 class TestAddUnitChange(unittest.TestCase):
 
@@ -229,6 +276,13 @@ class TestAddUnitChange(unittest.TestCase):
                           "requires": [],
                           "application": "application",
                           "to": "to"}, change.__dict__)
+
+    def test_dict_params_missing_data(self):
+        change = AddUnitChange(1, [], params={"application": "application"})
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "application": "application",
+                          "to": None}, change.__dict__)
 
 
 class TestCreateOfferChange(unittest.TestCase):
@@ -254,6 +308,15 @@ class TestCreateOfferChange(unittest.TestCase):
                           "endpoints": "endpoints",
                           "offer_name": "offer_name"}, change.__dict__)
 
+    def test_dict_params_missing_data(self):
+        change = CreateOfferChange(1, [], params={"application": "application",
+                                                  "endpoints": "endpoints"})
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "application": "application",
+                          "endpoints": "endpoints",
+                          "offer_name": None}, change.__dict__)
+
 
 class TestConsumeOfferChange(unittest.TestCase):
 
@@ -269,11 +332,18 @@ class TestConsumeOfferChange(unittest.TestCase):
 
     def test_dict_params(self):
         change = ConsumeOfferChange(1, [], params={"url": "url",
-                                                   "application_name": "application_name"})
+                                                   "application-name": "application_name"})
         self.assertEqual({"change_id": 1,
                           "requires": [],
                           "url": "url",
                           "application_name": "application_name"}, change.__dict__)
+
+    def test_dict_params_missing_data(self):
+        change = ConsumeOfferChange(1, [], params={"url": "url"})
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "url": "url",
+                          "application_name": None}, change.__dict__)
 
 
 class TestExposeChange(unittest.TestCase):
@@ -292,6 +362,12 @@ class TestExposeChange(unittest.TestCase):
         self.assertEqual({"change_id": 1,
                           "requires": [],
                           "application": "application"}, change.__dict__)
+
+    def test_dict_params_missing_data(self):
+        change = ExposeChange(1, [], params={})
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "application": None}, change.__dict__)
 
 
 class TestScaleChange(unittest.TestCase):
@@ -313,6 +389,13 @@ class TestScaleChange(unittest.TestCase):
                           "requires": [],
                           "application": "application",
                           "scale": "scale"}, change.__dict__)
+
+    def test_dict_params_missing_data(self):
+        change = ScaleChange(1, [], params={"application": "application"})
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "application": "application",
+                          "scale": None}, change.__dict__)
 
 
 class TestSetAnnotationsChange(unittest.TestCase):
@@ -337,3 +420,12 @@ class TestSetAnnotationsChange(unittest.TestCase):
                           "id": "id",
                           "entity_type": "entity_type",
                           "annotations": "annotations"}, change.__dict__)
+
+    def test_dict_params_missing_data(self):
+        change = SetAnnotationsChange(1, [], params={"id": "id",
+                                                     "entity-type": "entity_type"})
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "id": "id",
+                          "entity_type": "entity_type",
+                          "annotations": None}, change.__dict__)

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -1,6 +1,9 @@
 import unittest
 
-from juju.bundle import ChangeSet
+from juju.bundle import (AddApplicationChange, AddCharmChange,
+                         AddMachineChange, AddRelationChange, AddUnitChange,
+                         ChangeSet, ConsumeOfferChange, CreateOfferChange,
+                         ExposeChange, ScaleChange, SetAnnotationsChange)
 from juju.client import client
 from toposort import CircularDependencyError
 
@@ -43,3 +46,294 @@ class TestChangeSet(unittest.TestCase):
 
         changeset = ChangeSet([a, b])
         self.assertRaises(CircularDependencyError, changeset.sorted)
+
+
+class TestAddApplicationChange(unittest.TestCase):
+
+    def test_method(self):
+        self.assertEqual("deploy", AddApplicationChange.method())
+
+    def test_list_params_juju_2_4(self):
+        change = AddApplicationChange(1, [], params=["charm",
+                                                     "series",
+                                                     "application",
+                                                     "options",
+                                                     "constraints",
+                                                     "storage",
+                                                     "endpoint_bindings",
+                                                     "resources"])
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "charm": "charm",
+                          "series": "series",
+                          "application": "application",
+                          "options": "options",
+                          "constraints": "constraints",
+                          "storage": "storage",
+                          "endpoint_bindings": "endpoint_bindings",
+                          "resources": "resources",
+                          "devices": None,
+                          "num_units": None}, change.__dict__)
+
+    def test_list_params_juju_2_5(self):
+        change = AddApplicationChange(1, [], params=["charm",
+                                                     "series",
+                                                     "application",
+                                                     "options",
+                                                     "constraints",
+                                                     "storage",
+                                                     "endpoint_bindings",
+                                                     "devices",
+                                                     "resources",
+                                                     "num_units"])
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "charm": "charm",
+                          "series": "series",
+                          "application": "application",
+                          "options": "options",
+                          "constraints": "constraints",
+                          "storage": "storage",
+                          "endpoint_bindings": "endpoint_bindings",
+                          "resources": "resources",
+                          "devices": "devices",
+                          "num_units": "num_units"}, change.__dict__)
+
+    def test_dict_params(self):
+        change = AddApplicationChange(1, [], params={"charm": "charm",
+                                                     "series": "series",
+                                                     "application": "application",
+                                                     "options": "options",
+                                                     "constraints": "constraints",
+                                                     "storage": "storage",
+                                                     "endpoint-bindings": "endpoint_bindings",
+                                                     "resources": "resources",
+                                                     "devices": "devices",
+                                                     "num-units": "num_units"})
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "charm": "charm",
+                          "series": "series",
+                          "application": "application",
+                          "options": "options",
+                          "constraints": "constraints",
+                          "storage": "storage",
+                          "endpoint_bindings": "endpoint_bindings",
+                          "resources": "resources",
+                          "devices": "devices",
+                          "num_units": "num_units"}, change.__dict__)
+
+
+class TestAddCharmChange(unittest.TestCase):
+
+    def test_method(self):
+        self.assertEqual("addCharm", AddCharmChange.method())
+
+    def test_list_params_juju_2_6(self):
+        change = AddCharmChange(1, [], params=["charm",
+                                               "series"])
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "charm": "charm",
+                          "series": "series",
+                          "channel": None}, change.__dict__)
+
+    def test_list_params_juju_2_7(self):
+        change = AddCharmChange(1, [], params=["charm",
+                                               "series",
+                                               "channel"])
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "charm": "charm",
+                          "series": "series",
+                          "channel": "channel"}, change.__dict__)
+
+    def test_dict_params(self):
+        change = AddCharmChange(1, [], params={"charm": "charm",
+                                               "series": "series",
+                                               "channel": "channel"})
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "charm": "charm",
+                          "series": "series",
+                          "channel": "channel"}, change.__dict__)
+
+
+class TestAddMachineChange(unittest.TestCase):
+
+    def test_method(self):
+        self.assertEqual("addMachines", AddMachineChange.method())
+
+    def test_list_params(self):
+        change = AddMachineChange(1, [], params=[{"series": "series",
+                                                  "constraints": "constraints",
+                                                  "containerType": "container_type",
+                                                  "parentId": "parent_id"}])
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "series": "series",
+                          "constraints": "constraints",
+                          "container_type": "container_type",
+                          "parent_id": "parent_id"}, change.__dict__)
+
+    def test_dict_params(self):
+        change = AddMachineChange(1, [], params={"series": "series",
+                                                 "constraints": "constraints",
+                                                 "container-type": "container_type",
+                                                 "parent-id": "parent_id"})
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "series": "series",
+                          "constraints": "constraints",
+                          "container_type": "container_type",
+                          "parent_id": "parent_id"}, change.__dict__)
+
+
+class TestAddRelationChange(unittest.TestCase):
+
+    def test_method(self):
+        self.assertEqual("addRelation", AddRelationChange.method())
+
+    def test_list_params(self):
+        change = AddRelationChange(1, [], params=["endpoint1", "endpoint2"])
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "endpoint1": "endpoint1",
+                          "endpoint2": "endpoint2"}, change.__dict__)
+
+    def test_dict_params(self):
+        change = AddRelationChange(1, [], params={"endpoint1": "endpoint1",
+                                                  "endpoint2": "endpoint2"})
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "endpoint1": "endpoint1",
+                          "endpoint2": "endpoint2"}, change.__dict__)
+
+
+class TestAddUnitChange(unittest.TestCase):
+
+    def test_method(self):
+        self.assertEqual("addUnit", AddUnitChange.method())
+
+    def test_list_params(self):
+        change = AddUnitChange(1, [], params=["application", "to"])
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "application": "application",
+                          "to": "to"}, change.__dict__)
+
+    def test_dict_params(self):
+        change = AddUnitChange(1, [], params={"application": "application",
+                                              "to": "to"})
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "application": "application",
+                          "to": "to"}, change.__dict__)
+
+
+class TestCreateOfferChange(unittest.TestCase):
+
+    def test_method(self):
+        self.assertEqual("createOffer", CreateOfferChange.method())
+
+    def test_list_params(self):
+        change = CreateOfferChange(1, [], params=["application", "endpoints", "offer_name"])
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "application": "application",
+                          "endpoints": "endpoints",
+                          "offer_name": "offer_name"}, change.__dict__)
+
+    def test_dict_params(self):
+        change = CreateOfferChange(1, [], params={"application": "application",
+                                                  "endpoints": "endpoints",
+                                                  "offer-name": "offer_name"})
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "application": "application",
+                          "endpoints": "endpoints",
+                          "offer_name": "offer_name"}, change.__dict__)
+
+
+class TestConsumeOfferChange(unittest.TestCase):
+
+    def test_method(self):
+        self.assertEqual("consumeOffer", ConsumeOfferChange.method())
+
+    def test_list_params(self):
+        change = ConsumeOfferChange(1, [], params=["url", "application_name"])
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "url": "url",
+                          "application_name": "application_name"}, change.__dict__)
+
+    def test_dict_params(self):
+        change = ConsumeOfferChange(1, [], params={"url": "url",
+                                                   "application_name": "application_name"})
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "url": "url",
+                          "application_name": "application_name"}, change.__dict__)
+
+
+class TestExposeChange(unittest.TestCase):
+
+    def test_method(self):
+        self.assertEqual("expose", ExposeChange.method())
+
+    def test_list_params(self):
+        change = ExposeChange(1, [], params=["application"])
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "application": "application"}, change.__dict__)
+
+    def test_dict_params(self):
+        change = ExposeChange(1, [], params={"application": "application"})
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "application": "application"}, change.__dict__)
+
+
+class TestScaleChange(unittest.TestCase):
+
+    def test_method(self):
+        self.assertEqual("scale", ScaleChange.method())
+
+    def test_list_params(self):
+        change = ScaleChange(1, [], params=["application", "scale"])
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "application": "application",
+                          "scale": "scale"}, change.__dict__)
+
+    def test_dict_params(self):
+        change = ScaleChange(1, [], params={"application": "application",
+                                            "scale": "scale"})
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "application": "application",
+                          "scale": "scale"}, change.__dict__)
+
+
+class TestSetAnnotationsChange(unittest.TestCase):
+
+    def test_method(self):
+        self.assertEqual("setAnnotations", SetAnnotationsChange.method())
+
+    def test_list_params(self):
+        change = SetAnnotationsChange(1, [], params=["id", "entity_type", "annotations"])
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "id": "id",
+                          "entity_type": "entity_type",
+                          "annotations": "annotations"}, change.__dict__)
+
+    def test_dict_params(self):
+        change = SetAnnotationsChange(1, [], params={"id": "id",
+                                                     "entity-type": "entity_type",
+                                                     "annotations": "annotations"})
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "id": "id",
+                          "entity_type": "entity_type",
+                          "annotations": "annotations"}, change.__dict__)


### PR DESCRIPTION
The following adds a set of bundle changes classes as a way to
abstract the possible issue where breakages upstream cause chaos
downstream.

This is an idea and the real fix is to make sure that juju itself
correctly handles those changes.

The benefit of doing it this way is that we have similar set of
abstractions to the golang source, making it more familiar to all.