### PR TITLE
Bump pyyaml dependency version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     install_requires=[
         'macaroonbakery>=1.1,<2.0',
         'pyRFC3339>=1.0,<2.0',
-        'pyyaml>=3.0,<=4.2',
+        'pyyaml>=5.1.2,<=6.0',
         'theblues>=0.5.1,<1.0',
         'websockets>=7.0,<8.0',
         'paramiko>=2.4.0,<3.0.0',


### PR DESCRIPTION
There is a CVE against pyyaml <5.1 and since pyyaml 4 was never actually released (only prereleases) anyone including this library would bring in the vulnerable pyyaml. This patch bumps it to the current blessed release and subsequently addresses the CVE https://nvd.nist.gov/vuln/detail/CVE-2017-18342