### PR TITLE
BundleHandler uses GetChangesMapArgs when available

### DIFF
--- a/juju/bundle.py
+++ b/juju/bundle.py
@@ -135,9 +135,15 @@ class BundleHandler:
         self.bundle = await self._validate_bundle(self.bundle)
         self.bundle = await self._handle_local_charms(self.bundle)
 
-        self.plan = await self.bundle_facade.GetChanges(
-            bundleurl=entity_id,
-            yaml=yaml.dump(self.bundle))
+        if client.BundleFacade.best_facade_version(self.model.connection()) < 4:
+            self.plan = await self.bundle_facade.GetChanges(
+                bundleurl=entity_id,
+                yaml=yaml.dump(self.bundle))
+        else:
+            log.info("bundle_facade using GetChangesMapArgs API to deploy bundle changes")
+            self.plan = await self.bundle_facade.GetChangesMapArgs(
+                bundleurl=entity_id,
+                yaml=yaml.dump(self.bundle))
 
         if self.plan.errors:
             raise JujuError(self.plan.errors)

--- a/juju/client/_client.py
+++ b/juju/client/_client.py
@@ -3,20 +3,20 @@
 
 from juju.client._definitions import *
 
-from juju.client import _client1, _client2, _client3, _client4, _client5, _client6, _client7, _client8, _client9, _client10, _client12
+from juju.client import _client2, _client1, _client3, _client4, _client5, _client8, _client7, _client9, _client10, _client6, _client12
 
 
 CLIENTS = {
-    "1": _client1,
     "2": _client2,
+    "1": _client1,
     "3": _client3,
     "4": _client4,
     "5": _client5,
-    "6": _client6,
-    "7": _client7,
     "8": _client8,
+    "7": _client7,
     "9": _client9,
     "10": _client10,
+    "6": _client6,
     "12": _client12
 }
 

--- a/juju/client/_client1.py
+++ b/juju/client/_client1.py
@@ -46,7 +46,7 @@ class ActionPrunerFacade(Type):
     async def ModelConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -155,7 +155,7 @@ class AllWatcherFacade(Type):
     async def Next(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~Delta]<~Delta>
+        Returns -> typing.Sequence[~Delta]
         '''
 
         # map input types to rpc msg
@@ -319,8 +319,8 @@ class ApplicationScalerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Rescale(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -341,7 +341,7 @@ class ApplicationScalerFacade(Type):
     async def Watch(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[str], _ForwardRef('Error')]
+        Returns -> typing.Union[typing.Sequence[str], _ForwardRef('Error'), str]
         '''
 
         # map input types to rpc msg
@@ -512,7 +512,7 @@ class BackupsFacade(Type):
     async def List(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~BackupsMetadataResult]<~BackupsMetadataResult>
+        Returns -> typing.Sequence[~BackupsMetadataResult]
         '''
 
         # map input types to rpc msg
@@ -624,7 +624,7 @@ class BundleFacade(Type):
     async def GetChanges(self, yaml=None):
         '''
         yaml : str
-        Returns -> typing.Sequence<+T_co>[~BundleChange]<~BundleChange>
+        Returns -> typing.Union[typing.Sequence[~BundleChange], typing.Sequence[str]]
         '''
         if yaml is not None and not isinstance(yaml, (bytes, str)):
             raise Exception("Expected yaml to be a str, received: {}".format(type(yaml)))
@@ -749,8 +749,8 @@ class CAASAgentFacade(Type):
     @ReturnMapping(CloudSpecResults)
     async def CloudSpec(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~CloudSpecResult]<~CloudSpecResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~CloudSpecResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -770,8 +770,8 @@ class CAASAgentFacade(Type):
     @ReturnMapping(ControllerAPIInfoResults)
     async def ControllerAPIInfoForModels(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ControllerAPIInfoResult]<~ControllerAPIInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ControllerAPIInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -792,7 +792,7 @@ class CAASAgentFacade(Type):
     async def ControllerConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -830,7 +830,7 @@ class CAASAgentFacade(Type):
     async def ModelConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -848,8 +848,8 @@ class CAASAgentFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchCloudSpecsChanges(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -974,8 +974,8 @@ class CAASFirewallerFacade(Type):
     @ReturnMapping(ApplicationGetConfigResults)
     async def ApplicationsConfig(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ConfigResult]<~ConfigResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ConfigResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -995,8 +995,8 @@ class CAASFirewallerFacade(Type):
     @ReturnMapping(BoolResults)
     async def IsExposed(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~BoolResult]<~BoolResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~BoolResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1016,8 +1016,8 @@ class CAASFirewallerFacade(Type):
     @ReturnMapping(LifeResults)
     async def Life(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1037,8 +1037,8 @@ class CAASFirewallerFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def Watch(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1059,7 +1059,7 @@ class CAASFirewallerFacade(Type):
     async def WatchApplications(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[str], _ForwardRef('Error')]
+        Returns -> typing.Union[typing.Sequence[str], _ForwardRef('Error'), str]
         '''
 
         # map input types to rpc msg
@@ -1309,7 +1309,7 @@ class CAASOperatorFacade(Type):
     async def APIAddresses(self):
         '''
 
-        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence<+T_co>[str]]
+        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence[str]]
         '''
 
         # map input types to rpc msg
@@ -1328,7 +1328,7 @@ class CAASOperatorFacade(Type):
     async def APIHostPorts(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~HostPort]<~HostPort>
+        Returns -> typing.Sequence[~HostPort]
         '''
 
         # map input types to rpc msg
@@ -1346,8 +1346,8 @@ class CAASOperatorFacade(Type):
     @ReturnMapping(ApplicationCharmResults)
     async def Charm(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ApplicationCharmResult]<~ApplicationCharmResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ApplicationCharmResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1386,8 +1386,8 @@ class CAASOperatorFacade(Type):
     @ReturnMapping(LifeResults)
     async def Life(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1426,8 +1426,8 @@ class CAASOperatorFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Remove(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1447,8 +1447,8 @@ class CAASOperatorFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetPodSpec(self, specs=None):
         '''
-        specs : typing.Sequence<+T_co>[~EntityString]<~EntityString>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        specs : typing.Sequence[~EntityString]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if specs is not None and not isinstance(specs, (bytes, str, list)):
             raise Exception("Expected specs to be a Sequence, received: {}".format(type(specs)))
@@ -1468,8 +1468,8 @@ class CAASOperatorFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1489,8 +1489,8 @@ class CAASOperatorFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetTools(self, agent_tools=None):
         '''
-        agent_tools : typing.Sequence<+T_co>[~EntityVersion]<~EntityVersion>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        agent_tools : typing.Sequence[~EntityVersion]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if agent_tools is not None and not isinstance(agent_tools, (bytes, str, list)):
             raise Exception("Expected agent_tools to be a Sequence, received: {}".format(type(agent_tools)))
@@ -1510,8 +1510,8 @@ class CAASOperatorFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def Watch(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1550,8 +1550,8 @@ class CAASOperatorFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchUnits(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1736,7 +1736,7 @@ class CAASOperatorProvisionerFacade(Type):
     async def APIAddresses(self):
         '''
 
-        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence<+T_co>[str]]
+        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence[str]]
         '''
 
         # map input types to rpc msg
@@ -1755,7 +1755,7 @@ class CAASOperatorProvisionerFacade(Type):
     async def APIHostPorts(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~HostPort]<~HostPort>
+        Returns -> typing.Sequence[~HostPort]
         '''
 
         # map input types to rpc msg
@@ -1773,8 +1773,8 @@ class CAASOperatorProvisionerFacade(Type):
     @ReturnMapping(LifeResults)
     async def Life(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1814,7 +1814,7 @@ class CAASOperatorProvisionerFacade(Type):
     async def OperatorProvisioningInfo(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[str], _ForwardRef('KubernetesFilesystemParams'), typing.Mapping<~KT, +VT_co>[str, str], _ForwardRef('Number')]
+        Returns -> typing.Union[typing.Sequence[str], _ForwardRef('KubernetesFilesystemParams'), str, typing.Mapping[str, str], _ForwardRef('Number')]
         '''
 
         # map input types to rpc msg
@@ -1832,8 +1832,8 @@ class CAASOperatorProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetPasswords(self, changes=None):
         '''
-        changes : typing.Sequence<+T_co>[~EntityPassword]<~EntityPassword>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        changes : typing.Sequence[~EntityPassword]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if changes is not None and not isinstance(changes, (bytes, str, list)):
             raise Exception("Expected changes to be a Sequence, received: {}".format(type(changes)))
@@ -1873,7 +1873,7 @@ class CAASOperatorProvisionerFacade(Type):
     async def WatchApplications(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[str], _ForwardRef('Error')]
+        Returns -> typing.Union[typing.Sequence[str], _ForwardRef('Error'), str]
         '''
 
         # map input types to rpc msg
@@ -2283,8 +2283,8 @@ class CAASUnitProvisionerFacade(Type):
     @ReturnMapping(ApplicationGetConfigResults)
     async def ApplicationsConfig(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ConfigResult]<~ConfigResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ConfigResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2304,8 +2304,8 @@ class CAASUnitProvisionerFacade(Type):
     @ReturnMapping(IntResults)
     async def ApplicationsScale(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~IntResult]<~IntResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~IntResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2325,8 +2325,8 @@ class CAASUnitProvisionerFacade(Type):
     @ReturnMapping(LifeResults)
     async def Life(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2346,8 +2346,8 @@ class CAASUnitProvisionerFacade(Type):
     @ReturnMapping(KubernetesProvisioningInfoResults)
     async def ProvisioningInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~KubernetesProvisioningInfoResult]<~KubernetesProvisioningInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~KubernetesProvisioningInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2367,8 +2367,8 @@ class CAASUnitProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetOperatorStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2388,8 +2388,8 @@ class CAASUnitProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UpdateApplicationsService(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~UpdateApplicationServiceArg]<~UpdateApplicationServiceArg>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~UpdateApplicationServiceArg]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -2409,8 +2409,8 @@ class CAASUnitProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UpdateApplicationsUnits(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~UpdateApplicationUnits]<~UpdateApplicationUnits>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~UpdateApplicationUnits]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -2431,7 +2431,7 @@ class CAASUnitProvisionerFacade(Type):
     async def WatchApplications(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[str], _ForwardRef('Error')]
+        Returns -> typing.Union[typing.Sequence[str], _ForwardRef('Error'), str]
         '''
 
         # map input types to rpc msg
@@ -2449,8 +2449,8 @@ class CAASUnitProvisionerFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchApplicationsScale(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2470,8 +2470,8 @@ class CAASUnitProvisionerFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchPodSpec(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3235,7 +3235,7 @@ class ClientFacade(Type):
     async def APIHostPorts(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~HostPort]<~HostPort>
+        Returns -> typing.Sequence[~HostPort]
         '''
 
         # map input types to rpc msg
@@ -3329,8 +3329,8 @@ class ClientFacade(Type):
     @ReturnMapping(AddMachinesResults)
     async def AddMachines(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~AddMachineParams]<~AddMachineParams>
-        Returns -> typing.Sequence<+T_co>[~AddMachinesResult]<~AddMachinesResult>
+        params : typing.Sequence[~AddMachineParams]
+        Returns -> typing.Sequence[~AddMachinesResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -3350,8 +3350,8 @@ class ClientFacade(Type):
     @ReturnMapping(AddMachinesResults)
     async def AddMachinesV2(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~AddMachineParams]<~AddMachineParams>
-        Returns -> typing.Sequence<+T_co>[~AddMachinesResult]<~AddMachinesResult>
+        params : typing.Sequence[~AddMachineParams]
+        Returns -> typing.Sequence[~AddMachinesResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -3391,7 +3391,7 @@ class ClientFacade(Type):
     async def CACert(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[int]
+        Returns -> typing.Sequence[int]
         '''
 
         # map input types to rpc msg
@@ -3410,7 +3410,7 @@ class ClientFacade(Type):
     async def DestroyMachines(self, force=None, machine_names=None):
         '''
         force : bool
-        machine_names : typing.Sequence<+T_co>[str]
+        machine_names : typing.Sequence[str]
         Returns -> None
         '''
         if force is not None and not isinstance(force, bool):
@@ -3440,7 +3440,7 @@ class ClientFacade(Type):
         minor : int
         number : Number
         series : str
-        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence<+T_co>[~Tools]<~Tools>]
+        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence[~Tools]]
         '''
         if arch is not None and not isinstance(arch, (bytes, str)):
             raise Exception("Expected arch to be a str, received: {}".format(type(arch)))
@@ -3476,8 +3476,8 @@ class ClientFacade(Type):
     @ReturnMapping(FullStatus)
     async def FullStatus(self, patterns=None):
         '''
-        patterns : typing.Sequence<+T_co>[str]
-        Returns -> typing.Union[_ForwardRef('ModelStatusInfo'), typing.Sequence<+T_co>[~RelationStatus]<~RelationStatus>, typing.Mapping<~KT, +VT_co>[str, ~RemoteApplicationStatus]<~RemoteApplicationStatus>]
+        patterns : typing.Sequence[str]
+        Returns -> typing.Union[typing.Mapping[str, ~ApplicationStatus], typing.Mapping[str, ~MachineStatus], _ForwardRef('ModelStatusInfo'), typing.Sequence[~RelationStatus], typing.Mapping[str, ~RemoteApplicationStatus]]
         '''
         if patterns is not None and not isinstance(patterns, (bytes, str, list)):
             raise Exception("Expected patterns to be a Sequence, received: {}".format(type(patterns)))
@@ -3498,7 +3498,7 @@ class ClientFacade(Type):
     async def GetBundleChanges(self, yaml=None):
         '''
         yaml : str
-        Returns -> typing.Sequence<+T_co>[~BundleChange]<~BundleChange>
+        Returns -> typing.Union[typing.Sequence[~BundleChange], typing.Sequence[str]]
         '''
         if yaml is not None and not isinstance(yaml, (bytes, str)):
             raise Exception("Expected yaml to be a str, received: {}".format(type(yaml)))
@@ -3537,8 +3537,8 @@ class ClientFacade(Type):
     @ReturnMapping(AddMachinesResults)
     async def InjectMachines(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~AddMachineParams]<~AddMachineParams>
-        Returns -> typing.Sequence<+T_co>[~AddMachinesResult]<~AddMachinesResult>
+        params : typing.Sequence[~AddMachineParams]
+        Returns -> typing.Sequence[~AddMachinesResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -3559,7 +3559,7 @@ class ClientFacade(Type):
     async def ModelGet(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~ConfigValue]<~ConfigValue>
+        Returns -> typing.Mapping[str, ~ConfigValue]
         '''
 
         # map input types to rpc msg
@@ -3578,7 +3578,7 @@ class ClientFacade(Type):
     async def ModelInfo(self):
         '''
 
-        Returns -> typing.Union[_ForwardRef('Number'), _ForwardRef('ModelMigrationStatus'), _ForwardRef('ModelSLAInfo'), _ForwardRef('EntityStatus'), typing.Sequence<+T_co>[~ModelUserInfo]<~ModelUserInfo>]
+        Returns -> typing.Union[_ForwardRef('Number'), str, typing.Sequence[~ModelMachineInfo], _ForwardRef('ModelMigrationStatus'), _ForwardRef('ModelSLAInfo'), _ForwardRef('EntityStatus'), typing.Sequence[~ModelUserInfo]]
         '''
 
         # map input types to rpc msg
@@ -3596,7 +3596,7 @@ class ClientFacade(Type):
     @ReturnMapping(None)
     async def ModelSet(self, config=None):
         '''
-        config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        config : typing.Mapping[str, typing.Any]
         Returns -> None
         '''
         if config is not None and not isinstance(config, dict):
@@ -3617,7 +3617,7 @@ class ClientFacade(Type):
     @ReturnMapping(None)
     async def ModelUnset(self, keys=None):
         '''
-        keys : typing.Sequence<+T_co>[str]
+        keys : typing.Sequence[str]
         Returns -> None
         '''
         if keys is not None and not isinstance(keys, (bytes, str, list)):
@@ -3639,7 +3639,7 @@ class ClientFacade(Type):
     async def ModelUserInfo(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~ModelUserInfoResult]<~ModelUserInfoResult>
+        Returns -> typing.Sequence[~ModelUserInfoResult]
         '''
 
         # map input types to rpc msg
@@ -3735,8 +3735,8 @@ class ClientFacade(Type):
     @ReturnMapping(ResolveCharmResults)
     async def ResolveCharms(self, references=None):
         '''
-        references : typing.Sequence<+T_co>[str]
-        Returns -> typing.Sequence<+T_co>[~ResolveCharmResult]<~ResolveCharmResult>
+        references : typing.Sequence[str]
+        Returns -> typing.Sequence[~ResolveCharmResult]
         '''
         if references is not None and not isinstance(references, (bytes, str, list)):
             raise Exception("Expected references to be a Sequence, received: {}".format(type(references)))
@@ -3782,8 +3782,8 @@ class ClientFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RetryProvisioning(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3870,7 +3870,7 @@ class ClientFacade(Type):
     async def SetSLALevel(self, modelslainfo=None, creds=None):
         '''
         modelslainfo : ModelSLAInfo
-        creds : typing.Sequence<+T_co>[int]
+        creds : typing.Sequence[int]
         Returns -> None
         '''
         if modelslainfo is not None and not isinstance(modelslainfo, (dict, ModelSLAInfo)):
@@ -3895,8 +3895,8 @@ class ClientFacade(Type):
     @ReturnMapping(StatusHistoryResults)
     async def StatusHistory(self, requests=None):
         '''
-        requests : typing.Sequence<+T_co>[~StatusHistoryRequest]<~StatusHistoryRequest>
-        Returns -> typing.Sequence<+T_co>[~StatusHistoryResult]<~StatusHistoryResult>
+        requests : typing.Sequence[~StatusHistoryRequest]
+        Returns -> typing.Sequence[~StatusHistoryResult]
         '''
         if requests is not None and not isinstance(requests, (bytes, str, list)):
             raise Exception("Expected requests to be a Sequence, received: {}".format(type(requests)))
@@ -4121,8 +4121,8 @@ class CloudFacade(Type):
     @ReturnMapping(CloudResults)
     async def Cloud(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~CloudResult]<~CloudResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~CloudResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4143,7 +4143,7 @@ class CloudFacade(Type):
     async def Clouds(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~Cloud]<~Cloud>
+        Returns -> typing.Mapping[str, ~Cloud]
         '''
 
         # map input types to rpc msg
@@ -4161,8 +4161,8 @@ class CloudFacade(Type):
     @ReturnMapping(CloudCredentialResults)
     async def Credential(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~CloudCredentialResult]<~CloudCredentialResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~CloudCredentialResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4201,8 +4201,8 @@ class CloudFacade(Type):
     @ReturnMapping(InstanceTypesResults)
     async def InstanceTypes(self, constraints=None):
         '''
-        constraints : typing.Sequence<+T_co>[~CloudInstanceTypesConstraint]<~CloudInstanceTypesConstraint>
-        Returns -> typing.Sequence<+T_co>[~InstanceTypesResult]<~InstanceTypesResult>
+        constraints : typing.Sequence[~CloudInstanceTypesConstraint]
+        Returns -> typing.Sequence[~InstanceTypesResult]
         '''
         if constraints is not None and not isinstance(constraints, (bytes, str, list)):
             raise Exception("Expected constraints to be a Sequence, received: {}".format(type(constraints)))
@@ -4222,8 +4222,8 @@ class CloudFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RevokeCredentials(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4243,8 +4243,8 @@ class CloudFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UpdateCredentials(self, credentials=None):
         '''
-        credentials : typing.Sequence<+T_co>[~UpdateCloudCredential]<~UpdateCloudCredential>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        credentials : typing.Sequence[~UpdateCloudCredential]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if credentials is not None and not isinstance(credentials, (bytes, str, list)):
             raise Exception("Expected credentials to be a Sequence, received: {}".format(type(credentials)))
@@ -4264,8 +4264,8 @@ class CloudFacade(Type):
     @ReturnMapping(StringsResults)
     async def UserCredentials(self, user_clouds=None):
         '''
-        user_clouds : typing.Sequence<+T_co>[~UserCloud]<~UserCloud>
-        Returns -> typing.Sequence<+T_co>[~StringsResult]<~StringsResult>
+        user_clouds : typing.Sequence[~UserCloud]
+        Returns -> typing.Sequence[~StringsResult]
         '''
         if user_clouds is not None and not isinstance(user_clouds, (bytes, str, list)):
             raise Exception("Expected user_clouds to be a Sequence, received: {}".format(type(user_clouds)))
@@ -4371,7 +4371,7 @@ class CrossControllerFacade(Type):
     async def ControllerInfo(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~ControllerAPIInfoResult]<~ControllerAPIInfoResult>
+        Returns -> typing.Sequence[~ControllerAPIInfoResult]
         '''
 
         # map input types to rpc msg
@@ -4390,7 +4390,7 @@ class CrossControllerFacade(Type):
     async def WatchControllerInfo(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
 
         # map input types to rpc msg
@@ -4708,8 +4708,8 @@ class CrossModelRelationsFacade(Type):
     @ReturnMapping(ErrorResults)
     async def PublishIngressNetworkChanges(self, changes=None):
         '''
-        changes : typing.Sequence<+T_co>[~IngressNetworksChangeEvent]<~IngressNetworksChangeEvent>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        changes : typing.Sequence[~IngressNetworksChangeEvent]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if changes is not None and not isinstance(changes, (bytes, str, list)):
             raise Exception("Expected changes to be a Sequence, received: {}".format(type(changes)))
@@ -4729,8 +4729,8 @@ class CrossModelRelationsFacade(Type):
     @ReturnMapping(ErrorResults)
     async def PublishRelationChanges(self, changes=None):
         '''
-        changes : typing.Sequence<+T_co>[~RemoteRelationChangeEvent]<~RemoteRelationChangeEvent>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        changes : typing.Sequence[~RemoteRelationChangeEvent]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if changes is not None and not isinstance(changes, (bytes, str, list)):
             raise Exception("Expected changes to be a Sequence, received: {}".format(type(changes)))
@@ -4750,8 +4750,8 @@ class CrossModelRelationsFacade(Type):
     @ReturnMapping(RegisterRemoteRelationResults)
     async def RegisterRemoteRelations(self, relations=None):
         '''
-        relations : typing.Sequence<+T_co>[~RegisterRemoteRelationArg]<~RegisterRemoteRelationArg>
-        Returns -> typing.Sequence<+T_co>[~RegisterRemoteRelationResult]<~RegisterRemoteRelationResult>
+        relations : typing.Sequence[~RegisterRemoteRelationArg]
+        Returns -> typing.Sequence[~RegisterRemoteRelationResult]
         '''
         if relations is not None and not isinstance(relations, (bytes, str, list)):
             raise Exception("Expected relations to be a Sequence, received: {}".format(type(relations)))
@@ -4771,8 +4771,8 @@ class CrossModelRelationsFacade(Type):
     @ReturnMapping(SettingsResults)
     async def RelationUnitSettings(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RemoteRelationUnit]<~RemoteRelationUnit>
-        Returns -> typing.Sequence<+T_co>[~SettingsResult]<~SettingsResult>
+        relation_units : typing.Sequence[~RemoteRelationUnit]
+        Returns -> typing.Sequence[~SettingsResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -4792,8 +4792,8 @@ class CrossModelRelationsFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchEgressAddressesForRelations(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~RemoteEntityArg]<~RemoteEntityArg>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        args : typing.Sequence[~RemoteEntityArg]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -4813,8 +4813,8 @@ class CrossModelRelationsFacade(Type):
     @ReturnMapping(OfferStatusWatchResults)
     async def WatchOfferStatus(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~OfferArg]<~OfferArg>
-        Returns -> typing.Sequence<+T_co>[~OfferStatusWatchResult]<~OfferStatusWatchResult>
+        args : typing.Sequence[~OfferArg]
+        Returns -> typing.Sequence[~OfferStatusWatchResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -4834,8 +4834,8 @@ class CrossModelRelationsFacade(Type):
     @ReturnMapping(RelationUnitsWatchResults)
     async def WatchRelationUnits(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~RemoteEntityArg]<~RemoteEntityArg>
-        Returns -> typing.Sequence<+T_co>[~RelationUnitsWatchResult]<~RelationUnitsWatchResult>
+        args : typing.Sequence[~RemoteEntityArg]
+        Returns -> typing.Sequence[~RelationUnitsWatchResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -4855,8 +4855,8 @@ class CrossModelRelationsFacade(Type):
     @ReturnMapping(RelationStatusWatchResults)
     async def WatchRelationsSuspendedStatus(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~RemoteEntityArg]<~RemoteEntityArg>
-        Returns -> typing.Sequence<+T_co>[~RelationLifeSuspendedStatusWatchResult]<~RelationLifeSuspendedStatusWatchResult>
+        args : typing.Sequence[~RemoteEntityArg]
+        Returns -> typing.Sequence[~RelationLifeSuspendedStatusWatchResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -5033,7 +5033,7 @@ class DeployerFacade(Type):
     async def APIAddresses(self):
         '''
 
-        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence<+T_co>[str]]
+        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence[str]]
         '''
 
         # map input types to rpc msg
@@ -5052,7 +5052,7 @@ class DeployerFacade(Type):
     async def APIHostPorts(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~HostPort]<~HostPort>
+        Returns -> typing.Sequence[~HostPort]
         '''
 
         # map input types to rpc msg
@@ -5071,7 +5071,7 @@ class DeployerFacade(Type):
     async def ConnectionInfo(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[str]
+        Returns -> typing.Sequence[str]
         '''
 
         # map input types to rpc msg
@@ -5089,8 +5089,8 @@ class DeployerFacade(Type):
     @ReturnMapping(LifeResults)
     async def Life(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5129,8 +5129,8 @@ class DeployerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Remove(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5150,8 +5150,8 @@ class DeployerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetPasswords(self, changes=None):
         '''
-        changes : typing.Sequence<+T_co>[~EntityPassword]<~EntityPassword>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        changes : typing.Sequence[~EntityPassword]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if changes is not None and not isinstance(changes, (bytes, str, list)):
             raise Exception("Expected changes to be a Sequence, received: {}".format(type(changes)))
@@ -5171,8 +5171,8 @@ class DeployerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5192,8 +5192,8 @@ class DeployerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UpdateStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5232,8 +5232,8 @@ class DeployerFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchUnits(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5335,8 +5335,8 @@ class ExternalControllerUpdaterFacade(Type):
     @ReturnMapping(ExternalControllerInfoResults)
     async def ExternalControllerInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ExternalControllerInfoResult]<~ExternalControllerInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ExternalControllerInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5356,8 +5356,8 @@ class ExternalControllerUpdaterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetExternalControllerInfo(self, controllers=None):
         '''
-        controllers : typing.Sequence<+T_co>[~SetExternalControllerInfoParams]<~SetExternalControllerInfoParams>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        controllers : typing.Sequence[~SetExternalControllerInfoParams]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if controllers is not None and not isinstance(controllers, (bytes, str, list)):
             raise Exception("Expected controllers to be a Sequence, received: {}".format(type(controllers)))
@@ -5378,7 +5378,7 @@ class ExternalControllerUpdaterFacade(Type):
     async def WatchExternalControllers(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
 
         # map input types to rpc msg
@@ -5430,7 +5430,7 @@ class FanConfigurerFacade(Type):
     async def FanConfig(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~FanConfigEntry]<~FanConfigEntry>
+        Returns -> typing.Sequence[~FanConfigEntry]
         '''
 
         # map input types to rpc msg
@@ -5511,7 +5511,7 @@ class FirewallRulesFacade(Type):
     async def ListFirewallRules(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~FirewallRule]<~FirewallRule>
+        Returns -> typing.Sequence[~FirewallRule]
         '''
 
         # map input types to rpc msg
@@ -5529,8 +5529,8 @@ class FirewallRulesFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetFirewallRules(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~FirewallRule]<~FirewallRule>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~FirewallRule]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -5586,8 +5586,8 @@ class HostKeyReporterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ReportKeys(self, entity_keys=None):
         '''
-        entity_keys : typing.Sequence<+T_co>[~SSHHostKeys]<~SSHHostKeys>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entity_keys : typing.Sequence[~SSHHostKeys]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entity_keys is not None and not isinstance(entity_keys, (bytes, str, list)):
             raise Exception("Expected entity_keys to be a Sequence, received: {}".format(type(entity_keys)))
@@ -5671,9 +5671,9 @@ class KeyManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def AddKeys(self, ssh_keys=None, user=None):
         '''
-        ssh_keys : typing.Sequence<+T_co>[str]
+        ssh_keys : typing.Sequence[str]
         user : str
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if ssh_keys is not None and not isinstance(ssh_keys, (bytes, str, list)):
             raise Exception("Expected ssh_keys to be a Sequence, received: {}".format(type(ssh_keys)))
@@ -5697,9 +5697,9 @@ class KeyManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def DeleteKeys(self, ssh_keys=None, user=None):
         '''
-        ssh_keys : typing.Sequence<+T_co>[str]
+        ssh_keys : typing.Sequence[str]
         user : str
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if ssh_keys is not None and not isinstance(ssh_keys, (bytes, str, list)):
             raise Exception("Expected ssh_keys to be a Sequence, received: {}".format(type(ssh_keys)))
@@ -5723,9 +5723,9 @@ class KeyManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ImportKeys(self, ssh_keys=None, user=None):
         '''
-        ssh_keys : typing.Sequence<+T_co>[str]
+        ssh_keys : typing.Sequence[str]
         user : str
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if ssh_keys is not None and not isinstance(ssh_keys, (bytes, str, list)):
             raise Exception("Expected ssh_keys to be a Sequence, received: {}".format(type(ssh_keys)))
@@ -5751,7 +5751,7 @@ class KeyManagerFacade(Type):
         '''
         entities : Entities
         mode : bool
-        Returns -> typing.Sequence<+T_co>[~StringsResult]<~StringsResult>
+        Returns -> typing.Sequence[~StringsResult]
         '''
         if entities is not None and not isinstance(entities, (dict, Entities)):
             raise Exception("Expected entities to be a Entities, received: {}".format(type(entities)))
@@ -5824,8 +5824,8 @@ class KeyUpdaterFacade(Type):
     @ReturnMapping(StringsResults)
     async def AuthorisedKeys(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsResult]<~StringsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5845,8 +5845,8 @@ class KeyUpdaterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchAuthorisedKeys(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5915,8 +5915,8 @@ class LifeFlagFacade(Type):
     @ReturnMapping(LifeResults)
     async def Life(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5936,8 +5936,8 @@ class LifeFlagFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def Watch(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6025,8 +6025,8 @@ class LogForwardingFacade(Type):
     @ReturnMapping(LogForwardingGetLastSentResults)
     async def GetLastSent(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~LogForwardingID]<~LogForwardingID>
-        Returns -> typing.Sequence<+T_co>[~LogForwardingGetLastSentResult]<~LogForwardingGetLastSentResult>
+        ids : typing.Sequence[~LogForwardingID]
+        Returns -> typing.Sequence[~LogForwardingGetLastSentResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -6046,8 +6046,8 @@ class LogForwardingFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetLastSent(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~LogForwardingSetLastSentParam]<~LogForwardingSetLastSentParam>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        params : typing.Sequence[~LogForwardingSetLastSentParam]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -6116,8 +6116,8 @@ class LoggerFacade(Type):
     @ReturnMapping(StringResults)
     async def LoggingConfig(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6137,8 +6137,8 @@ class LoggerFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchLoggingConfig(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6267,8 +6267,8 @@ class MachineActionsFacade(Type):
     @ReturnMapping(ActionResults)
     async def Actions(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ActionResult]<~ActionResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ActionResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6288,8 +6288,8 @@ class MachineActionsFacade(Type):
     @ReturnMapping(ErrorResults)
     async def BeginActions(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6309,8 +6309,8 @@ class MachineActionsFacade(Type):
     @ReturnMapping(ErrorResults)
     async def FinishActions(self, results=None):
         '''
-        results : typing.Sequence<+T_co>[~ActionExecutionResult]<~ActionExecutionResult>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        results : typing.Sequence[~ActionExecutionResult]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if results is not None and not isinstance(results, (bytes, str, list)):
             raise Exception("Expected results to be a Sequence, received: {}".format(type(results)))
@@ -6330,8 +6330,8 @@ class MachineActionsFacade(Type):
     @ReturnMapping(ActionsByReceivers)
     async def RunningActions(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ActionsByReceiver]<~ActionsByReceiver>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ActionsByReceiver]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6351,8 +6351,8 @@ class MachineActionsFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchActionNotifications(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6448,8 +6448,8 @@ class MachineUndertakerFacade(Type):
     @ReturnMapping(EntitiesResults)
     async def AllMachineRemovals(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~EntitiesResult]<~EntitiesResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~EntitiesResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6469,7 +6469,7 @@ class MachineUndertakerFacade(Type):
     @ReturnMapping(None)
     async def CompleteMachineRemovals(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
+        entities : typing.Sequence[~Entity]
         Returns -> None
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
@@ -6490,8 +6490,8 @@ class MachineUndertakerFacade(Type):
     @ReturnMapping(ProviderInterfaceInfoResults)
     async def GetMachineProviderInterfaceInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ProviderInterfaceInfoResult]<~ProviderInterfaceInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ProviderInterfaceInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6511,8 +6511,8 @@ class MachineUndertakerFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchMachineRemovals(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6750,7 +6750,7 @@ class MachinerFacade(Type):
     async def APIAddresses(self):
         '''
 
-        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence<+T_co>[str]]
+        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence[str]]
         '''
 
         # map input types to rpc msg
@@ -6769,7 +6769,7 @@ class MachinerFacade(Type):
     async def APIHostPorts(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~HostPort]<~HostPort>
+        Returns -> typing.Sequence[~HostPort]
         '''
 
         # map input types to rpc msg
@@ -6787,8 +6787,8 @@ class MachinerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def EnsureDead(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6808,8 +6808,8 @@ class MachinerFacade(Type):
     @ReturnMapping(JobsResults)
     async def Jobs(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~JobsResult]<~JobsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~JobsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6829,8 +6829,8 @@ class MachinerFacade(Type):
     @ReturnMapping(LifeResults)
     async def Life(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6869,8 +6869,8 @@ class MachinerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetMachineAddresses(self, machine_addresses=None):
         '''
-        machine_addresses : typing.Sequence<+T_co>[~MachineAddresses]<~MachineAddresses>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        machine_addresses : typing.Sequence[~MachineAddresses]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if machine_addresses is not None and not isinstance(machine_addresses, (bytes, str, list)):
             raise Exception("Expected machine_addresses to be a Sequence, received: {}".format(type(machine_addresses)))
@@ -6890,7 +6890,7 @@ class MachinerFacade(Type):
     @ReturnMapping(None)
     async def SetObservedNetworkConfig(self, config=None, tag=None):
         '''
-        config : typing.Sequence<+T_co>[~NetworkConfig]<~NetworkConfig>
+        config : typing.Sequence[~NetworkConfig]
         tag : str
         Returns -> None
         '''
@@ -6916,8 +6916,8 @@ class MachinerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetProviderNetworkConfig(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6937,8 +6937,8 @@ class MachinerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6958,8 +6958,8 @@ class MachinerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UpdateStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6979,8 +6979,8 @@ class MachinerFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def Watch(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7069,8 +7069,8 @@ class MeterStatusFacade(Type):
     @ReturnMapping(MeterStatusResults)
     async def GetMeterStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MeterStatusResult]<~MeterStatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MeterStatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7090,8 +7090,8 @@ class MeterStatusFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchMeterStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7168,8 +7168,8 @@ class MetricsManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def CleanupOldMetrics(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7189,8 +7189,8 @@ class MetricsManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SendMetrics(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7258,8 +7258,8 @@ class MigrationFlagFacade(Type):
     @ReturnMapping(PhaseResults)
     async def Phase(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~PhaseResult]<~PhaseResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~PhaseResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7279,8 +7279,8 @@ class MigrationFlagFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def Watch(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7468,7 +7468,7 @@ class MigrationMasterFacade(Type):
     async def Export(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~SerializedModelTools]<~SerializedModelTools>
+        Returns -> typing.Union[typing.Sequence[int], typing.Sequence[str], typing.Sequence[~SerializedModelResource], typing.Sequence[~SerializedModelTools]]
         '''
 
         # map input types to rpc msg
@@ -7506,7 +7506,7 @@ class MigrationMasterFacade(Type):
     async def MinionReports(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[str], int]
+        Returns -> typing.Union[typing.Sequence[str], str, int]
         '''
 
         # map input types to rpc msg
@@ -7525,7 +7525,7 @@ class MigrationMasterFacade(Type):
     async def ModelInfo(self):
         '''
 
-        Returns -> typing.Union[_ForwardRef('Number'), _ForwardRef('Number'), str]
+        Returns -> typing.Union[_ForwardRef('Number'), str]
         '''
 
         # map input types to rpc msg
@@ -7770,7 +7770,7 @@ class MigrationStatusWatcherFacade(Type):
     async def Next(self):
         '''
 
-        Returns -> typing.Union[int, typing.Sequence<+T_co>[str]]
+        Returns -> typing.Union[int, str, typing.Sequence[str]]
         '''
 
         # map input types to rpc msg
@@ -8008,7 +8008,7 @@ class MigrationTargetFacade(Type):
     async def CACert(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[int]
+        Returns -> typing.Sequence[int]
         '''
 
         # map input types to rpc msg
@@ -8027,7 +8027,7 @@ class MigrationTargetFacade(Type):
     async def CheckMachines(self, model_tag=None):
         '''
         model_tag : str
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if model_tag is not None and not isinstance(model_tag, (bytes, str)):
             raise Exception("Expected model_tag to be a str, received: {}".format(type(model_tag)))
@@ -8047,10 +8047,10 @@ class MigrationTargetFacade(Type):
     @ReturnMapping(None)
     async def Import(self, bytes_=None, charms=None, resources=None, tools=None):
         '''
-        bytes_ : typing.Sequence<+T_co>[int]
-        charms : typing.Sequence<+T_co>[str]
-        resources : typing.Sequence<+T_co>[~SerializedModelResource]<~SerializedModelResource>
-        tools : typing.Sequence<+T_co>[~SerializedModelTools]<~SerializedModelTools>
+        bytes_ : typing.Sequence[int]
+        charms : typing.Sequence[str]
+        resources : typing.Sequence[~SerializedModelResource]
+        tools : typing.Sequence[~SerializedModelTools]
         Returns -> None
         '''
         if bytes_ is not None and not isinstance(bytes_, (bytes, str, list)):
@@ -8211,7 +8211,7 @@ class ModelConfigFacade(Type):
     async def ModelGet(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~ConfigValue]<~ConfigValue>
+        Returns -> typing.Mapping[str, ~ConfigValue]
         '''
 
         # map input types to rpc msg
@@ -8229,7 +8229,7 @@ class ModelConfigFacade(Type):
     @ReturnMapping(None)
     async def ModelSet(self, config=None):
         '''
-        config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        config : typing.Mapping[str, typing.Any]
         Returns -> None
         '''
         if config is not None and not isinstance(config, dict):
@@ -8250,7 +8250,7 @@ class ModelConfigFacade(Type):
     @ReturnMapping(None)
     async def ModelUnset(self, keys=None):
         '''
-        keys : typing.Sequence<+T_co>[str]
+        keys : typing.Sequence[str]
         Returns -> None
         '''
         if keys is not None and not isinstance(keys, (bytes, str, list)):
@@ -8291,7 +8291,7 @@ class ModelConfigFacade(Type):
     async def SetSLALevel(self, modelslainfo=None, creds=None):
         '''
         modelslainfo : ModelSLAInfo
-        creds : typing.Sequence<+T_co>[int]
+        creds : typing.Sequence[int]
         Returns -> None
         '''
         if modelslainfo is not None and not isinstance(modelslainfo, (dict, ModelSLAInfo)):
@@ -8435,9 +8435,9 @@ class ModelGenerationFacade(Type):
     @ReturnMapping(GenerationResults)
     async def BranchInfo(self, branches=None, detailed=None):
         '''
-        branches : typing.Sequence<+T_co>[str]
+        branches : typing.Sequence[str]
         detailed : bool
-        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence<+T_co>[~Generation]<~Generation>]
+        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence[~Generation]]
         '''
         if branches is not None and not isinstance(branches, (bytes, str, list)):
             raise Exception("Expected branches to be a Sequence, received: {}".format(type(branches)))
@@ -8504,8 +8504,8 @@ class ModelGenerationFacade(Type):
     async def TrackBranch(self, branch=None, entities=None):
         '''
         branch : str
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if branch is not None and not isinstance(branch, (bytes, str)):
             raise Exception("Expected branch to be a str, received: {}".format(type(branch)))
@@ -8622,8 +8622,8 @@ class ModelUpgraderFacade(Type):
     @ReturnMapping(IntResults)
     async def ModelEnvironVersion(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~IntResult]<~IntResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~IntResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -8643,8 +8643,8 @@ class ModelUpgraderFacade(Type):
     @ReturnMapping(IntResults)
     async def ModelTargetEnvironVersion(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~IntResult]<~IntResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~IntResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -8664,8 +8664,8 @@ class ModelUpgraderFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetModelEnvironVersion(self, models=None):
         '''
-        models : typing.Sequence<+T_co>[~SetModelEnvironVersion]<~SetModelEnvironVersion>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        models : typing.Sequence[~SetModelEnvironVersion]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if models is not None and not isinstance(models, (bytes, str, list)):
             raise Exception("Expected models to be a Sequence, received: {}".format(type(models)))
@@ -8685,8 +8685,8 @@ class ModelUpgraderFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetModelStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -8706,8 +8706,8 @@ class ModelUpgraderFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchModelEnvironVersion(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -8813,7 +8813,7 @@ class OfferStatusWatcherFacade(Type):
     async def Next(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[~OfferStatusChange]<~OfferStatusChange>, _ForwardRef('Error')]
+        Returns -> typing.Union[typing.Sequence[~OfferStatusChange], _ForwardRef('Error'), str]
         '''
 
         # map input types to rpc msg
@@ -8886,8 +8886,8 @@ class PayloadsFacade(Type):
     @ReturnMapping(PayloadListResults)
     async def List(self, patterns=None):
         '''
-        patterns : typing.Sequence<+T_co>[str]
-        Returns -> typing.Sequence<+T_co>[~Payload]<~Payload>
+        patterns : typing.Sequence[str]
+        Returns -> typing.Sequence[~Payload]
         '''
         if patterns is not None and not isinstance(patterns, (bytes, str, list)):
             raise Exception("Expected patterns to be a Sequence, received: {}".format(type(patterns)))
@@ -9006,8 +9006,8 @@ class PayloadsHookContextFacade(Type):
     @ReturnMapping(PayloadResults)
     async def List(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~PayloadResult]<~PayloadResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~PayloadResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -9027,8 +9027,8 @@ class PayloadsHookContextFacade(Type):
     @ReturnMapping(PayloadResults)
     async def LookUp(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~LookUpPayloadArg]<~LookUpPayloadArg>
-        Returns -> typing.Sequence<+T_co>[~PayloadResult]<~PayloadResult>
+        args : typing.Sequence[~LookUpPayloadArg]
+        Returns -> typing.Sequence[~PayloadResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -9048,8 +9048,8 @@ class PayloadsHookContextFacade(Type):
     @ReturnMapping(PayloadResults)
     async def SetStatus(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~SetPayloadStatusArg]<~SetPayloadStatusArg>
-        Returns -> typing.Sequence<+T_co>[~PayloadResult]<~PayloadResult>
+        args : typing.Sequence[~SetPayloadStatusArg]
+        Returns -> typing.Sequence[~PayloadResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -9069,8 +9069,8 @@ class PayloadsHookContextFacade(Type):
     @ReturnMapping(PayloadResults)
     async def Track(self, payloads=None):
         '''
-        payloads : typing.Sequence<+T_co>[~Payload]<~Payload>
-        Returns -> typing.Sequence<+T_co>[~PayloadResult]<~PayloadResult>
+        payloads : typing.Sequence[~Payload]
+        Returns -> typing.Sequence[~PayloadResult]
         '''
         if payloads is not None and not isinstance(payloads, (bytes, str, list)):
             raise Exception("Expected payloads to be a Sequence, received: {}".format(type(payloads)))
@@ -9090,8 +9090,8 @@ class PayloadsHookContextFacade(Type):
     @ReturnMapping(PayloadResults)
     async def Untrack(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~PayloadResult]<~PayloadResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~PayloadResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -9220,8 +9220,8 @@ class ProxyUpdaterFacade(Type):
     @ReturnMapping(ProxyConfigResults)
     async def ProxyConfig(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ProxyConfigResult]<~ProxyConfigResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ProxyConfigResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -9241,8 +9241,8 @@ class ProxyUpdaterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchForProxyConfigAndAPIHostPortChanges(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -9298,7 +9298,7 @@ class RelationStatusWatcherFacade(Type):
     async def Next(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[~RelationLifeSuspendedStatusChange]<~RelationLifeSuspendedStatusChange>, _ForwardRef('Error')]
+        Returns -> typing.Union[typing.Sequence[~RelationLifeSuspendedStatusChange], _ForwardRef('Error'), str]
         '''
 
         # map input types to rpc msg
@@ -9810,8 +9810,8 @@ class RemoteRelationsFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ConsumeRemoteRelationChanges(self, changes=None):
         '''
-        changes : typing.Sequence<+T_co>[~RemoteRelationChangeEvent]<~RemoteRelationChangeEvent>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        changes : typing.Sequence[~RemoteRelationChangeEvent]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if changes is not None and not isinstance(changes, (bytes, str, list)):
             raise Exception("Expected changes to be a Sequence, received: {}".format(type(changes)))
@@ -9831,8 +9831,8 @@ class RemoteRelationsFacade(Type):
     @ReturnMapping(ControllerAPIInfoResults)
     async def ControllerAPIInfoForModels(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ControllerAPIInfoResult]<~ControllerAPIInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ControllerAPIInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -9853,7 +9853,7 @@ class RemoteRelationsFacade(Type):
     async def ControllerConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -9871,8 +9871,8 @@ class RemoteRelationsFacade(Type):
     @ReturnMapping(TokenResults)
     async def ExportEntities(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~TokenResult]<~TokenResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~TokenResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -9892,8 +9892,8 @@ class RemoteRelationsFacade(Type):
     @ReturnMapping(StringResults)
     async def GetTokens(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~GetTokenArg]<~GetTokenArg>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        args : typing.Sequence[~GetTokenArg]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -9913,8 +9913,8 @@ class RemoteRelationsFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ImportRemoteEntities(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~RemoteEntityTokenArg]<~RemoteEntityTokenArg>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~RemoteEntityTokenArg]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -9934,8 +9934,8 @@ class RemoteRelationsFacade(Type):
     @ReturnMapping(SettingsResults)
     async def RelationUnitSettings(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnit]<~RelationUnit>
-        Returns -> typing.Sequence<+T_co>[~SettingsResult]<~SettingsResult>
+        relation_units : typing.Sequence[~RelationUnit]
+        Returns -> typing.Sequence[~SettingsResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -9955,8 +9955,8 @@ class RemoteRelationsFacade(Type):
     @ReturnMapping(RemoteRelationResults)
     async def Relations(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~RemoteRelationResult]<~RemoteRelationResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~RemoteRelationResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -9976,8 +9976,8 @@ class RemoteRelationsFacade(Type):
     @ReturnMapping(RemoteApplicationResults)
     async def RemoteApplications(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~RemoteApplicationResult]<~RemoteApplicationResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~RemoteApplicationResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -9997,8 +9997,8 @@ class RemoteRelationsFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SaveMacaroons(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~EntityMacaroonArg]<~EntityMacaroonArg>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~EntityMacaroonArg]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -10018,8 +10018,8 @@ class RemoteRelationsFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetRemoteApplicationsStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -10039,8 +10039,8 @@ class RemoteRelationsFacade(Type):
     @ReturnMapping(RelationUnitsWatchResults)
     async def WatchLocalRelationUnits(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~RelationUnitsWatchResult]<~RelationUnitsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~RelationUnitsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -10060,8 +10060,8 @@ class RemoteRelationsFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchRemoteApplicationRelations(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -10082,7 +10082,7 @@ class RemoteRelationsFacade(Type):
     async def WatchRemoteApplications(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[str], _ForwardRef('Error')]
+        Returns -> typing.Union[typing.Sequence[str], _ForwardRef('Error'), str]
         '''
 
         # map input types to rpc msg
@@ -10101,7 +10101,7 @@ class RemoteRelationsFacade(Type):
     async def WatchRemoteRelations(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[str], _ForwardRef('Error')]
+        Returns -> typing.Union[typing.Sequence[str], _ForwardRef('Error'), str]
         '''
 
         # map input types to rpc msg
@@ -10367,10 +10367,10 @@ class ResourcesFacade(Type):
         channel : str
         force : bool
         macaroon : Macaroon
-        resources : typing.Sequence<+T_co>[~CharmResource]<~CharmResource>
+        resources : typing.Sequence[~CharmResource]
         tag : str
         url : str
-        Returns -> typing.Union[_ForwardRef('ErrorResult'), _ForwardRef('Error'), typing.Sequence<+T_co>[str]]
+        Returns -> typing.Union[_ForwardRef('ErrorResult'), _ForwardRef('Error'), typing.Sequence[str]]
         '''
         if addcharmwithauthorization is not None and not isinstance(addcharmwithauthorization, (dict, AddCharmWithAuthorization)):
             raise Exception("Expected addcharmwithauthorization to be a AddCharmWithAuthorization, received: {}".format(type(addcharmwithauthorization)))
@@ -10418,8 +10418,8 @@ class ResourcesFacade(Type):
     @ReturnMapping(ResourcesResults)
     async def ListResources(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ResourcesResult]<~ResourcesResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ResourcesResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -10527,8 +10527,8 @@ class ResourcesHookContextFacade(Type):
     @ReturnMapping(UnitResourcesResult)
     async def GetResourceInfo(self, resource_names=None):
         '''
-        resource_names : typing.Sequence<+T_co>[str]
-        Returns -> typing.Union[_ForwardRef('ErrorResult'), _ForwardRef('Error'), typing.Sequence<+T_co>[~UnitResourceResult]<~UnitResourceResult>]
+        resource_names : typing.Sequence[str]
+        Returns -> typing.Union[_ForwardRef('ErrorResult'), _ForwardRef('Error'), typing.Sequence[~UnitResourceResult]]
         '''
         if resource_names is not None and not isinstance(resource_names, (bytes, str, list)):
             raise Exception("Expected resource_names to be a Sequence, received: {}".format(type(resource_names)))
@@ -10608,8 +10608,8 @@ class RetryStrategyFacade(Type):
     @ReturnMapping(RetryStrategyResults)
     async def RetryStrategy(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~RetryStrategyResult]<~RetryStrategyResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~RetryStrategyResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -10629,8 +10629,8 @@ class RetryStrategyFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchRetryStrategy(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -10710,8 +10710,8 @@ class SSHClientFacade(Type):
     @ReturnMapping(SSHAddressResults)
     async def PrivateAddress(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~SSHAddressResult]<~SSHAddressResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~SSHAddressResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -10750,8 +10750,8 @@ class SSHClientFacade(Type):
     @ReturnMapping(SSHAddressResults)
     async def PublicAddress(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~SSHAddressResult]<~SSHAddressResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~SSHAddressResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -10771,8 +10771,8 @@ class SSHClientFacade(Type):
     @ReturnMapping(SSHPublicKeysResults)
     async def PublicKeys(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~SSHPublicKeysResult]<~SSHPublicKeysResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~SSHPublicKeysResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -10845,8 +10845,8 @@ class SingularFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Claim(self, claims=None):
         '''
-        claims : typing.Sequence<+T_co>[~SingularClaim]<~SingularClaim>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        claims : typing.Sequence[~SingularClaim]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if claims is not None and not isinstance(claims, (bytes, str, list)):
             raise Exception("Expected claims to be a Sequence, received: {}".format(type(claims)))
@@ -10866,8 +10866,8 @@ class SingularFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Wait(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -10912,7 +10912,7 @@ class StringsWatcherFacade(Type):
     async def Next(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[str], _ForwardRef('Error')]
+        Returns -> typing.Union[typing.Sequence[str], _ForwardRef('Error'), str]
         '''
 
         # map input types to rpc msg
@@ -11038,7 +11038,7 @@ class UndertakerFacade(Type):
     async def ModelConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -11113,8 +11113,8 @@ class UndertakerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -11134,8 +11134,8 @@ class UndertakerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UpdateStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -11156,7 +11156,7 @@ class UndertakerFacade(Type):
     async def WatchModelResources(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
 
         # map input types to rpc msg
@@ -11237,8 +11237,8 @@ class UnitAssignerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def AssignUnits(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -11258,8 +11258,8 @@ class UnitAssignerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetAgentStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -11280,7 +11280,7 @@ class UnitAssignerFacade(Type):
     async def WatchUnitAssignments(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[str], _ForwardRef('Error')]
+        Returns -> typing.Union[typing.Sequence[str], _ForwardRef('Error'), str]
         '''
 
         # map input types to rpc msg
@@ -11450,8 +11450,8 @@ class UpgradeSeriesFacade(Type):
     @ReturnMapping(ErrorResults)
     async def FinishUpgradeSeries(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~UpdateSeriesArg]<~UpdateSeriesArg>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~UpdateSeriesArg]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -11471,8 +11471,8 @@ class UpgradeSeriesFacade(Type):
     @ReturnMapping(UpgradeSeriesStatusResults)
     async def MachineStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~UpgradeSeriesStatusResult]<~UpgradeSeriesStatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~UpgradeSeriesStatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -11493,7 +11493,7 @@ class UpgradeSeriesFacade(Type):
     async def PinMachineApplications(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~PinApplicationResult]<~PinApplicationResult>
+        Returns -> typing.Sequence[~PinApplicationResult]
         '''
 
         # map input types to rpc msg
@@ -11512,7 +11512,7 @@ class UpgradeSeriesFacade(Type):
     async def PinnedLeadership(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[str]
+        Returns -> typing.Sequence[str]
         '''
 
         # map input types to rpc msg
@@ -11530,8 +11530,8 @@ class UpgradeSeriesFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetMachineStatus(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~UpgradeSeriesStatusParam]<~UpgradeSeriesStatusParam>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        params : typing.Sequence[~UpgradeSeriesStatusParam]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -11551,8 +11551,8 @@ class UpgradeSeriesFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetUpgradeSeriesUnitStatus(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~UpgradeSeriesStatusParam]<~UpgradeSeriesStatusParam>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        params : typing.Sequence[~UpgradeSeriesStatusParam]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -11572,9 +11572,9 @@ class UpgradeSeriesFacade(Type):
     @ReturnMapping(ErrorResults)
     async def StartUnitCompletion(self, entities=None, message=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
+        entities : typing.Sequence[~Entity]
         message : str
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -11598,8 +11598,8 @@ class UpgradeSeriesFacade(Type):
     @ReturnMapping(StringResults)
     async def TargetSeries(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -11619,8 +11619,8 @@ class UpgradeSeriesFacade(Type):
     @ReturnMapping(EntitiesResults)
     async def UnitsCompleted(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~EntitiesResult]<~EntitiesResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~EntitiesResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -11640,8 +11640,8 @@ class UpgradeSeriesFacade(Type):
     @ReturnMapping(EntitiesResults)
     async def UnitsPrepared(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~EntitiesResult]<~EntitiesResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~EntitiesResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -11662,7 +11662,7 @@ class UpgradeSeriesFacade(Type):
     async def UnpinMachineApplications(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~PinApplicationResult]<~PinApplicationResult>
+        Returns -> typing.Sequence[~PinApplicationResult]
         '''
 
         # map input types to rpc msg
@@ -11680,8 +11680,8 @@ class UpgradeSeriesFacade(Type):
     @ReturnMapping(UpgradeSeriesStatusResults)
     async def UpgradeSeriesUnitStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~UpgradeSeriesStatusResult]<~UpgradeSeriesStatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~UpgradeSeriesStatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -11701,8 +11701,8 @@ class UpgradeSeriesFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchUpgradeSeriesNotifications(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -11893,8 +11893,8 @@ class UpgraderFacade(Type):
     @ReturnMapping(VersionResults)
     async def DesiredVersion(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~VersionResult]<~VersionResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~VersionResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -11914,8 +11914,8 @@ class UpgraderFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetTools(self, agent_tools=None):
         '''
-        agent_tools : typing.Sequence<+T_co>[~EntityVersion]<~EntityVersion>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        agent_tools : typing.Sequence[~EntityVersion]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if agent_tools is not None and not isinstance(agent_tools, (bytes, str, list)):
             raise Exception("Expected agent_tools to be a Sequence, received: {}".format(type(agent_tools)))
@@ -11935,8 +11935,8 @@ class UpgraderFacade(Type):
     @ReturnMapping(ToolsResults)
     async def Tools(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ToolsResult]<~ToolsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ToolsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -11956,8 +11956,8 @@ class UpgraderFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchAPIVersion(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -12094,8 +12094,8 @@ class UserManagerFacade(Type):
     @ReturnMapping(AddUserResults)
     async def AddUser(self, users=None):
         '''
-        users : typing.Sequence<+T_co>[~AddUser]<~AddUser>
-        Returns -> typing.Sequence<+T_co>[~AddUserResult]<~AddUserResult>
+        users : typing.Sequence[~AddUser]
+        Returns -> typing.Sequence[~AddUserResult]
         '''
         if users is not None and not isinstance(users, (bytes, str, list)):
             raise Exception("Expected users to be a Sequence, received: {}".format(type(users)))
@@ -12115,8 +12115,8 @@ class UserManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def DisableUser(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -12136,8 +12136,8 @@ class UserManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def EnableUser(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -12157,8 +12157,8 @@ class UserManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RemoveUser(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -12178,8 +12178,8 @@ class UserManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetPassword(self, changes=None):
         '''
-        changes : typing.Sequence<+T_co>[~EntityPassword]<~EntityPassword>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        changes : typing.Sequence[~EntityPassword]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if changes is not None and not isinstance(changes, (bytes, str, list)):
             raise Exception("Expected changes to be a Sequence, received: {}".format(type(changes)))
@@ -12199,9 +12199,9 @@ class UserManagerFacade(Type):
     @ReturnMapping(UserInfoResults)
     async def UserInfo(self, entities=None, include_disabled=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
+        entities : typing.Sequence[~Entity]
         include_disabled : bool
-        Returns -> typing.Sequence<+T_co>[~UserInfoResult]<~UserInfoResult>
+        Returns -> typing.Sequence[~UserInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -12257,7 +12257,7 @@ class VolumeAttachmentPlansWatcherFacade(Type):
     async def Next(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[~MachineStorageId]<~MachineStorageId>, _ForwardRef('Error')]
+        Returns -> typing.Union[typing.Sequence[~MachineStorageId], _ForwardRef('Error'), str]
         '''
 
         # map input types to rpc msg

--- a/juju/client/_client10.py
+++ b/juju/client/_client10.py
@@ -678,9 +678,9 @@ class ApplicationFacade(Type):
     @ReturnMapping(AddRelationResults)
     async def AddRelation(self, endpoints=None, via_cidrs=None):
         '''
-        endpoints : typing.Sequence<+T_co>[str]
-        via_cidrs : typing.Sequence<+T_co>[str]
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~CharmRelation]<~CharmRelation>
+        endpoints : typing.Sequence[str]
+        via_cidrs : typing.Sequence[str]
+        Returns -> typing.Mapping[str, ~CharmRelation]
         '''
         if endpoints is not None and not isinstance(endpoints, (bytes, str, list)):
             raise Exception("Expected endpoints to be a Sequence, received: {}".format(type(endpoints)))
@@ -705,11 +705,11 @@ class ApplicationFacade(Type):
     async def AddUnits(self, application=None, attach_storage=None, num_units=None, placement=None, policy=None):
         '''
         application : str
-        attach_storage : typing.Sequence<+T_co>[str]
+        attach_storage : typing.Sequence[str]
         num_units : int
-        placement : typing.Sequence<+T_co>[~Placement]<~Placement>
+        placement : typing.Sequence[~Placement]
         policy : str
-        Returns -> typing.Sequence<+T_co>[str]
+        Returns -> typing.Sequence[str]
         '''
         if application is not None and not isinstance(application, (bytes, str)):
             raise Exception("Expected application to be a str, received: {}".format(type(application)))
@@ -745,8 +745,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ApplicationInfoResults)
     async def ApplicationsInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ApplicationInfoResult]<~ApplicationInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ApplicationInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -766,8 +766,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ApplicationGetConfigResults)
     async def CharmConfig(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~ApplicationGet]<~ApplicationGet>
-        Returns -> typing.Sequence<+T_co>[~ConfigResult]<~ConfigResult>
+        args : typing.Sequence[~ApplicationGet]
+        Returns -> typing.Sequence[~ConfigResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -788,7 +788,7 @@ class ApplicationFacade(Type):
     async def CharmRelations(self, application=None):
         '''
         application : str
-        Returns -> typing.Sequence<+T_co>[str]
+        Returns -> typing.Sequence[str]
         '''
         if application is not None and not isinstance(application, (bytes, str)):
             raise Exception("Expected application to be a str, received: {}".format(type(application)))
@@ -808,8 +808,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Consume(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~ConsumeApplicationArg]<~ConsumeApplicationArg>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~ConsumeApplicationArg]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -829,8 +829,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Deploy(self, applications=None):
         '''
-        applications : typing.Sequence<+T_co>[~ApplicationDeploy]<~ApplicationDeploy>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        applications : typing.Sequence[~ApplicationDeploy]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if applications is not None and not isinstance(applications, (bytes, str, list)):
             raise Exception("Expected applications to be a Sequence, received: {}".format(type(applications)))
@@ -871,8 +871,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(DestroyApplicationResults)
     async def DestroyApplication(self, applications=None):
         '''
-        applications : typing.Sequence<+T_co>[~DestroyApplicationParams]<~DestroyApplicationParams>
-        Returns -> typing.Sequence<+T_co>[~DestroyApplicationResult]<~DestroyApplicationResult>
+        applications : typing.Sequence[~DestroyApplicationParams]
+        Returns -> typing.Sequence[~DestroyApplicationResult]
         '''
         if applications is not None and not isinstance(applications, (bytes, str, list)):
             raise Exception("Expected applications to be a Sequence, received: {}".format(type(applications)))
@@ -892,8 +892,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def DestroyConsumedApplications(self, applications=None):
         '''
-        applications : typing.Sequence<+T_co>[~DestroyConsumedApplicationParams]<~DestroyConsumedApplicationParams>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        applications : typing.Sequence[~DestroyConsumedApplicationParams]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if applications is not None and not isinstance(applications, (bytes, str, list)):
             raise Exception("Expected applications to be a Sequence, received: {}".format(type(applications)))
@@ -913,7 +913,7 @@ class ApplicationFacade(Type):
     @ReturnMapping(None)
     async def DestroyRelation(self, endpoints=None, force=None, max_wait=None, relation_id=None):
         '''
-        endpoints : typing.Sequence<+T_co>[str]
+        endpoints : typing.Sequence[str]
         force : bool
         max_wait : int
         relation_id : int
@@ -949,8 +949,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(DestroyUnitResults)
     async def DestroyUnit(self, units=None):
         '''
-        units : typing.Sequence<+T_co>[~DestroyUnitParams]<~DestroyUnitParams>
-        Returns -> typing.Sequence<+T_co>[~DestroyUnitResult]<~DestroyUnitResult>
+        units : typing.Sequence[~DestroyUnitParams]
+        Returns -> typing.Sequence[~DestroyUnitResult]
         '''
         if units is not None and not isinstance(units, (bytes, str, list)):
             raise Exception("Expected units to be a Sequence, received: {}".format(type(units)))
@@ -970,7 +970,7 @@ class ApplicationFacade(Type):
     @ReturnMapping(None)
     async def DestroyUnits(self, unit_names=None):
         '''
-        unit_names : typing.Sequence<+T_co>[str]
+        unit_names : typing.Sequence[str]
         Returns -> None
         '''
         if unit_names is not None and not isinstance(unit_names, (bytes, str, list)):
@@ -1014,7 +1014,7 @@ class ApplicationFacade(Type):
         '''
         application : str
         branch : str
-        Returns -> typing.Union[str, typing.Mapping<~KT, +VT_co>[str, typing.Any], _ForwardRef('Value')]
+        Returns -> typing.Union[str, typing.Mapping[str, typing.Any], _ForwardRef('Value')]
         '''
         if application is not None and not isinstance(application, (bytes, str)):
             raise Exception("Expected application to be a str, received: {}".format(type(application)))
@@ -1064,8 +1064,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ApplicationGetConfigResults)
     async def GetConfig(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ConfigResult]<~ConfigResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ConfigResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1085,8 +1085,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ApplicationGetConstraintsResults)
     async def GetConstraints(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ApplicationConstraint]<~ApplicationConstraint>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ApplicationConstraint]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1109,7 +1109,7 @@ class ApplicationFacade(Type):
         all_ : bool
         retry : bool
         tags : Entities
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if all_ is not None and not isinstance(all_, bool):
             raise Exception("Expected all_ to be a bool, received: {}".format(type(all_)))
@@ -1137,8 +1137,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ScaleApplicationResults)
     async def ScaleApplications(self, applications=None):
         '''
-        applications : typing.Sequence<+T_co>[~ScaleApplicationParams]<~ScaleApplicationParams>
-        Returns -> typing.Sequence<+T_co>[~ScaleApplicationResult]<~ScaleApplicationResult>
+        applications : typing.Sequence[~ScaleApplicationParams]
+        Returns -> typing.Sequence[~ScaleApplicationResult]
         '''
         if applications is not None and not isinstance(applications, (bytes, str, list)):
             raise Exception("Expected applications to be a Sequence, received: {}".format(type(applications)))
@@ -1160,7 +1160,7 @@ class ApplicationFacade(Type):
         '''
         application : str
         branch : str
-        options : typing.Mapping<~KT, +VT_co>[str, str]
+        options : typing.Mapping[str, str]
         Returns -> None
         '''
         if application is not None and not isinstance(application, (bytes, str)):
@@ -1189,8 +1189,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetApplicationsConfig(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~ApplicationConfigSet]<~ApplicationConfigSet>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~ApplicationConfigSet]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -1213,14 +1213,14 @@ class ApplicationFacade(Type):
         application : str
         channel : str
         charm_url : str
-        config_settings : typing.Mapping<~KT, +VT_co>[str, str]
+        config_settings : typing.Mapping[str, str]
         config_settings_yaml : str
         force : bool
         force_series : bool
         force_units : bool
         generation : str
-        resource_ids : typing.Mapping<~KT, +VT_co>[str, str]
-        storage_constraints : typing.Mapping<~KT, +VT_co>[str, ~StorageConstraints]<~StorageConstraints>
+        resource_ids : typing.Mapping[str, str]
+        storage_constraints : typing.Mapping[str, ~StorageConstraints]
         Returns -> None
         '''
         if application is not None and not isinstance(application, (bytes, str)):
@@ -1307,8 +1307,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetMetricCredentials(self, creds=None):
         '''
-        creds : typing.Sequence<+T_co>[~ApplicationMetricCredential]<~ApplicationMetricCredential>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        creds : typing.Sequence[~ApplicationMetricCredential]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if creds is not None and not isinstance(creds, (bytes, str, list)):
             raise Exception("Expected creds to be a Sequence, received: {}".format(type(creds)))
@@ -1328,8 +1328,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetRelationsSuspended(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~RelationSuspendedArg]<~RelationSuspendedArg>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~RelationSuspendedArg]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -1372,7 +1372,7 @@ class ApplicationFacade(Type):
         '''
         application : str
         branch : str
-        options : typing.Sequence<+T_co>[str]
+        options : typing.Sequence[str]
         Returns -> None
         '''
         if application is not None and not isinstance(application, (bytes, str)):
@@ -1401,8 +1401,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UnsetApplicationsConfig(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~ApplicationUnset]<~ApplicationUnset>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~ApplicationUnset]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -1430,7 +1430,7 @@ class ApplicationFacade(Type):
         force_series : bool
         generation : str
         min_units : int
-        settings : typing.Mapping<~KT, +VT_co>[str, str]
+        settings : typing.Mapping[str, str]
         settings_yaml : str
         Returns -> None
         '''
@@ -1488,8 +1488,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UpdateApplicationSeries(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~UpdateSeriesArg]<~UpdateSeriesArg>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~UpdateSeriesArg]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))

--- a/juju/client/_client12.py
+++ b/juju/client/_client12.py
@@ -974,7 +974,7 @@ class UniterFacade(Type):
     async def APIAddresses(self):
         '''
 
-        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence<+T_co>[str]]
+        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence[str]]
         '''
 
         # map input types to rpc msg
@@ -993,7 +993,7 @@ class UniterFacade(Type):
     async def APIHostPorts(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~HostPort]<~HostPort>
+        Returns -> typing.Sequence[~HostPort]
         '''
 
         # map input types to rpc msg
@@ -1011,8 +1011,8 @@ class UniterFacade(Type):
     @ReturnMapping(ActionResults)
     async def Actions(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ActionResult]<~ActionResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ActionResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1032,8 +1032,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def AddMetricBatches(self, batches=None):
         '''
-        batches : typing.Sequence<+T_co>[~MetricBatchParam]<~MetricBatchParam>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        batches : typing.Sequence[~MetricBatchParam]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if batches is not None and not isinstance(batches, (bytes, str, list)):
             raise Exception("Expected batches to be a Sequence, received: {}".format(type(batches)))
@@ -1053,8 +1053,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def AddUnitStorage(self, storages=None):
         '''
-        storages : typing.Sequence<+T_co>[~StorageAddParams]<~StorageAddParams>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        storages : typing.Sequence[~StorageAddParams]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if storages is not None and not isinstance(storages, (bytes, str, list)):
             raise Exception("Expected storages to be a Sequence, received: {}".format(type(storages)))
@@ -1074,8 +1074,8 @@ class UniterFacade(Type):
     @ReturnMapping(MachinePortsResults)
     async def AllMachinePorts(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MachinePortsResult]<~MachinePortsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MachinePortsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1095,8 +1095,8 @@ class UniterFacade(Type):
     @ReturnMapping(ApplicationStatusResults)
     async def ApplicationStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ApplicationStatusResult]<~ApplicationStatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ApplicationStatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1116,8 +1116,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringResults)
     async def AssignedMachine(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1137,8 +1137,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringResults)
     async def AvailabilityZone(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1158,8 +1158,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def BeginActions(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1179,8 +1179,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringResults)
     async def CharmArchiveSha256(self, urls=None):
         '''
-        urls : typing.Sequence<+T_co>[~CharmURL]<~CharmURL>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        urls : typing.Sequence[~CharmURL]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if urls is not None and not isinstance(urls, (bytes, str, list)):
             raise Exception("Expected urls to be a Sequence, received: {}".format(type(urls)))
@@ -1200,8 +1200,8 @@ class UniterFacade(Type):
     @ReturnMapping(IntResults)
     async def CharmModifiedVersion(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~IntResult]<~IntResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~IntResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1221,8 +1221,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringBoolResults)
     async def CharmURL(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringBoolResult]<~StringBoolResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringBoolResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1242,8 +1242,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ClearResolved(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1263,8 +1263,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ClosePorts(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityPortRange]<~EntityPortRange>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityPortRange]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1322,8 +1322,8 @@ class UniterFacade(Type):
     @ReturnMapping(ConfigSettingsResults)
     async def ConfigSettings(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ConfigSettingsResult]<~ConfigSettingsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ConfigSettingsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1362,8 +1362,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Destroy(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1383,8 +1383,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def DestroyAllSubordinates(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1404,8 +1404,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def DestroyUnitStorageAttachments(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1425,8 +1425,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def EnsureDead(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1446,8 +1446,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def EnterScope(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnit]<~RelationUnit>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        relation_units : typing.Sequence[~RelationUnit]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -1467,8 +1467,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def FinishActions(self, results=None):
         '''
-        results : typing.Sequence<+T_co>[~ActionExecutionResult]<~ActionExecutionResult>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        results : typing.Sequence[~ActionExecutionResult]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if results is not None and not isinstance(results, (bytes, str, list)):
             raise Exception("Expected results to be a Sequence, received: {}".format(type(results)))
@@ -1488,8 +1488,8 @@ class UniterFacade(Type):
     @ReturnMapping(MeterStatusResults)
     async def GetMeterStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MeterStatusResult]<~MeterStatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MeterStatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1509,8 +1509,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringBoolResults)
     async def GetPrincipal(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringBoolResult]<~StringBoolResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringBoolResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1530,8 +1530,8 @@ class UniterFacade(Type):
     @ReturnMapping(GoalStateResults)
     async def GoalStates(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~GoalStateResult]<~GoalStateResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~GoalStateResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1551,8 +1551,8 @@ class UniterFacade(Type):
     @ReturnMapping(BoolResults)
     async def HasSubordinates(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~BoolResult]<~BoolResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~BoolResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1572,8 +1572,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def LeaveScope(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnit]<~RelationUnit>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        relation_units : typing.Sequence[~RelationUnit]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -1593,8 +1593,8 @@ class UniterFacade(Type):
     @ReturnMapping(LifeResults)
     async def Life(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1614,8 +1614,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Merge(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~MergeLeadershipSettingsParam]<~MergeLeadershipSettingsParam>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        params : typing.Sequence[~MergeLeadershipSettingsParam]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -1636,7 +1636,7 @@ class UniterFacade(Type):
     async def ModelConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -1673,10 +1673,10 @@ class UniterFacade(Type):
     @ReturnMapping(NetworkInfoResults)
     async def NetworkInfo(self, bindings=None, relation_id=None, unit=None):
         '''
-        bindings : typing.Sequence<+T_co>[str]
+        bindings : typing.Sequence[str]
         relation_id : int
         unit : str
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~NetworkInfoResult]<~NetworkInfoResult>
+        Returns -> typing.Mapping[str, ~NetworkInfoResult]
         '''
         if bindings is not None and not isinstance(bindings, (bytes, str, list)):
             raise Exception("Expected bindings to be a Sequence, received: {}".format(type(bindings)))
@@ -1704,8 +1704,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def OpenPorts(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityPortRange]<~EntityPortRange>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityPortRange]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1725,8 +1725,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringResults)
     async def PrivateAddress(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1765,8 +1765,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringResults)
     async def PublicAddress(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1786,8 +1786,8 @@ class UniterFacade(Type):
     @ReturnMapping(GetLeadershipSettingsBulkResults)
     async def Read(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~GetLeadershipSettingsResult]<~GetLeadershipSettingsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~GetLeadershipSettingsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1807,8 +1807,8 @@ class UniterFacade(Type):
     @ReturnMapping(SettingsResults)
     async def ReadRemoteSettings(self, relation_unit_pairs=None):
         '''
-        relation_unit_pairs : typing.Sequence<+T_co>[~RelationUnitPair]<~RelationUnitPair>
-        Returns -> typing.Sequence<+T_co>[~SettingsResult]<~SettingsResult>
+        relation_unit_pairs : typing.Sequence[~RelationUnitPair]
+        Returns -> typing.Sequence[~SettingsResult]
         '''
         if relation_unit_pairs is not None and not isinstance(relation_unit_pairs, (bytes, str, list)):
             raise Exception("Expected relation_unit_pairs to be a Sequence, received: {}".format(type(relation_unit_pairs)))
@@ -1828,8 +1828,8 @@ class UniterFacade(Type):
     @ReturnMapping(SettingsResults)
     async def ReadSettings(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnit]<~RelationUnit>
-        Returns -> typing.Sequence<+T_co>[~SettingsResult]<~SettingsResult>
+        relation_units : typing.Sequence[~RelationUnit]
+        Returns -> typing.Sequence[~SettingsResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -1849,8 +1849,8 @@ class UniterFacade(Type):
     @ReturnMapping(UnitRefreshResults)
     async def Refresh(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~UnitRefreshResult]<~UnitRefreshResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~UnitRefreshResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1870,8 +1870,8 @@ class UniterFacade(Type):
     @ReturnMapping(RelationResults)
     async def Relation(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnit]<~RelationUnit>
-        Returns -> typing.Sequence<+T_co>[~RelationResult]<~RelationResult>
+        relation_units : typing.Sequence[~RelationUnit]
+        Returns -> typing.Sequence[~RelationResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -1891,8 +1891,8 @@ class UniterFacade(Type):
     @ReturnMapping(RelationResults)
     async def RelationById(self, relation_ids=None):
         '''
-        relation_ids : typing.Sequence<+T_co>[int]
-        Returns -> typing.Sequence<+T_co>[~RelationResult]<~RelationResult>
+        relation_ids : typing.Sequence[int]
+        Returns -> typing.Sequence[~RelationResult]
         '''
         if relation_ids is not None and not isinstance(relation_ids, (bytes, str, list)):
             raise Exception("Expected relation_ids to be a Sequence, received: {}".format(type(relation_ids)))
@@ -1912,8 +1912,8 @@ class UniterFacade(Type):
     @ReturnMapping(RelationUnitStatusResults)
     async def RelationsStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~RelationUnitStatusResult]<~RelationUnitStatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~RelationUnitStatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1933,8 +1933,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RemoveStorageAttachments(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~StorageAttachmentId]<~StorageAttachmentId>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        ids : typing.Sequence[~StorageAttachmentId]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -1954,8 +1954,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RequestReboot(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1975,8 +1975,8 @@ class UniterFacade(Type):
     @ReturnMapping(ResolvedModeResults)
     async def Resolved(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ResolvedModeResult]<~ResolvedModeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ResolvedModeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2015,8 +2015,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetAgentStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2036,8 +2036,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetApplicationStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2057,8 +2057,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetCharmURL(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityCharmURL]<~EntityCharmURL>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityCharmURL]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2078,8 +2078,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetPodSpec(self, specs=None):
         '''
-        specs : typing.Sequence<+T_co>[~EntityString]<~EntityString>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        specs : typing.Sequence[~EntityString]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if specs is not None and not isinstance(specs, (bytes, str, list)):
             raise Exception("Expected specs to be a Sequence, received: {}".format(type(specs)))
@@ -2099,8 +2099,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetRelationStatus(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~RelationStatusArg]<~RelationStatusArg>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~RelationStatusArg]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -2120,8 +2120,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2141,8 +2141,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetUnitStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2162,8 +2162,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetUpgradeSeriesUnitStatus(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~UpgradeSeriesStatusParam]<~UpgradeSeriesStatusParam>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        params : typing.Sequence[~UpgradeSeriesStatusParam]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -2183,8 +2183,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetWorkloadVersion(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityWorkloadVersion]<~EntityWorkloadVersion>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityWorkloadVersion]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2204,8 +2204,8 @@ class UniterFacade(Type):
     @ReturnMapping(LifeResults)
     async def StorageAttachmentLife(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~StorageAttachmentId]<~StorageAttachmentId>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        ids : typing.Sequence[~StorageAttachmentId]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -2225,8 +2225,8 @@ class UniterFacade(Type):
     @ReturnMapping(StorageAttachmentResults)
     async def StorageAttachments(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~StorageAttachmentId]<~StorageAttachmentId>
-        Returns -> typing.Sequence<+T_co>[~StorageAttachmentResult]<~StorageAttachmentResult>
+        ids : typing.Sequence[~StorageAttachmentId]
+        Returns -> typing.Sequence[~StorageAttachmentResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -2246,8 +2246,8 @@ class UniterFacade(Type):
     @ReturnMapping(StatusResults)
     async def UnitStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StatusResult]<~StatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2267,8 +2267,8 @@ class UniterFacade(Type):
     @ReturnMapping(StorageAttachmentIdsResults)
     async def UnitStorageAttachments(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StorageAttachmentIdsResult]<~StorageAttachmentIdsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StorageAttachmentIdsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2288,8 +2288,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UpdateSettings(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnitSettings]<~RelationUnitSettings>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        relation_units : typing.Sequence[~RelationUnitSettings]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -2309,8 +2309,8 @@ class UniterFacade(Type):
     @ReturnMapping(UpgradeSeriesStatusResults)
     async def UpgradeSeriesUnitStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~UpgradeSeriesStatusResult]<~UpgradeSeriesStatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~UpgradeSeriesStatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2330,8 +2330,8 @@ class UniterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def Watch(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2370,8 +2370,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchActionNotifications(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2391,8 +2391,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchConfigSettingsHash(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2431,8 +2431,8 @@ class UniterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchLeadershipSettings(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2452,8 +2452,8 @@ class UniterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchMeterStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2473,8 +2473,8 @@ class UniterFacade(Type):
     @ReturnMapping(RelationUnitsWatchResults)
     async def WatchRelationUnits(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnit]<~RelationUnit>
-        Returns -> typing.Sequence<+T_co>[~RelationUnitsWatchResult]<~RelationUnitsWatchResult>
+        relation_units : typing.Sequence[~RelationUnit]
+        Returns -> typing.Sequence[~RelationUnitsWatchResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -2494,8 +2494,8 @@ class UniterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchStorageAttachments(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~StorageAttachmentId]<~StorageAttachmentId>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        ids : typing.Sequence[~StorageAttachmentId]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -2515,8 +2515,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchTrustConfigSettingsHash(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2536,8 +2536,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchUnitAddressesHash(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2557,8 +2557,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchUnitRelations(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2578,8 +2578,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchUnitStorageAttachments(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2599,8 +2599,8 @@ class UniterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchUpgradeSeriesNotifications(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2620,8 +2620,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringResults)
     async def WorkloadVersion(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))

--- a/juju/client/_client2.py
+++ b/juju/client/_client2.py
@@ -165,8 +165,8 @@ class ActionFacade(Type):
     @ReturnMapping(ActionResults)
     async def Actions(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ActionResult]<~ActionResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ActionResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -186,8 +186,8 @@ class ActionFacade(Type):
     @ReturnMapping(ApplicationsCharmActionsResults)
     async def ApplicationsCharmsActions(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ApplicationCharmActionsResult]<~ApplicationCharmActionsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ApplicationCharmActionsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -207,8 +207,8 @@ class ActionFacade(Type):
     @ReturnMapping(ActionResults)
     async def Cancel(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ActionResult]<~ActionResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ActionResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -228,8 +228,8 @@ class ActionFacade(Type):
     @ReturnMapping(ActionResults)
     async def Enqueue(self, actions=None):
         '''
-        actions : typing.Sequence<+T_co>[~Action]<~Action>
-        Returns -> typing.Sequence<+T_co>[~ActionResult]<~ActionResult>
+        actions : typing.Sequence[~Action]
+        Returns -> typing.Sequence[~ActionResult]
         '''
         if actions is not None and not isinstance(actions, (bytes, str, list)):
             raise Exception("Expected actions to be a Sequence, received: {}".format(type(actions)))
@@ -249,8 +249,8 @@ class ActionFacade(Type):
     @ReturnMapping(FindTagsResults)
     async def FindActionTagsByPrefix(self, prefixes=None):
         '''
-        prefixes : typing.Sequence<+T_co>[str]
-        Returns -> typing.Sequence<+T_co>[~Entity]<~Entity>
+        prefixes : typing.Sequence[str]
+        Returns -> typing.Sequence[~Entity]
         '''
         if prefixes is not None and not isinstance(prefixes, (bytes, str, list)):
             raise Exception("Expected prefixes to be a Sequence, received: {}".format(type(prefixes)))
@@ -270,8 +270,8 @@ class ActionFacade(Type):
     @ReturnMapping(ActionsByNames)
     async def FindActionsByNames(self, names=None):
         '''
-        names : typing.Sequence<+T_co>[str]
-        Returns -> typing.Sequence<+T_co>[~ActionsByName]<~ActionsByName>
+        names : typing.Sequence[str]
+        Returns -> typing.Sequence[~ActionsByName]
         '''
         if names is not None and not isinstance(names, (bytes, str, list)):
             raise Exception("Expected names to be a Sequence, received: {}".format(type(names)))
@@ -291,8 +291,8 @@ class ActionFacade(Type):
     @ReturnMapping(ActionsByReceivers)
     async def ListAll(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ActionsByReceiver]<~ActionsByReceiver>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ActionsByReceiver]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -312,8 +312,8 @@ class ActionFacade(Type):
     @ReturnMapping(ActionsByReceivers)
     async def ListCompleted(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ActionsByReceiver]<~ActionsByReceiver>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ActionsByReceiver]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -333,8 +333,8 @@ class ActionFacade(Type):
     @ReturnMapping(ActionsByReceivers)
     async def ListPending(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ActionsByReceiver]<~ActionsByReceiver>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ActionsByReceiver]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -354,8 +354,8 @@ class ActionFacade(Type):
     @ReturnMapping(ActionsByReceivers)
     async def ListRunning(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ActionsByReceiver]<~ActionsByReceiver>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ActionsByReceiver]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -375,12 +375,12 @@ class ActionFacade(Type):
     @ReturnMapping(ActionResults)
     async def Run(self, applications=None, commands=None, machines=None, timeout=None, units=None):
         '''
-        applications : typing.Sequence<+T_co>[str]
+        applications : typing.Sequence[str]
         commands : str
-        machines : typing.Sequence<+T_co>[str]
+        machines : typing.Sequence[str]
         timeout : int
-        units : typing.Sequence<+T_co>[str]
-        Returns -> typing.Sequence<+T_co>[~ActionResult]<~ActionResult>
+        units : typing.Sequence[str]
+        Returns -> typing.Sequence[~ActionResult]
         '''
         if applications is not None and not isinstance(applications, (bytes, str, list)):
             raise Exception("Expected applications to be a Sequence, received: {}".format(type(applications)))
@@ -416,12 +416,12 @@ class ActionFacade(Type):
     @ReturnMapping(ActionResults)
     async def RunOnAllMachines(self, applications=None, commands=None, machines=None, timeout=None, units=None):
         '''
-        applications : typing.Sequence<+T_co>[str]
+        applications : typing.Sequence[str]
         commands : str
-        machines : typing.Sequence<+T_co>[str]
+        machines : typing.Sequence[str]
         timeout : int
-        units : typing.Sequence<+T_co>[str]
-        Returns -> typing.Sequence<+T_co>[~ActionResult]<~ActionResult>
+        units : typing.Sequence[str]
+        Returns -> typing.Sequence[~ActionResult]
         '''
         if applications is not None and not isinstance(applications, (bytes, str, list)):
             raise Exception("Expected applications to be a Sequence, received: {}".format(type(applications)))
@@ -632,8 +632,8 @@ class AgentFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ClearReboot(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -653,8 +653,8 @@ class AgentFacade(Type):
     @ReturnMapping(CloudSpecResults)
     async def CloudSpec(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~CloudSpecResult]<~CloudSpecResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~CloudSpecResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -674,8 +674,8 @@ class AgentFacade(Type):
     @ReturnMapping(ControllerAPIInfoResults)
     async def ControllerAPIInfoForModels(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ControllerAPIInfoResult]<~ControllerAPIInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ControllerAPIInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -696,7 +696,7 @@ class AgentFacade(Type):
     async def ControllerConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -733,8 +733,8 @@ class AgentFacade(Type):
     @ReturnMapping(AgentGetEntitiesResults)
     async def GetEntities(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~AgentGetEntitiesResult]<~AgentGetEntitiesResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~AgentGetEntitiesResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -774,7 +774,7 @@ class AgentFacade(Type):
     async def ModelConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -792,8 +792,8 @@ class AgentFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetPasswords(self, changes=None):
         '''
-        changes : typing.Sequence<+T_co>[~EntityPassword]<~EntityPassword>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        changes : typing.Sequence[~EntityPassword]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if changes is not None and not isinstance(changes, (bytes, str, list)):
             raise Exception("Expected changes to be a Sequence, received: {}".format(type(changes)))
@@ -832,8 +832,8 @@ class AgentFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchCloudSpecsChanges(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -853,8 +853,8 @@ class AgentFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchCredentials(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -914,7 +914,7 @@ class AllModelWatcherFacade(Type):
     async def Next(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~Delta]<~Delta>
+        Returns -> typing.Sequence[~Delta]
         '''
 
         # map input types to rpc msg
@@ -1011,8 +1011,8 @@ class AnnotationsFacade(Type):
     @ReturnMapping(AnnotationsGetResults)
     async def Get(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~AnnotationsGetResult]<~AnnotationsGetResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~AnnotationsGetResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1032,8 +1032,8 @@ class AnnotationsFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Set(self, annotations=None):
         '''
-        annotations : typing.Sequence<+T_co>[~EntityAnnotations]<~EntityAnnotations>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        annotations : typing.Sequence[~EntityAnnotations]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if annotations is not None and not isinstance(annotations, (bytes, str, list)):
             raise Exception("Expected annotations to be a Sequence, received: {}".format(type(annotations)))
@@ -1347,8 +1347,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(AddRelationResults)
     async def AddRelation(self, endpoints=None):
         '''
-        endpoints : typing.Sequence<+T_co>[str]
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~CharmRelation]<~CharmRelation>
+        endpoints : typing.Sequence[str]
+        Returns -> typing.Mapping[str, ~CharmRelation]
         '''
         if endpoints is not None and not isinstance(endpoints, (bytes, str, list)):
             raise Exception("Expected endpoints to be a Sequence, received: {}".format(type(endpoints)))
@@ -1370,8 +1370,8 @@ class ApplicationFacade(Type):
         '''
         application : str
         num_units : int
-        placement : typing.Sequence<+T_co>[~Placement]<~Placement>
-        Returns -> typing.Sequence<+T_co>[str]
+        placement : typing.Sequence[~Placement]
+        Returns -> typing.Sequence[str]
         '''
         if application is not None and not isinstance(application, (bytes, str)):
             raise Exception("Expected application to be a str, received: {}".format(type(application)))
@@ -1400,7 +1400,7 @@ class ApplicationFacade(Type):
     async def CharmRelations(self, application=None):
         '''
         application : str
-        Returns -> typing.Sequence<+T_co>[str]
+        Returns -> typing.Sequence[str]
         '''
         if application is not None and not isinstance(application, (bytes, str)):
             raise Exception("Expected application to be a str, received: {}".format(type(application)))
@@ -1420,8 +1420,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Deploy(self, applications=None):
         '''
-        applications : typing.Sequence<+T_co>[~ApplicationDeploy]<~ApplicationDeploy>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        applications : typing.Sequence[~ApplicationDeploy]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if applications is not None and not isinstance(applications, (bytes, str, list)):
             raise Exception("Expected applications to be a Sequence, received: {}".format(type(applications)))
@@ -1462,7 +1462,7 @@ class ApplicationFacade(Type):
     @ReturnMapping(None)
     async def DestroyRelation(self, endpoints=None):
         '''
-        endpoints : typing.Sequence<+T_co>[str]
+        endpoints : typing.Sequence[str]
         Returns -> None
         '''
         if endpoints is not None and not isinstance(endpoints, (bytes, str, list)):
@@ -1483,7 +1483,7 @@ class ApplicationFacade(Type):
     @ReturnMapping(None)
     async def DestroyUnits(self, unit_names=None):
         '''
-        unit_names : typing.Sequence<+T_co>[str]
+        unit_names : typing.Sequence[str]
         Returns -> None
         '''
         if unit_names is not None and not isinstance(unit_names, (bytes, str, list)):
@@ -1526,7 +1526,7 @@ class ApplicationFacade(Type):
     async def Get(self, application=None):
         '''
         application : str
-        Returns -> typing.Union[str, typing.Mapping<~KT, +VT_co>[str, typing.Any], _ForwardRef('Value')]
+        Returns -> typing.Union[str, typing.Mapping[str, typing.Any], _ForwardRef('Value')]
         '''
         if application is not None and not isinstance(application, (bytes, str)):
             raise Exception("Expected application to be a str, received: {}".format(type(application)))
@@ -1589,7 +1589,7 @@ class ApplicationFacade(Type):
     async def Set(self, application=None, options=None):
         '''
         application : str
-        options : typing.Mapping<~KT, +VT_co>[str, str]
+        options : typing.Mapping[str, str]
         Returns -> None
         '''
         if application is not None and not isinstance(application, (bytes, str)):
@@ -1617,12 +1617,12 @@ class ApplicationFacade(Type):
         application : str
         channel : str
         charm_url : str
-        config_settings : typing.Mapping<~KT, +VT_co>[str, str]
+        config_settings : typing.Mapping[str, str]
         config_settings_yaml : str
         force_series : bool
         force_units : bool
-        resource_ids : typing.Mapping<~KT, +VT_co>[str, str]
-        storage_constraints : typing.Mapping<~KT, +VT_co>[str, ~StorageConstraints]<~StorageConstraints>
+        resource_ids : typing.Mapping[str, str]
+        storage_constraints : typing.Mapping[str, ~StorageConstraints]
         Returns -> None
         '''
         if application is not None and not isinstance(application, (bytes, str)):
@@ -1701,8 +1701,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetMetricCredentials(self, creds=None):
         '''
-        creds : typing.Sequence<+T_co>[~ApplicationMetricCredential]<~ApplicationMetricCredential>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        creds : typing.Sequence[~ApplicationMetricCredential]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if creds is not None and not isinstance(creds, (bytes, str, list)):
             raise Exception("Expected creds to be a Sequence, received: {}".format(type(creds)))
@@ -1744,7 +1744,7 @@ class ApplicationFacade(Type):
     async def Unset(self, application=None, options=None):
         '''
         application : str
-        options : typing.Sequence<+T_co>[str]
+        options : typing.Sequence[str]
         Returns -> None
         '''
         if application is not None and not isinstance(application, (bytes, str)):
@@ -1775,7 +1775,7 @@ class ApplicationFacade(Type):
         force_charm_url : bool
         force_series : bool
         min_units : int
-        settings : typing.Mapping<~KT, +VT_co>[str, str]
+        settings : typing.Mapping[str, str]
         settings_yaml : str
         Returns -> None
         '''
@@ -2140,8 +2140,8 @@ class ApplicationOffersFacade(Type):
     @ReturnMapping(ApplicationOffersResults)
     async def ApplicationOffers(self, offer_urls=None):
         '''
-        offer_urls : typing.Sequence<+T_co>[str]
-        Returns -> typing.Sequence<+T_co>[~ApplicationOfferResult]<~ApplicationOfferResult>
+        offer_urls : typing.Sequence[str]
+        Returns -> typing.Sequence[~ApplicationOfferResult]
         '''
         if offer_urls is not None and not isinstance(offer_urls, (bytes, str, list)):
             raise Exception("Expected offer_urls to be a Sequence, received: {}".format(type(offer_urls)))
@@ -2162,8 +2162,8 @@ class ApplicationOffersFacade(Type):
     async def DestroyOffers(self, force=None, offer_urls=None):
         '''
         force : bool
-        offer_urls : typing.Sequence<+T_co>[str]
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        offer_urls : typing.Sequence[str]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if force is not None and not isinstance(force, bool):
             raise Exception("Expected force to be a bool, received: {}".format(type(force)))
@@ -2187,8 +2187,8 @@ class ApplicationOffersFacade(Type):
     @ReturnMapping(QueryApplicationOffersResults)
     async def FindApplicationOffers(self, filters=None):
         '''
-        filters : typing.Sequence<+T_co>[~OfferFilter]<~OfferFilter>
-        Returns -> typing.Sequence<+T_co>[~ApplicationOfferAdminDetails]<~ApplicationOfferAdminDetails>
+        filters : typing.Sequence[~OfferFilter]
+        Returns -> typing.Sequence[~ApplicationOfferAdminDetails]
         '''
         if filters is not None and not isinstance(filters, (bytes, str, list)):
             raise Exception("Expected filters to be a Sequence, received: {}".format(type(filters)))
@@ -2208,8 +2208,8 @@ class ApplicationOffersFacade(Type):
     @ReturnMapping(ConsumeOfferDetailsResults)
     async def GetConsumeDetails(self, offer_urls=None):
         '''
-        offer_urls : typing.Sequence<+T_co>[str]
-        Returns -> typing.Sequence<+T_co>[~ConsumeOfferDetailsResult]<~ConsumeOfferDetailsResult>
+        offer_urls : typing.Sequence[str]
+        Returns -> typing.Sequence[~ConsumeOfferDetailsResult]
         '''
         if offer_urls is not None and not isinstance(offer_urls, (bytes, str, list)):
             raise Exception("Expected offer_urls to be a Sequence, received: {}".format(type(offer_urls)))
@@ -2229,8 +2229,8 @@ class ApplicationOffersFacade(Type):
     @ReturnMapping(QueryApplicationOffersResults)
     async def ListApplicationOffers(self, filters=None):
         '''
-        filters : typing.Sequence<+T_co>[~OfferFilter]<~OfferFilter>
-        Returns -> typing.Sequence<+T_co>[~ApplicationOfferAdminDetails]<~ApplicationOfferAdminDetails>
+        filters : typing.Sequence[~OfferFilter]
+        Returns -> typing.Sequence[~ApplicationOfferAdminDetails]
         '''
         if filters is not None and not isinstance(filters, (bytes, str, list)):
             raise Exception("Expected filters to be a Sequence, received: {}".format(type(filters)))
@@ -2250,8 +2250,8 @@ class ApplicationOffersFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ModifyOfferAccess(self, changes=None):
         '''
-        changes : typing.Sequence<+T_co>[~ModifyOfferAccess]<~ModifyOfferAccess>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        changes : typing.Sequence[~ModifyOfferAccess]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if changes is not None and not isinstance(changes, (bytes, str, list)):
             raise Exception("Expected changes to be a Sequence, received: {}".format(type(changes)))
@@ -2271,8 +2271,8 @@ class ApplicationOffersFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Offer(self, offers=None):
         '''
-        offers : typing.Sequence<+T_co>[~AddApplicationOffer]<~AddApplicationOffer>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        offers : typing.Sequence[~AddApplicationOffer]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if offers is not None and not isinstance(offers, (bytes, str, list)):
             raise Exception("Expected offers to be a Sequence, received: {}".format(type(offers)))
@@ -2292,8 +2292,8 @@ class ApplicationOffersFacade(Type):
     @ReturnMapping(RemoteApplicationInfoResults)
     async def RemoteApplicationInfo(self, offer_urls=None):
         '''
-        offer_urls : typing.Sequence<+T_co>[str]
-        Returns -> typing.Sequence<+T_co>[~RemoteApplicationInfoResult]<~RemoteApplicationInfoResult>
+        offer_urls : typing.Sequence[str]
+        Returns -> typing.Sequence[~RemoteApplicationInfoResult]
         '''
         if offer_urls is not None and not isinstance(offer_urls, (bytes, str, list)):
             raise Exception("Expected offer_urls to be a Sequence, received: {}".format(type(offer_urls)))
@@ -2500,7 +2500,7 @@ class BackupsFacade(Type):
     async def List(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~BackupsMetadataResult]<~BackupsMetadataResult>
+        Returns -> typing.Sequence[~BackupsMetadataResult]
         '''
 
         # map input types to rpc msg
@@ -2537,8 +2537,8 @@ class BackupsFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Remove(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[str]
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        ids : typing.Sequence[str]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -2626,7 +2626,7 @@ class BlockFacade(Type):
     async def List(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~BlockResult]<~BlockResult>
+        Returns -> typing.Sequence[~BlockResult]
         '''
 
         # map input types to rpc msg
@@ -2765,7 +2765,7 @@ class BundleFacade(Type):
         '''
         bundleurl : str
         yaml : str
-        Returns -> typing.Sequence<+T_co>[~BundleChange]<~BundleChange>
+        Returns -> typing.Union[typing.Sequence[~BundleChange], typing.Sequence[str]]
         '''
         if bundleurl is not None and not isinstance(bundleurl, (bytes, str)):
             raise Exception("Expected bundleurl to be a str, received: {}".format(type(bundleurl)))
@@ -3013,7 +3013,7 @@ class CharmsFacade(Type):
     async def CharmInfo(self, url=None):
         '''
         url : str
-        Returns -> typing.Union[_ForwardRef('CharmActions'), typing.Mapping<~KT, +VT_co>[str, ~CharmOption]<~CharmOption>, _ForwardRef('CharmLXDProfile'), _ForwardRef('CharmMeta'), _ForwardRef('CharmMetrics'), int, str]
+        Returns -> typing.Union[_ForwardRef('CharmActions'), typing.Mapping[str, ~CharmOption], _ForwardRef('CharmLXDProfile'), _ForwardRef('CharmMeta'), _ForwardRef('CharmMetrics'), int, str]
         '''
         if url is not None and not isinstance(url, (bytes, str)):
             raise Exception("Expected url to be a str, received: {}".format(type(url)))
@@ -3054,8 +3054,8 @@ class CharmsFacade(Type):
     @ReturnMapping(CharmsListResult)
     async def List(self, names=None):
         '''
-        names : typing.Sequence<+T_co>[str]
-        Returns -> typing.Sequence<+T_co>[str]
+        names : typing.Sequence[str]
+        Returns -> typing.Sequence[str]
         '''
         if names is not None and not isinstance(names, (bytes, str, list)):
             raise Exception("Expected names to be a Sequence, received: {}".format(type(names)))
@@ -3983,7 +3983,7 @@ class ClientFacade(Type):
     async def APIHostPorts(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~HostPort]<~HostPort>
+        Returns -> typing.Sequence[~HostPort]
         '''
 
         # map input types to rpc msg
@@ -4087,8 +4087,8 @@ class ClientFacade(Type):
     @ReturnMapping(AddMachinesResults)
     async def AddMachines(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~AddMachineParams]<~AddMachineParams>
-        Returns -> typing.Sequence<+T_co>[~AddMachinesResult]<~AddMachinesResult>
+        params : typing.Sequence[~AddMachineParams]
+        Returns -> typing.Sequence[~AddMachinesResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -4108,8 +4108,8 @@ class ClientFacade(Type):
     @ReturnMapping(AddMachinesResults)
     async def AddMachinesV2(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~AddMachineParams]<~AddMachineParams>
-        Returns -> typing.Sequence<+T_co>[~AddMachinesResult]<~AddMachinesResult>
+        params : typing.Sequence[~AddMachineParams]
+        Returns -> typing.Sequence[~AddMachinesResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -4149,7 +4149,7 @@ class ClientFacade(Type):
     async def CACert(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[int]
+        Returns -> typing.Sequence[int]
         '''
 
         # map input types to rpc msg
@@ -4168,7 +4168,7 @@ class ClientFacade(Type):
     async def DestroyMachines(self, force=None, machine_names=None):
         '''
         force : bool
-        machine_names : typing.Sequence<+T_co>[str]
+        machine_names : typing.Sequence[str]
         Returns -> None
         '''
         if force is not None and not isinstance(force, bool):
@@ -4199,7 +4199,7 @@ class ClientFacade(Type):
         minor : int
         number : Number
         series : str
-        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence<+T_co>[~Tools]<~Tools>]
+        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence[~Tools]]
         '''
         if agentstream is not None and not isinstance(agentstream, (bytes, str)):
             raise Exception("Expected agentstream to be a str, received: {}".format(type(agentstream)))
@@ -4239,8 +4239,8 @@ class ClientFacade(Type):
     @ReturnMapping(FullStatus)
     async def FullStatus(self, patterns=None):
         '''
-        patterns : typing.Sequence<+T_co>[str]
-        Returns -> typing.Union[_ForwardRef('ModelStatusInfo'), typing.Sequence<+T_co>[~RelationStatus]<~RelationStatus>, typing.Mapping<~KT, +VT_co>[str, ~RemoteApplicationStatus]<~RemoteApplicationStatus>]
+        patterns : typing.Sequence[str]
+        Returns -> typing.Union[typing.Mapping[str, ~ApplicationStatus], typing.Mapping[str, ~BranchStatus], str, typing.Mapping[str, ~MachineStatus], _ForwardRef('ModelStatusInfo'), typing.Mapping[str, ~ApplicationOfferStatus], typing.Sequence[~RelationStatus], typing.Mapping[str, ~RemoteApplicationStatus]]
         '''
         if patterns is not None and not isinstance(patterns, (bytes, str, list)):
             raise Exception("Expected patterns to be a Sequence, received: {}".format(type(patterns)))
@@ -4262,7 +4262,7 @@ class ClientFacade(Type):
         '''
         bundleurl : str
         yaml : str
-        Returns -> typing.Sequence<+T_co>[~BundleChange]<~BundleChange>
+        Returns -> typing.Union[typing.Sequence[~BundleChange], typing.Sequence[str]]
         '''
         if bundleurl is not None and not isinstance(bundleurl, (bytes, str)):
             raise Exception("Expected bundleurl to be a str, received: {}".format(type(bundleurl)))
@@ -4305,8 +4305,8 @@ class ClientFacade(Type):
     @ReturnMapping(AddMachinesResults)
     async def InjectMachines(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~AddMachineParams]<~AddMachineParams>
-        Returns -> typing.Sequence<+T_co>[~AddMachinesResult]<~AddMachinesResult>
+        params : typing.Sequence[~AddMachineParams]
+        Returns -> typing.Sequence[~AddMachinesResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -4327,7 +4327,7 @@ class ClientFacade(Type):
     async def ModelGet(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~ConfigValue]<~ConfigValue>
+        Returns -> typing.Mapping[str, ~ConfigValue]
         '''
 
         # map input types to rpc msg
@@ -4346,7 +4346,7 @@ class ClientFacade(Type):
     async def ModelInfo(self):
         '''
 
-        Returns -> typing.Union[_ForwardRef('Number'), bool, _ForwardRef('ModelMigrationStatus'), _ForwardRef('ModelSLAInfo'), _ForwardRef('EntityStatus'), typing.Sequence<+T_co>[~ModelUserInfo]<~ModelUserInfo>]
+        Returns -> typing.Union[_ForwardRef('Number'), str, bool, typing.Sequence[~ModelMachineInfo], _ForwardRef('ModelMigrationStatus'), _ForwardRef('ModelSLAInfo'), _ForwardRef('EntityStatus'), typing.Sequence[~ModelUserInfo]]
         '''
 
         # map input types to rpc msg
@@ -4364,7 +4364,7 @@ class ClientFacade(Type):
     @ReturnMapping(None)
     async def ModelSet(self, config=None):
         '''
-        config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        config : typing.Mapping[str, typing.Any]
         Returns -> None
         '''
         if config is not None and not isinstance(config, dict):
@@ -4385,7 +4385,7 @@ class ClientFacade(Type):
     @ReturnMapping(None)
     async def ModelUnset(self, keys=None):
         '''
-        keys : typing.Sequence<+T_co>[str]
+        keys : typing.Sequence[str]
         Returns -> None
         '''
         if keys is not None and not isinstance(keys, (bytes, str, list)):
@@ -4407,7 +4407,7 @@ class ClientFacade(Type):
     async def ModelUserInfo(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~ModelUserInfoResult]<~ModelUserInfoResult>
+        Returns -> typing.Sequence[~ModelUserInfoResult]
         '''
 
         # map input types to rpc msg
@@ -4503,8 +4503,8 @@ class ClientFacade(Type):
     @ReturnMapping(ResolveCharmResults)
     async def ResolveCharms(self, references=None):
         '''
-        references : typing.Sequence<+T_co>[str]
-        Returns -> typing.Sequence<+T_co>[~ResolveCharmResult]<~ResolveCharmResult>
+        references : typing.Sequence[str]
+        Returns -> typing.Sequence[~ResolveCharmResult]
         '''
         if references is not None and not isinstance(references, (bytes, str, list)):
             raise Exception("Expected references to be a Sequence, received: {}".format(type(references)))
@@ -4550,8 +4550,8 @@ class ClientFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RetryProvisioning(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4643,7 +4643,7 @@ class ClientFacade(Type):
     async def SetSLALevel(self, modelslainfo=None, creds=None, level=None, owner=None):
         '''
         modelslainfo : ModelSLAInfo
-        creds : typing.Sequence<+T_co>[int]
+        creds : typing.Sequence[int]
         level : str
         owner : str
         Returns -> None
@@ -4678,8 +4678,8 @@ class ClientFacade(Type):
     @ReturnMapping(StatusHistoryResults)
     async def StatusHistory(self, requests=None):
         '''
-        requests : typing.Sequence<+T_co>[~StatusHistoryRequest]<~StatusHistoryRequest>
-        Returns -> typing.Sequence<+T_co>[~StatusHistoryResult]<~StatusHistoryResult>
+        requests : typing.Sequence[~StatusHistoryRequest]
+        Returns -> typing.Sequence[~StatusHistoryResult]
         '''
         if requests is not None and not isinstance(requests, (bytes, str, list)):
             raise Exception("Expected requests to be a Sequence, received: {}".format(type(requests)))
@@ -4960,8 +4960,8 @@ class DiscoverSpacesFacade(Type):
     @ReturnMapping(ErrorResults)
     async def AddSubnets(self, subnets=None):
         '''
-        subnets : typing.Sequence<+T_co>[~AddSubnetParams]<~AddSubnetParams>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        subnets : typing.Sequence[~AddSubnetParams]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if subnets is not None and not isinstance(subnets, (bytes, str, list)):
             raise Exception("Expected subnets to be a Sequence, received: {}".format(type(subnets)))
@@ -4981,8 +4981,8 @@ class DiscoverSpacesFacade(Type):
     @ReturnMapping(ErrorResults)
     async def CreateSpaces(self, spaces=None):
         '''
-        spaces : typing.Sequence<+T_co>[~CreateSpaceParams]<~CreateSpaceParams>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        spaces : typing.Sequence[~CreateSpaceParams]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if spaces is not None and not isinstance(spaces, (bytes, str, list)):
             raise Exception("Expected spaces to be a Sequence, received: {}".format(type(spaces)))
@@ -5003,7 +5003,7 @@ class DiscoverSpacesFacade(Type):
     async def ListSpaces(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~ProviderSpace]<~ProviderSpace>
+        Returns -> typing.Sequence[~ProviderSpace]
         '''
 
         # map input types to rpc msg
@@ -5023,7 +5023,7 @@ class DiscoverSpacesFacade(Type):
         '''
         space_tag : str
         zone : str
-        Returns -> typing.Sequence<+T_co>[~Subnet]<~Subnet>
+        Returns -> typing.Sequence[~Subnet]
         '''
         if space_tag is not None and not isinstance(space_tag, (bytes, str)):
             raise Exception("Expected space_tag to be a str, received: {}".format(type(space_tag)))
@@ -5048,7 +5048,7 @@ class DiscoverSpacesFacade(Type):
     async def ModelConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -5127,8 +5127,8 @@ class DiskManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetMachineBlockDevices(self, machine_block_devices=None):
         '''
-        machine_block_devices : typing.Sequence<+T_co>[~MachineBlockDevices]<~MachineBlockDevices>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        machine_block_devices : typing.Sequence[~MachineBlockDevices]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if machine_block_devices is not None and not isinstance(machine_block_devices, (bytes, str, list)):
             raise Exception("Expected machine_block_devices to be a Sequence, received: {}".format(type(machine_block_devices)))
@@ -5173,7 +5173,7 @@ class EntityWatcherFacade(Type):
     async def Next(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[str], _ForwardRef('Error')]
+        Returns -> typing.Union[typing.Sequence[str], _ForwardRef('Error'), str]
         '''
 
         # map input types to rpc msg
@@ -5242,7 +5242,7 @@ class FilesystemAttachmentsWatcherFacade(Type):
     async def Next(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[~MachineStorageId]<~MachineStorageId>, _ForwardRef('Error')]
+        Returns -> typing.Union[typing.Sequence[~MachineStorageId], _ForwardRef('Error'), str]
         '''
 
         # map input types to rpc msg
@@ -5346,8 +5346,8 @@ class HighAvailabilityFacade(Type):
     @ReturnMapping(ControllersChangeResults)
     async def EnableHA(self, specs=None):
         '''
-        specs : typing.Sequence<+T_co>[~ControllersSpec]<~ControllersSpec>
-        Returns -> typing.Sequence<+T_co>[~ControllersChangeResult]<~ControllersChangeResult>
+        specs : typing.Sequence[~ControllersSpec]
+        Returns -> typing.Sequence[~ControllersChangeResult]
         '''
         if specs is not None and not isinstance(specs, (bytes, str, list)):
             raise Exception("Expected specs to be a Sequence, received: {}".format(type(specs)))
@@ -5424,8 +5424,8 @@ class ImageManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def DeleteImages(self, images=None):
         '''
-        images : typing.Sequence<+T_co>[~ImageSpec]<~ImageSpec>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        images : typing.Sequence[~ImageSpec]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if images is not None and not isinstance(images, (bytes, str, list)):
             raise Exception("Expected images to be a Sequence, received: {}".format(type(images)))
@@ -5445,8 +5445,8 @@ class ImageManagerFacade(Type):
     @ReturnMapping(ListImageResult)
     async def ListImages(self, images=None):
         '''
-        images : typing.Sequence<+T_co>[~ImageSpec]<~ImageSpec>
-        Returns -> typing.Sequence<+T_co>[~ImageMetadata]<~ImageMetadata>
+        images : typing.Sequence[~ImageSpec]
+        Returns -> typing.Sequence[~ImageMetadata]
         '''
         if images is not None and not isinstance(images, (bytes, str, list)):
             raise Exception("Expected images to be a Sequence, received: {}".format(type(images)))
@@ -5549,8 +5549,8 @@ class ImageMetadataFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Delete(self, image_ids=None):
         '''
-        image_ids : typing.Sequence<+T_co>[str]
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        image_ids : typing.Sequence[str]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if image_ids is not None and not isinstance(image_ids, (bytes, str, list)):
             raise Exception("Expected image_ids to be a Sequence, received: {}".format(type(image_ids)))
@@ -5570,13 +5570,13 @@ class ImageMetadataFacade(Type):
     @ReturnMapping(ListCloudImageMetadataResult)
     async def List(self, arches=None, region=None, root_storage_type=None, series=None, stream=None, virt_type=None):
         '''
-        arches : typing.Sequence<+T_co>[str]
+        arches : typing.Sequence[str]
         region : str
         root_storage_type : str
-        series : typing.Sequence<+T_co>[str]
+        series : typing.Sequence[str]
         stream : str
         virt_type : str
-        Returns -> typing.Sequence<+T_co>[~CloudImageMetadata]<~CloudImageMetadata>
+        Returns -> typing.Sequence[~CloudImageMetadata]
         '''
         if arches is not None and not isinstance(arches, (bytes, str, list)):
             raise Exception("Expected arches to be a Sequence, received: {}".format(type(arches)))
@@ -5616,8 +5616,8 @@ class ImageMetadataFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Save(self, metadata=None):
         '''
-        metadata : typing.Sequence<+T_co>[~CloudImageMetadataList]<~CloudImageMetadataList>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        metadata : typing.Sequence[~CloudImageMetadataList]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if metadata is not None and not isinstance(metadata, (bytes, str, list)):
             raise Exception("Expected metadata to be a Sequence, received: {}".format(type(metadata)))
@@ -5803,7 +5803,7 @@ class InstanceMutaterFacade(Type):
     async def CharmProfilingInfo(self, tag=None):
         '''
         tag : str
-        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence<+T_co>[~ProfileInfoResult]<~ProfileInfoResult>]
+        Returns -> typing.Union[typing.Sequence[str], _ForwardRef('Error'), str, typing.Sequence[~ProfileInfoResult]]
         '''
         if tag is not None and not isinstance(tag, (bytes, str)):
             raise Exception("Expected tag to be a str, received: {}".format(type(tag)))
@@ -5844,8 +5844,8 @@ class InstanceMutaterFacade(Type):
     @ReturnMapping(LifeResults)
     async def Life(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5865,8 +5865,8 @@ class InstanceMutaterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetCharmProfiles(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~SetProfileArg]<~SetProfileArg>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~SetProfileArg]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -5886,8 +5886,8 @@ class InstanceMutaterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetModificationStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5908,7 +5908,7 @@ class InstanceMutaterFacade(Type):
     async def WatchContainers(self, tag=None):
         '''
         tag : str
-        Returns -> typing.Union[typing.Sequence<+T_co>[str], _ForwardRef('Error')]
+        Returns -> typing.Union[typing.Sequence[str], _ForwardRef('Error'), str]
         '''
         if tag is not None and not isinstance(tag, (bytes, str)):
             raise Exception("Expected tag to be a str, received: {}".format(type(tag)))
@@ -5928,8 +5928,8 @@ class InstanceMutaterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchLXDProfileVerificationNeeded(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5950,7 +5950,7 @@ class InstanceMutaterFacade(Type):
     async def WatchMachines(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[str], _ForwardRef('Error')]
+        Returns -> typing.Union[typing.Sequence[str], _ForwardRef('Error'), str]
         '''
 
         # map input types to rpc msg
@@ -6034,8 +6034,8 @@ class LeadershipServiceFacade(Type):
     @ReturnMapping(ClaimLeadershipBulkResults)
     async def ClaimLeadership(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~ClaimLeadershipParams]<~ClaimLeadershipParams>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        params : typing.Sequence[~ClaimLeadershipParams]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -6193,8 +6193,8 @@ class MachineManagerFacade(Type):
     @ReturnMapping(AddMachinesResults)
     async def AddMachines(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~AddMachineParams]<~AddMachineParams>
-        Returns -> typing.Sequence<+T_co>[~AddMachinesResult]<~AddMachinesResult>
+        params : typing.Sequence[~AddMachineParams]
+        Returns -> typing.Sequence[~AddMachinesResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -6214,8 +6214,8 @@ class MachineManagerFacade(Type):
     @ReturnMapping(InstanceTypesResults)
     async def InstanceTypes(self, constraints=None):
         '''
-        constraints : typing.Sequence<+T_co>[~ModelInstanceTypesConstraint]<~ModelInstanceTypesConstraint>
-        Returns -> typing.Sequence<+T_co>[~InstanceTypesResult]<~InstanceTypesResult>
+        constraints : typing.Sequence[~ModelInstanceTypesConstraint]
+        Returns -> typing.Sequence[~InstanceTypesResult]
         '''
         if constraints is not None and not isinstance(constraints, (bytes, str, list)):
             raise Exception("Expected constraints to be a Sequence, received: {}".format(type(constraints)))
@@ -6291,8 +6291,8 @@ class MetricsAdderFacade(Type):
     @ReturnMapping(ErrorResults)
     async def AddMetricBatches(self, batches=None):
         '''
-        batches : typing.Sequence<+T_co>[~MetricBatchParam]<~MetricBatchParam>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        batches : typing.Sequence[~MetricBatchParam]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if batches is not None and not isinstance(batches, (bytes, str, list)):
             raise Exception("Expected batches to be a Sequence, received: {}".format(type(batches)))
@@ -6384,8 +6384,8 @@ class MetricsDebugFacade(Type):
     @ReturnMapping(MetricResults)
     async def GetMetrics(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~EntityMetrics]<~EntityMetrics>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~EntityMetrics]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6405,8 +6405,8 @@ class MetricsDebugFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetMeterStatus(self, statues=None):
         '''
-        statues : typing.Sequence<+T_co>[~MeterStatusParam]<~MeterStatusParam>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        statues : typing.Sequence[~MeterStatusParam]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if statues is not None and not isinstance(statues, (bytes, str, list)):
             raise Exception("Expected statues to be a Sequence, received: {}".format(type(statues)))
@@ -6501,7 +6501,7 @@ class ModelConfigFacade(Type):
     async def ModelGet(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~ConfigValue]<~ConfigValue>
+        Returns -> typing.Mapping[str, ~ConfigValue]
         '''
 
         # map input types to rpc msg
@@ -6519,7 +6519,7 @@ class ModelConfigFacade(Type):
     @ReturnMapping(None)
     async def ModelSet(self, config=None):
         '''
-        config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        config : typing.Mapping[str, typing.Any]
         Returns -> None
         '''
         if config is not None and not isinstance(config, dict):
@@ -6540,7 +6540,7 @@ class ModelConfigFacade(Type):
     @ReturnMapping(None)
     async def ModelUnset(self, keys=None):
         '''
-        keys : typing.Sequence<+T_co>[str]
+        keys : typing.Sequence[str]
         Returns -> None
         '''
         if keys is not None and not isinstance(keys, (bytes, str, list)):
@@ -6581,7 +6581,7 @@ class ModelConfigFacade(Type):
     async def Sequences(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, int]
+        Returns -> typing.Mapping[str, int]
         '''
 
         # map input types to rpc msg
@@ -6600,7 +6600,7 @@ class ModelConfigFacade(Type):
     async def SetSLALevel(self, modelslainfo=None, creds=None, level=None, owner=None):
         '''
         modelslainfo : ModelSLAInfo
-        creds : typing.Sequence<+T_co>[int]
+        creds : typing.Sequence[int]
         level : str
         owner : str
         Returns -> None
@@ -6778,9 +6778,9 @@ class ModelGenerationFacade(Type):
     @ReturnMapping(GenerationResults)
     async def BranchInfo(self, branches=None, detailed=None):
         '''
-        branches : typing.Sequence<+T_co>[str]
+        branches : typing.Sequence[str]
         detailed : bool
-        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence<+T_co>[~Generation]<~Generation>]
+        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence[~Generation]]
         '''
         if branches is not None and not isinstance(branches, (bytes, str, list)):
             raise Exception("Expected branches to be a Sequence, received: {}".format(type(branches)))
@@ -6847,8 +6847,8 @@ class ModelGenerationFacade(Type):
     async def TrackBranch(self, branch=None, entities=None):
         '''
         branch : str
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if branch is not None and not isinstance(branch, (bytes, str)):
             raise Exception("Expected branch to be a str, received: {}".format(type(branch)))
@@ -7161,12 +7161,12 @@ class ModelManagerFacade(Type):
     async def CreateModel(self, cloud_tag=None, config=None, credential=None, name=None, owner_tag=None, region=None):
         '''
         cloud_tag : str
-        config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        config : typing.Mapping[str, typing.Any]
         credential : str
         name : str
         owner_tag : str
         region : str
-        Returns -> typing.Union[_ForwardRef('Number'), _ForwardRef('ModelMigrationStatus'), _ForwardRef('ModelSLAInfo'), _ForwardRef('EntityStatus'), typing.Sequence<+T_co>[~ModelUserInfo]<~ModelUserInfo>]
+        Returns -> typing.Union[_ForwardRef('Number'), str, typing.Sequence[~ModelMachineInfo], _ForwardRef('ModelMigrationStatus'), _ForwardRef('ModelSLAInfo'), _ForwardRef('EntityStatus'), typing.Sequence[~ModelUserInfo]]
         '''
         if cloud_tag is not None and not isinstance(cloud_tag, (bytes, str)):
             raise Exception("Expected cloud_tag to be a str, received: {}".format(type(cloud_tag)))
@@ -7206,8 +7206,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def DestroyModels(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7227,8 +7227,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(MapResults)
     async def DumpModels(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MapResult]<~MapResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MapResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7248,8 +7248,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(MapResults)
     async def DumpModelsDB(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MapResult]<~MapResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MapResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7270,7 +7270,7 @@ class ModelManagerFacade(Type):
     async def ListModels(self, tag=None):
         '''
         tag : str
-        Returns -> typing.Sequence<+T_co>[~UserModel]<~UserModel>
+        Returns -> typing.Sequence[~UserModel]
         '''
         if tag is not None and not isinstance(tag, (bytes, str)):
             raise Exception("Expected tag to be a str, received: {}".format(type(tag)))
@@ -7291,7 +7291,7 @@ class ModelManagerFacade(Type):
     async def ModelDefaults(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~ModelDefaults]<~ModelDefaults>
+        Returns -> typing.Mapping[str, ~ModelDefaults]
         '''
 
         # map input types to rpc msg
@@ -7309,8 +7309,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ModelInfoResults)
     async def ModelInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ModelInfoResult]<~ModelInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ModelInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7330,8 +7330,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ModelStatusResults)
     async def ModelStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ModelStatus]<~ModelStatus>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ModelStatus]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7351,8 +7351,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ModifyModelAccess(self, changes=None):
         '''
-        changes : typing.Sequence<+T_co>[~ModifyModelAccess]<~ModifyModelAccess>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        changes : typing.Sequence[~ModifyModelAccess]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if changes is not None and not isinstance(changes, (bytes, str, list)):
             raise Exception("Expected changes to be a Sequence, received: {}".format(type(changes)))
@@ -7372,8 +7372,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetModelDefaults(self, config=None):
         '''
-        config : typing.Sequence<+T_co>[~ModelDefaultValues]<~ModelDefaultValues>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        config : typing.Sequence[~ModelDefaultValues]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if config is not None and not isinstance(config, (bytes, str, list)):
             raise Exception("Expected config to be a Sequence, received: {}".format(type(config)))
@@ -7393,8 +7393,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UnsetModelDefaults(self, keys=None):
         '''
-        keys : typing.Sequence<+T_co>[~ModelUnsetKeys]<~ModelUnsetKeys>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        keys : typing.Sequence[~ModelUnsetKeys]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if keys is not None and not isinstance(keys, (bytes, str, list)):
             raise Exception("Expected keys to be a Sequence, received: {}".format(type(keys)))
@@ -7479,8 +7479,8 @@ class ProxyUpdaterFacade(Type):
     @ReturnMapping(ProxyConfigResults)
     async def ProxyConfig(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ProxyConfigResult]<~ProxyConfigResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ProxyConfigResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7500,8 +7500,8 @@ class ProxyUpdaterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchForProxyConfigAndAPIHostPortChanges(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7576,8 +7576,8 @@ class RebootFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ClearReboot(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7597,8 +7597,8 @@ class RebootFacade(Type):
     @ReturnMapping(RebootActionResults)
     async def GetRebootAction(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~RebootActionResult]<~RebootActionResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~RebootActionResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7618,8 +7618,8 @@ class RebootFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RequestReboot(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7754,8 +7754,8 @@ class SSHClientFacade(Type):
     @ReturnMapping(SSHAddressesResults)
     async def AllAddresses(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~SSHAddressesResult]<~SSHAddressesResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~SSHAddressesResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7775,8 +7775,8 @@ class SSHClientFacade(Type):
     @ReturnMapping(SSHAddressResults)
     async def PrivateAddress(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~SSHAddressResult]<~SSHAddressResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~SSHAddressResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7815,8 +7815,8 @@ class SSHClientFacade(Type):
     @ReturnMapping(SSHAddressResults)
     async def PublicAddress(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~SSHAddressResult]<~SSHAddressResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~SSHAddressResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7836,8 +7836,8 @@ class SSHClientFacade(Type):
     @ReturnMapping(SSHPublicKeysResults)
     async def PublicKeys(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~SSHPublicKeysResult]<~SSHPublicKeysResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~SSHPublicKeysResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7907,8 +7907,8 @@ class SingularFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Claim(self, claims=None):
         '''
-        claims : typing.Sequence<+T_co>[~SingularClaim]<~SingularClaim>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        claims : typing.Sequence[~SingularClaim]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if claims is not None and not isinstance(claims, (bytes, str, list)):
             raise Exception("Expected claims to be a Sequence, received: {}".format(type(claims)))
@@ -7928,8 +7928,8 @@ class SingularFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Wait(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -8023,8 +8023,8 @@ class SpacesFacade(Type):
     @ReturnMapping(ErrorResults)
     async def CreateSpaces(self, spaces=None):
         '''
-        spaces : typing.Sequence<+T_co>[~CreateSpaceParams]<~CreateSpaceParams>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        spaces : typing.Sequence[~CreateSpaceParams]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if spaces is not None and not isinstance(spaces, (bytes, str, list)):
             raise Exception("Expected spaces to be a Sequence, received: {}".format(type(spaces)))
@@ -8045,7 +8045,7 @@ class SpacesFacade(Type):
     async def ListSpaces(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~Space]<~Space>
+        Returns -> typing.Sequence[~Space]
         '''
 
         # map input types to rpc msg
@@ -8101,7 +8101,7 @@ class StatusHistoryFacade(Type):
     async def ModelConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -8258,8 +8258,8 @@ class SubnetsFacade(Type):
     @ReturnMapping(ErrorResults)
     async def AddSubnets(self, subnets=None):
         '''
-        subnets : typing.Sequence<+T_co>[~AddSubnetParams]<~AddSubnetParams>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        subnets : typing.Sequence[~AddSubnetParams]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if subnets is not None and not isinstance(subnets, (bytes, str, list)):
             raise Exception("Expected subnets to be a Sequence, received: {}".format(type(subnets)))
@@ -8280,7 +8280,7 @@ class SubnetsFacade(Type):
     async def AllSpaces(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~SpaceResult]<~SpaceResult>
+        Returns -> typing.Sequence[~SpaceResult]
         '''
 
         # map input types to rpc msg
@@ -8299,7 +8299,7 @@ class SubnetsFacade(Type):
     async def AllZones(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~ZoneResult]<~ZoneResult>
+        Returns -> typing.Sequence[~ZoneResult]
         '''
 
         # map input types to rpc msg
@@ -8319,7 +8319,7 @@ class SubnetsFacade(Type):
         '''
         space_tag : str
         zone : str
-        Returns -> typing.Sequence<+T_co>[~Subnet]<~Subnet>
+        Returns -> typing.Sequence[~Subnet]
         '''
         if space_tag is not None and not isinstance(space_tag, (bytes, str)):
             raise Exception("Expected space_tag to be a str, received: {}".format(type(space_tag)))
@@ -8460,8 +8460,8 @@ class UserManagerFacade(Type):
     @ReturnMapping(AddUserResults)
     async def AddUser(self, users=None):
         '''
-        users : typing.Sequence<+T_co>[~AddUser]<~AddUser>
-        Returns -> typing.Sequence<+T_co>[~AddUserResult]<~AddUserResult>
+        users : typing.Sequence[~AddUser]
+        Returns -> typing.Sequence[~AddUserResult]
         '''
         if users is not None and not isinstance(users, (bytes, str, list)):
             raise Exception("Expected users to be a Sequence, received: {}".format(type(users)))
@@ -8481,8 +8481,8 @@ class UserManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def DisableUser(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -8502,8 +8502,8 @@ class UserManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def EnableUser(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -8523,8 +8523,8 @@ class UserManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RemoveUser(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -8544,8 +8544,8 @@ class UserManagerFacade(Type):
     @ReturnMapping(AddUserResults)
     async def ResetPassword(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~AddUserResult]<~AddUserResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~AddUserResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -8565,8 +8565,8 @@ class UserManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetPassword(self, changes=None):
         '''
-        changes : typing.Sequence<+T_co>[~EntityPassword]<~EntityPassword>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        changes : typing.Sequence[~EntityPassword]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if changes is not None and not isinstance(changes, (bytes, str, list)):
             raise Exception("Expected changes to be a Sequence, received: {}".format(type(changes)))
@@ -8586,9 +8586,9 @@ class UserManagerFacade(Type):
     @ReturnMapping(UserInfoResults)
     async def UserInfo(self, entities=None, include_disabled=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
+        entities : typing.Sequence[~Entity]
         include_disabled : bool
-        Returns -> typing.Sequence<+T_co>[~UserInfoResult]<~UserInfoResult>
+        Returns -> typing.Sequence[~UserInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -8644,7 +8644,7 @@ class VolumeAttachmentsWatcherFacade(Type):
     async def Next(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[~MachineStorageId]<~MachineStorageId>, _ForwardRef('Error')]
+        Returns -> typing.Union[typing.Sequence[~MachineStorageId], _ForwardRef('Error'), str]
         '''
 
         # map input types to rpc msg

--- a/juju/client/_client3.py
+++ b/juju/client/_client3.py
@@ -162,8 +162,8 @@ class ActionFacade(Type):
     @ReturnMapping(ActionResults)
     async def Actions(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ActionResult]<~ActionResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ActionResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -183,8 +183,8 @@ class ActionFacade(Type):
     @ReturnMapping(ApplicationsCharmActionsResults)
     async def ApplicationsCharmsActions(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ApplicationCharmActionsResult]<~ApplicationCharmActionsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ApplicationCharmActionsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -204,8 +204,8 @@ class ActionFacade(Type):
     @ReturnMapping(ActionResults)
     async def Cancel(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ActionResult]<~ActionResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ActionResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -225,8 +225,8 @@ class ActionFacade(Type):
     @ReturnMapping(ActionResults)
     async def Enqueue(self, actions=None):
         '''
-        actions : typing.Sequence<+T_co>[~Action]<~Action>
-        Returns -> typing.Sequence<+T_co>[~ActionResult]<~ActionResult>
+        actions : typing.Sequence[~Action]
+        Returns -> typing.Sequence[~ActionResult]
         '''
         if actions is not None and not isinstance(actions, (bytes, str, list)):
             raise Exception("Expected actions to be a Sequence, received: {}".format(type(actions)))
@@ -246,8 +246,8 @@ class ActionFacade(Type):
     @ReturnMapping(FindTagsResults)
     async def FindActionTagsByPrefix(self, prefixes=None):
         '''
-        prefixes : typing.Sequence<+T_co>[str]
-        Returns -> typing.Sequence<+T_co>[~Entity]<~Entity>
+        prefixes : typing.Sequence[str]
+        Returns -> typing.Sequence[~Entity]
         '''
         if prefixes is not None and not isinstance(prefixes, (bytes, str, list)):
             raise Exception("Expected prefixes to be a Sequence, received: {}".format(type(prefixes)))
@@ -267,8 +267,8 @@ class ActionFacade(Type):
     @ReturnMapping(ActionsByNames)
     async def FindActionsByNames(self, names=None):
         '''
-        names : typing.Sequence<+T_co>[str]
-        Returns -> typing.Sequence<+T_co>[~ActionsByName]<~ActionsByName>
+        names : typing.Sequence[str]
+        Returns -> typing.Sequence[~ActionsByName]
         '''
         if names is not None and not isinstance(names, (bytes, str, list)):
             raise Exception("Expected names to be a Sequence, received: {}".format(type(names)))
@@ -288,8 +288,8 @@ class ActionFacade(Type):
     @ReturnMapping(ActionsByReceivers)
     async def ListAll(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ActionsByReceiver]<~ActionsByReceiver>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ActionsByReceiver]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -309,8 +309,8 @@ class ActionFacade(Type):
     @ReturnMapping(ActionsByReceivers)
     async def ListCompleted(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ActionsByReceiver]<~ActionsByReceiver>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ActionsByReceiver]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -330,8 +330,8 @@ class ActionFacade(Type):
     @ReturnMapping(ActionsByReceivers)
     async def ListPending(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ActionsByReceiver]<~ActionsByReceiver>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ActionsByReceiver]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -351,8 +351,8 @@ class ActionFacade(Type):
     @ReturnMapping(ActionsByReceivers)
     async def ListRunning(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ActionsByReceiver]<~ActionsByReceiver>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ActionsByReceiver]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -372,12 +372,12 @@ class ActionFacade(Type):
     @ReturnMapping(ActionResults)
     async def Run(self, applications=None, commands=None, machines=None, timeout=None, units=None):
         '''
-        applications : typing.Sequence<+T_co>[str]
+        applications : typing.Sequence[str]
         commands : str
-        machines : typing.Sequence<+T_co>[str]
+        machines : typing.Sequence[str]
         timeout : int
-        units : typing.Sequence<+T_co>[str]
-        Returns -> typing.Sequence<+T_co>[~ActionResult]<~ActionResult>
+        units : typing.Sequence[str]
+        Returns -> typing.Sequence[~ActionResult]
         '''
         if applications is not None and not isinstance(applications, (bytes, str, list)):
             raise Exception("Expected applications to be a Sequence, received: {}".format(type(applications)))
@@ -413,12 +413,12 @@ class ActionFacade(Type):
     @ReturnMapping(ActionResults)
     async def RunOnAllMachines(self, applications=None, commands=None, machines=None, timeout=None, units=None):
         '''
-        applications : typing.Sequence<+T_co>[str]
+        applications : typing.Sequence[str]
         commands : str
-        machines : typing.Sequence<+T_co>[str]
+        machines : typing.Sequence[str]
         timeout : int
-        units : typing.Sequence<+T_co>[str]
-        Returns -> typing.Sequence<+T_co>[~ActionResult]<~ActionResult>
+        units : typing.Sequence[str]
+        Returns -> typing.Sequence[~ActionResult]
         '''
         if applications is not None and not isinstance(applications, (bytes, str, list)):
             raise Exception("Expected applications to be a Sequence, received: {}".format(type(applications)))
@@ -748,8 +748,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(AddRelationResults)
     async def AddRelation(self, endpoints=None):
         '''
-        endpoints : typing.Sequence<+T_co>[str]
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~CharmRelation]<~CharmRelation>
+        endpoints : typing.Sequence[str]
+        Returns -> typing.Mapping[str, ~CharmRelation]
         '''
         if endpoints is not None and not isinstance(endpoints, (bytes, str, list)):
             raise Exception("Expected endpoints to be a Sequence, received: {}".format(type(endpoints)))
@@ -771,8 +771,8 @@ class ApplicationFacade(Type):
         '''
         application : str
         num_units : int
-        placement : typing.Sequence<+T_co>[~Placement]<~Placement>
-        Returns -> typing.Sequence<+T_co>[str]
+        placement : typing.Sequence[~Placement]
+        Returns -> typing.Sequence[str]
         '''
         if application is not None and not isinstance(application, (bytes, str)):
             raise Exception("Expected application to be a str, received: {}".format(type(application)))
@@ -801,7 +801,7 @@ class ApplicationFacade(Type):
     async def CharmRelations(self, application=None):
         '''
         application : str
-        Returns -> typing.Sequence<+T_co>[str]
+        Returns -> typing.Sequence[str]
         '''
         if application is not None and not isinstance(application, (bytes, str)):
             raise Exception("Expected application to be a str, received: {}".format(type(application)))
@@ -821,8 +821,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Deploy(self, applications=None):
         '''
-        applications : typing.Sequence<+T_co>[~ApplicationDeploy]<~ApplicationDeploy>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        applications : typing.Sequence[~ApplicationDeploy]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if applications is not None and not isinstance(applications, (bytes, str, list)):
             raise Exception("Expected applications to be a Sequence, received: {}".format(type(applications)))
@@ -863,7 +863,7 @@ class ApplicationFacade(Type):
     @ReturnMapping(None)
     async def DestroyRelation(self, endpoints=None):
         '''
-        endpoints : typing.Sequence<+T_co>[str]
+        endpoints : typing.Sequence[str]
         Returns -> None
         '''
         if endpoints is not None and not isinstance(endpoints, (bytes, str, list)):
@@ -884,7 +884,7 @@ class ApplicationFacade(Type):
     @ReturnMapping(None)
     async def DestroyUnits(self, unit_names=None):
         '''
-        unit_names : typing.Sequence<+T_co>[str]
+        unit_names : typing.Sequence[str]
         Returns -> None
         '''
         if unit_names is not None and not isinstance(unit_names, (bytes, str, list)):
@@ -927,7 +927,7 @@ class ApplicationFacade(Type):
     async def Get(self, application=None):
         '''
         application : str
-        Returns -> typing.Union[str, typing.Mapping<~KT, +VT_co>[str, typing.Any], _ForwardRef('Value')]
+        Returns -> typing.Union[str, typing.Mapping[str, typing.Any], _ForwardRef('Value')]
         '''
         if application is not None and not isinstance(application, (bytes, str)):
             raise Exception("Expected application to be a str, received: {}".format(type(application)))
@@ -990,7 +990,7 @@ class ApplicationFacade(Type):
     async def Set(self, application=None, options=None):
         '''
         application : str
-        options : typing.Mapping<~KT, +VT_co>[str, str]
+        options : typing.Mapping[str, str]
         Returns -> None
         '''
         if application is not None and not isinstance(application, (bytes, str)):
@@ -1018,12 +1018,12 @@ class ApplicationFacade(Type):
         application : str
         channel : str
         charm_url : str
-        config_settings : typing.Mapping<~KT, +VT_co>[str, str]
+        config_settings : typing.Mapping[str, str]
         config_settings_yaml : str
         force_series : bool
         force_units : bool
-        resource_ids : typing.Mapping<~KT, +VT_co>[str, str]
-        storage_constraints : typing.Mapping<~KT, +VT_co>[str, ~StorageConstraints]<~StorageConstraints>
+        resource_ids : typing.Mapping[str, str]
+        storage_constraints : typing.Mapping[str, ~StorageConstraints]
         Returns -> None
         '''
         if application is not None and not isinstance(application, (bytes, str)):
@@ -1102,8 +1102,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetMetricCredentials(self, creds=None):
         '''
-        creds : typing.Sequence<+T_co>[~ApplicationMetricCredential]<~ApplicationMetricCredential>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        creds : typing.Sequence[~ApplicationMetricCredential]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if creds is not None and not isinstance(creds, (bytes, str, list)):
             raise Exception("Expected creds to be a Sequence, received: {}".format(type(creds)))
@@ -1145,7 +1145,7 @@ class ApplicationFacade(Type):
     async def Unset(self, application=None, options=None):
         '''
         application : str
-        options : typing.Sequence<+T_co>[str]
+        options : typing.Sequence[str]
         Returns -> None
         '''
         if application is not None and not isinstance(application, (bytes, str)):
@@ -1176,7 +1176,7 @@ class ApplicationFacade(Type):
         force_charm_url : bool
         force_series : bool
         min_units : int
-        settings : typing.Mapping<~KT, +VT_co>[str, str]
+        settings : typing.Mapping[str, str]
         settings_yaml : str
         Returns -> None
         '''
@@ -1295,7 +1295,7 @@ class BundleFacade(Type):
         '''
         bundleurl : str
         yaml : str
-        Returns -> typing.Sequence<+T_co>[~BundleChange]<~BundleChange>
+        Returns -> typing.Union[typing.Sequence[~BundleChange], typing.Sequence[str]]
         '''
         if bundleurl is not None and not isinstance(bundleurl, (bytes, str)):
             raise Exception("Expected bundleurl to be a str, received: {}".format(type(bundleurl)))
@@ -1704,8 +1704,8 @@ class CloudFacade(Type):
     @ReturnMapping(ErrorResults)
     async def AddCredentials(self, credentials=None):
         '''
-        credentials : typing.Sequence<+T_co>[~TaggedCredential]<~TaggedCredential>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        credentials : typing.Sequence[~TaggedCredential]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if credentials is not None and not isinstance(credentials, (bytes, str, list)):
             raise Exception("Expected credentials to be a Sequence, received: {}".format(type(credentials)))
@@ -1725,8 +1725,8 @@ class CloudFacade(Type):
     @ReturnMapping(UpdateCredentialResults)
     async def CheckCredentialsModels(self, credentials=None):
         '''
-        credentials : typing.Sequence<+T_co>[~TaggedCredential]<~TaggedCredential>
-        Returns -> typing.Sequence<+T_co>[~UpdateCredentialResult]<~UpdateCredentialResult>
+        credentials : typing.Sequence[~TaggedCredential]
+        Returns -> typing.Sequence[~UpdateCredentialResult]
         '''
         if credentials is not None and not isinstance(credentials, (bytes, str, list)):
             raise Exception("Expected credentials to be a Sequence, received: {}".format(type(credentials)))
@@ -1746,8 +1746,8 @@ class CloudFacade(Type):
     @ReturnMapping(CloudResults)
     async def Cloud(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~CloudResult]<~CloudResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~CloudResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1767,8 +1767,8 @@ class CloudFacade(Type):
     @ReturnMapping(CloudInfoResults)
     async def CloudInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~CloudInfoResult]<~CloudInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~CloudInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1789,7 +1789,7 @@ class CloudFacade(Type):
     async def Clouds(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~Cloud]<~Cloud>
+        Returns -> typing.Mapping[str, ~Cloud]
         '''
 
         # map input types to rpc msg
@@ -1807,8 +1807,8 @@ class CloudFacade(Type):
     @ReturnMapping(CloudCredentialResults)
     async def Credential(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~CloudCredentialResult]<~CloudCredentialResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~CloudCredentialResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1828,9 +1828,9 @@ class CloudFacade(Type):
     @ReturnMapping(CredentialContentResults)
     async def CredentialContents(self, credentials=None, include_secrets=None):
         '''
-        credentials : typing.Sequence<+T_co>[~CloudCredentialArg]<~CloudCredentialArg>
+        credentials : typing.Sequence[~CloudCredentialArg]
         include_secrets : bool
-        Returns -> typing.Sequence<+T_co>[~CredentialContentResult]<~CredentialContentResult>
+        Returns -> typing.Sequence[~CredentialContentResult]
         '''
         if credentials is not None and not isinstance(credentials, (bytes, str, list)):
             raise Exception("Expected credentials to be a Sequence, received: {}".format(type(credentials)))
@@ -1873,8 +1873,8 @@ class CloudFacade(Type):
     @ReturnMapping(InstanceTypesResults)
     async def InstanceTypes(self, constraints=None):
         '''
-        constraints : typing.Sequence<+T_co>[~CloudInstanceTypesConstraint]<~CloudInstanceTypesConstraint>
-        Returns -> typing.Sequence<+T_co>[~InstanceTypesResult]<~InstanceTypesResult>
+        constraints : typing.Sequence[~CloudInstanceTypesConstraint]
+        Returns -> typing.Sequence[~InstanceTypesResult]
         '''
         if constraints is not None and not isinstance(constraints, (bytes, str, list)):
             raise Exception("Expected constraints to be a Sequence, received: {}".format(type(constraints)))
@@ -1896,7 +1896,7 @@ class CloudFacade(Type):
         '''
         all_ : bool
         user_tag : str
-        Returns -> typing.Sequence<+T_co>[~ListCloudInfoResult]<~ListCloudInfoResult>
+        Returns -> typing.Sequence[~ListCloudInfoResult]
         '''
         if all_ is not None and not isinstance(all_, bool):
             raise Exception("Expected all_ to be a bool, received: {}".format(type(all_)))
@@ -1920,8 +1920,8 @@ class CloudFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ModifyCloudAccess(self, changes=None):
         '''
-        changes : typing.Sequence<+T_co>[~ModifyCloudAccess]<~ModifyCloudAccess>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        changes : typing.Sequence[~ModifyCloudAccess]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if changes is not None and not isinstance(changes, (bytes, str, list)):
             raise Exception("Expected changes to be a Sequence, received: {}".format(type(changes)))
@@ -1941,8 +1941,8 @@ class CloudFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RemoveClouds(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1962,8 +1962,8 @@ class CloudFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RevokeCredentialsCheckModels(self, credentials=None):
         '''
-        credentials : typing.Sequence<+T_co>[~RevokeCredentialArg]<~RevokeCredentialArg>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        credentials : typing.Sequence[~RevokeCredentialArg]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if credentials is not None and not isinstance(credentials, (bytes, str, list)):
             raise Exception("Expected credentials to be a Sequence, received: {}".format(type(credentials)))
@@ -1983,9 +1983,9 @@ class CloudFacade(Type):
     @ReturnMapping(UpdateCredentialResults)
     async def UpdateCredentialsCheckModels(self, credentials=None, force=None):
         '''
-        credentials : typing.Sequence<+T_co>[~TaggedCredential]<~TaggedCredential>
+        credentials : typing.Sequence[~TaggedCredential]
         force : bool
-        Returns -> typing.Sequence<+T_co>[~UpdateCredentialResult]<~UpdateCredentialResult>
+        Returns -> typing.Sequence[~UpdateCredentialResult]
         '''
         if credentials is not None and not isinstance(credentials, (bytes, str, list)):
             raise Exception("Expected credentials to be a Sequence, received: {}".format(type(credentials)))
@@ -2009,8 +2009,8 @@ class CloudFacade(Type):
     @ReturnMapping(StringsResults)
     async def UserCredentials(self, user_clouds=None):
         '''
-        user_clouds : typing.Sequence<+T_co>[~UserCloud]<~UserCloud>
-        Returns -> typing.Sequence<+T_co>[~StringsResult]<~StringsResult>
+        user_clouds : typing.Sequence[~UserCloud]
+        Returns -> typing.Sequence[~StringsResult]
         '''
         if user_clouds is not None and not isinstance(user_clouds, (bytes, str, list)):
             raise Exception("Expected user_clouds to be a Sequence, received: {}".format(type(user_clouds)))
@@ -2301,7 +2301,7 @@ class ControllerFacade(Type):
     async def AllModels(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~UserModel]<~UserModel>
+        Returns -> typing.Sequence[~UserModel]
         '''
 
         # map input types to rpc msg
@@ -2319,8 +2319,8 @@ class ControllerFacade(Type):
     @ReturnMapping(CloudSpecResults)
     async def CloudSpec(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~CloudSpecResult]<~CloudSpecResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~CloudSpecResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2341,7 +2341,7 @@ class ControllerFacade(Type):
     async def ControllerConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -2399,8 +2399,8 @@ class ControllerFacade(Type):
     @ReturnMapping(UserAccessResults)
     async def GetControllerAccess(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~UserAccessResult]<~UserAccessResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~UserAccessResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2421,7 +2421,7 @@ class ControllerFacade(Type):
     async def HostedModelConfigs(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~HostedModelConfig]<~HostedModelConfig>
+        Returns -> typing.Sequence[~HostedModelConfig]
         '''
 
         # map input types to rpc msg
@@ -2439,8 +2439,8 @@ class ControllerFacade(Type):
     @ReturnMapping(InitiateMigrationResults)
     async def InitiateMigration(self, specs=None):
         '''
-        specs : typing.Sequence<+T_co>[~MigrationSpec]<~MigrationSpec>
-        Returns -> typing.Sequence<+T_co>[~InitiateMigrationResult]<~InitiateMigrationResult>
+        specs : typing.Sequence[~MigrationSpec]
+        Returns -> typing.Sequence[~InitiateMigrationResult]
         '''
         if specs is not None and not isinstance(specs, (bytes, str, list)):
             raise Exception("Expected specs to be a Sequence, received: {}".format(type(specs)))
@@ -2461,7 +2461,7 @@ class ControllerFacade(Type):
     async def ListBlockedModels(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~ModelBlockInfo]<~ModelBlockInfo>
+        Returns -> typing.Sequence[~ModelBlockInfo]
         '''
 
         # map input types to rpc msg
@@ -2480,7 +2480,7 @@ class ControllerFacade(Type):
     async def ModelConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~ConfigValue]<~ConfigValue>
+        Returns -> typing.Mapping[str, ~ConfigValue]
         '''
 
         # map input types to rpc msg
@@ -2498,8 +2498,8 @@ class ControllerFacade(Type):
     @ReturnMapping(ModelStatusResults)
     async def ModelStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ModelStatus]<~ModelStatus>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ModelStatus]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2519,8 +2519,8 @@ class ControllerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ModifyControllerAccess(self, changes=None):
         '''
-        changes : typing.Sequence<+T_co>[~ModifyControllerAccess]<~ModifyControllerAccess>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        changes : typing.Sequence[~ModifyControllerAccess]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if changes is not None and not isinstance(changes, (bytes, str, list)):
             raise Exception("Expected changes to be a Sequence, received: {}".format(type(changes)))
@@ -2775,8 +2775,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(CloudSpecResults)
     async def CloudSpec(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~CloudSpecResult]<~CloudSpecResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~CloudSpecResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2796,8 +2796,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(StringResults)
     async def GetAssignedMachine(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2836,8 +2836,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(BoolResults)
     async def GetExposed(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~BoolResult]<~BoolResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~BoolResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2857,8 +2857,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(StringsResults)
     async def GetMachineActiveSubnets(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsResult]<~StringsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2878,8 +2878,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(MachinePortsResults)
     async def GetMachinePorts(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~MachinePorts]<~MachinePorts>
-        Returns -> typing.Sequence<+T_co>[~MachinePortsResult]<~MachinePortsResult>
+        params : typing.Sequence[~MachinePorts]
+        Returns -> typing.Sequence[~MachinePortsResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -2899,8 +2899,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(StringResults)
     async def InstanceId(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2920,8 +2920,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(LifeResults)
     async def Life(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2942,7 +2942,7 @@ class FirewallerFacade(Type):
     async def ModelConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -2960,8 +2960,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def Watch(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3001,7 +3001,7 @@ class FirewallerFacade(Type):
     async def WatchModelMachines(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[str], _ForwardRef('Error')]
+        Returns -> typing.Union[typing.Sequence[str], _ForwardRef('Error'), str]
         '''
 
         # map input types to rpc msg
@@ -3019,8 +3019,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchOpenedPorts(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3040,8 +3040,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchUnits(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3266,8 +3266,8 @@ class InstancePollerFacade(Type):
     @ReturnMapping(BoolResults)
     async def AreManuallyProvisioned(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~BoolResult]<~BoolResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~BoolResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3287,8 +3287,8 @@ class InstancePollerFacade(Type):
     @ReturnMapping(StringResults)
     async def InstanceId(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3308,8 +3308,8 @@ class InstancePollerFacade(Type):
     @ReturnMapping(StatusResults)
     async def InstanceStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StatusResult]<~StatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3329,8 +3329,8 @@ class InstancePollerFacade(Type):
     @ReturnMapping(LifeResults)
     async def Life(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3351,7 +3351,7 @@ class InstancePollerFacade(Type):
     async def ModelConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -3369,8 +3369,8 @@ class InstancePollerFacade(Type):
     @ReturnMapping(MachineAddressesResults)
     async def ProviderAddresses(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MachineAddressesResult]<~MachineAddressesResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MachineAddressesResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3390,8 +3390,8 @@ class InstancePollerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetInstanceStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3411,8 +3411,8 @@ class InstancePollerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetProviderAddresses(self, machine_addresses=None):
         '''
-        machine_addresses : typing.Sequence<+T_co>[~MachineAddresses]<~MachineAddresses>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        machine_addresses : typing.Sequence[~MachineAddresses]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if machine_addresses is not None and not isinstance(machine_addresses, (bytes, str, list)):
             raise Exception("Expected machine_addresses to be a Sequence, received: {}".format(type(machine_addresses)))
@@ -3432,8 +3432,8 @@ class InstancePollerFacade(Type):
     @ReturnMapping(StatusResults)
     async def Status(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StatusResult]<~StatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3473,7 +3473,7 @@ class InstancePollerFacade(Type):
     async def WatchModelMachines(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[str], _ForwardRef('Error')]
+        Returns -> typing.Union[typing.Sequence[str], _ForwardRef('Error'), str]
         '''
 
         # map input types to rpc msg
@@ -3660,8 +3660,8 @@ class MachineManagerFacade(Type):
     @ReturnMapping(AddMachinesResults)
     async def AddMachines(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~AddMachineParams]<~AddMachineParams>
-        Returns -> typing.Sequence<+T_co>[~AddMachinesResult]<~AddMachinesResult>
+        params : typing.Sequence[~AddMachineParams]
+        Returns -> typing.Sequence[~AddMachinesResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -3681,8 +3681,8 @@ class MachineManagerFacade(Type):
     @ReturnMapping(DestroyMachineResults)
     async def DestroyMachine(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~DestroyMachineResult]<~DestroyMachineResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~DestroyMachineResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3702,8 +3702,8 @@ class MachineManagerFacade(Type):
     @ReturnMapping(DestroyMachineResults)
     async def ForceDestroyMachine(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~DestroyMachineResult]<~DestroyMachineResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~DestroyMachineResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3723,8 +3723,8 @@ class MachineManagerFacade(Type):
     @ReturnMapping(InstanceTypesResults)
     async def InstanceTypes(self, constraints=None):
         '''
-        constraints : typing.Sequence<+T_co>[~ModelInstanceTypesConstraint]<~ModelInstanceTypesConstraint>
-        Returns -> typing.Sequence<+T_co>[~InstanceTypesResult]<~InstanceTypesResult>
+        constraints : typing.Sequence[~ModelInstanceTypesConstraint]
+        Returns -> typing.Sequence[~InstanceTypesResult]
         '''
         if constraints is not None and not isinstance(constraints, (bytes, str, list)):
             raise Exception("Expected constraints to be a Sequence, received: {}".format(type(constraints)))
@@ -4049,12 +4049,12 @@ class ModelManagerFacade(Type):
     async def CreateModel(self, cloud_tag=None, config=None, credential=None, name=None, owner_tag=None, region=None):
         '''
         cloud_tag : str
-        config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        config : typing.Mapping[str, typing.Any]
         credential : str
         name : str
         owner_tag : str
         region : str
-        Returns -> typing.Union[_ForwardRef('Number'), _ForwardRef('ModelMigrationStatus'), _ForwardRef('ModelSLAInfo'), _ForwardRef('EntityStatus'), typing.Sequence<+T_co>[~ModelUserInfo]<~ModelUserInfo>]
+        Returns -> typing.Union[_ForwardRef('Number'), str, typing.Sequence[~ModelMachineInfo], _ForwardRef('ModelMigrationStatus'), _ForwardRef('ModelSLAInfo'), _ForwardRef('EntityStatus'), typing.Sequence[~ModelUserInfo]]
         '''
         if cloud_tag is not None and not isinstance(cloud_tag, (bytes, str)):
             raise Exception("Expected cloud_tag to be a str, received: {}".format(type(cloud_tag)))
@@ -4094,8 +4094,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def DestroyModels(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4115,9 +4115,9 @@ class ModelManagerFacade(Type):
     @ReturnMapping(StringResults)
     async def DumpModels(self, entities=None, simplified=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
+        entities : typing.Sequence[~Entity]
         simplified : bool
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4141,8 +4141,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(MapResults)
     async def DumpModelsDB(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MapResult]<~MapResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MapResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4163,7 +4163,7 @@ class ModelManagerFacade(Type):
     async def ListModels(self, tag=None):
         '''
         tag : str
-        Returns -> typing.Sequence<+T_co>[~UserModel]<~UserModel>
+        Returns -> typing.Sequence[~UserModel]
         '''
         if tag is not None and not isinstance(tag, (bytes, str)):
             raise Exception("Expected tag to be a str, received: {}".format(type(tag)))
@@ -4184,7 +4184,7 @@ class ModelManagerFacade(Type):
     async def ModelDefaults(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~ModelDefaults]<~ModelDefaults>
+        Returns -> typing.Mapping[str, ~ModelDefaults]
         '''
 
         # map input types to rpc msg
@@ -4202,8 +4202,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ModelInfoResults)
     async def ModelInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ModelInfoResult]<~ModelInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ModelInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4223,8 +4223,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ModelStatusResults)
     async def ModelStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ModelStatus]<~ModelStatus>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ModelStatus]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4244,8 +4244,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ModifyModelAccess(self, changes=None):
         '''
-        changes : typing.Sequence<+T_co>[~ModifyModelAccess]<~ModifyModelAccess>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        changes : typing.Sequence[~ModifyModelAccess]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if changes is not None and not isinstance(changes, (bytes, str, list)):
             raise Exception("Expected changes to be a Sequence, received: {}".format(type(changes)))
@@ -4265,8 +4265,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetModelDefaults(self, config=None):
         '''
-        config : typing.Sequence<+T_co>[~ModelDefaultValues]<~ModelDefaultValues>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        config : typing.Sequence[~ModelDefaultValues]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if config is not None and not isinstance(config, (bytes, str, list)):
             raise Exception("Expected config to be a Sequence, received: {}".format(type(config)))
@@ -4286,8 +4286,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UnsetModelDefaults(self, keys=None):
         '''
-        keys : typing.Sequence<+T_co>[~ModelUnsetKeys]<~ModelUnsetKeys>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        keys : typing.Sequence[~ModelUnsetKeys]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if keys is not None and not isinstance(keys, (bytes, str, list)):
             raise Exception("Expected keys to be a Sequence, received: {}".format(type(keys)))
@@ -4957,7 +4957,7 @@ class ProvisionerFacade(Type):
     async def APIAddresses(self):
         '''
 
-        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence<+T_co>[str]]
+        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence[str]]
         '''
 
         # map input types to rpc msg
@@ -4976,7 +4976,7 @@ class ProvisionerFacade(Type):
     async def APIHostPorts(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~HostPort]<~HostPort>
+        Returns -> typing.Sequence[~HostPort]
         '''
 
         # map input types to rpc msg
@@ -4995,7 +4995,7 @@ class ProvisionerFacade(Type):
     async def CACert(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[int]
+        Returns -> typing.Sequence[int]
         '''
 
         # map input types to rpc msg
@@ -5013,8 +5013,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ConstraintsResults)
     async def Constraints(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ConstraintsResult]<~ConstraintsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ConstraintsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5035,7 +5035,7 @@ class ProvisionerFacade(Type):
     async def ContainerConfig(self):
         '''
 
-        Returns -> typing.Union[_ForwardRef('UpdateBehavior'), str, _ForwardRef('Settings'), _ForwardRef('Settings'), bool]
+        Returns -> typing.Union[_ForwardRef('UpdateBehavior'), str, _ForwardRef('Settings'), bool]
         '''
 
         # map input types to rpc msg
@@ -5054,7 +5054,7 @@ class ProvisionerFacade(Type):
     async def ContainerManagerConfig(self, type_=None):
         '''
         type_ : str
-        Returns -> typing.Mapping<~KT, +VT_co>[str, str]
+        Returns -> typing.Mapping[str, str]
         '''
         if type_ is not None and not isinstance(type_, (bytes, str)):
             raise Exception("Expected type_ to be a str, received: {}".format(type(type_)))
@@ -5075,7 +5075,7 @@ class ProvisionerFacade(Type):
     async def ControllerConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -5093,8 +5093,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(DistributionGroupResults)
     async def DistributionGroup(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~DistributionGroupResult]<~DistributionGroupResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~DistributionGroupResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5114,8 +5114,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def EnsureDead(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5140,7 +5140,7 @@ class ProvisionerFacade(Type):
         minor : int
         number : Number
         series : str
-        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence<+T_co>[~Tools]<~Tools>]
+        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence[~Tools]]
         '''
         if arch is not None and not isinstance(arch, (bytes, str)):
             raise Exception("Expected arch to be a str, received: {}".format(type(arch)))
@@ -5176,8 +5176,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(MachineNetworkConfigResults)
     async def GetContainerInterfaceInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MachineNetworkConfigResult]<~MachineNetworkConfigResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MachineNetworkConfigResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5197,8 +5197,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(HostNetworkChangeResults)
     async def HostChangesForContainers(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~HostNetworkChange]<~HostNetworkChange>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~HostNetworkChange]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5218,8 +5218,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(StringResults)
     async def InstanceId(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5239,8 +5239,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(StatusResults)
     async def InstanceStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StatusResult]<~StatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5260,8 +5260,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(LifeResults)
     async def Life(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5282,7 +5282,7 @@ class ProvisionerFacade(Type):
     async def MachinesWithTransientErrors(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~StatusResult]<~StatusResult>
+        Returns -> typing.Sequence[~StatusResult]
         '''
 
         # map input types to rpc msg
@@ -5300,8 +5300,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def MarkMachinesForRemoval(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5322,7 +5322,7 @@ class ProvisionerFacade(Type):
     async def ModelConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -5359,8 +5359,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(MachineNetworkConfigResults)
     async def PrepareContainerInterfaceInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MachineNetworkConfigResult]<~MachineNetworkConfigResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MachineNetworkConfigResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5380,8 +5380,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ProvisioningInfoResults)
     async def ProvisioningInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ProvisioningInfoResult]<~ProvisioningInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ProvisioningInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5401,8 +5401,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ReleaseContainerAddresses(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5422,8 +5422,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Remove(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5443,8 +5443,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(StringResults)
     async def Series(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5464,7 +5464,7 @@ class ProvisionerFacade(Type):
     @ReturnMapping(None)
     async def SetHostMachineNetworkConfig(self, config=None, tag=None):
         '''
-        config : typing.Sequence<+T_co>[~NetworkConfig]<~NetworkConfig>
+        config : typing.Sequence[~NetworkConfig]
         tag : str
         Returns -> None
         '''
@@ -5490,8 +5490,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetInstanceInfo(self, machines=None):
         '''
-        machines : typing.Sequence<+T_co>[~InstanceInfo]<~InstanceInfo>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        machines : typing.Sequence[~InstanceInfo]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if machines is not None and not isinstance(machines, (bytes, str, list)):
             raise Exception("Expected machines to be a Sequence, received: {}".format(type(machines)))
@@ -5511,8 +5511,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetInstanceStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5532,7 +5532,7 @@ class ProvisionerFacade(Type):
     @ReturnMapping(None)
     async def SetObservedNetworkConfig(self, config=None, tag=None):
         '''
-        config : typing.Sequence<+T_co>[~NetworkConfig]<~NetworkConfig>
+        config : typing.Sequence[~NetworkConfig]
         tag : str
         Returns -> None
         '''
@@ -5558,8 +5558,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetPasswords(self, changes=None):
         '''
-        changes : typing.Sequence<+T_co>[~EntityPassword]<~EntityPassword>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        changes : typing.Sequence[~EntityPassword]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if changes is not None and not isinstance(changes, (bytes, str, list)):
             raise Exception("Expected changes to be a Sequence, received: {}".format(type(changes)))
@@ -5579,8 +5579,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetProviderNetworkConfig(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5600,8 +5600,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5621,8 +5621,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetSupportedContainers(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~MachineContainers]<~MachineContainers>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        params : typing.Sequence[~MachineContainers]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -5643,7 +5643,7 @@ class ProvisionerFacade(Type):
     async def StateAddresses(self):
         '''
 
-        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence<+T_co>[str]]
+        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence[str]]
         '''
 
         # map input types to rpc msg
@@ -5661,8 +5661,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(StatusResults)
     async def Status(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StatusResult]<~StatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5682,8 +5682,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ToolsResults)
     async def Tools(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ToolsResult]<~ToolsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ToolsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5703,8 +5703,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UpdateStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5743,8 +5743,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchAllContainers(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~WatchContainer]<~WatchContainer>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        params : typing.Sequence[~WatchContainer]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -5764,8 +5764,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchContainers(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~WatchContainer]<~WatchContainer>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        params : typing.Sequence[~WatchContainer]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -5824,7 +5824,7 @@ class ProvisionerFacade(Type):
     async def WatchModelMachines(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[str], _ForwardRef('Error')]
+        Returns -> typing.Union[typing.Sequence[str], _ForwardRef('Error'), str]
         '''
 
         # map input types to rpc msg
@@ -5914,8 +5914,8 @@ class SpacesFacade(Type):
     @ReturnMapping(ErrorResults)
     async def CreateSpaces(self, spaces=None):
         '''
-        spaces : typing.Sequence<+T_co>[~CreateSpaceParams]<~CreateSpaceParams>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        spaces : typing.Sequence[~CreateSpaceParams]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if spaces is not None and not isinstance(spaces, (bytes, str, list)):
             raise Exception("Expected spaces to be a Sequence, received: {}".format(type(spaces)))
@@ -5936,7 +5936,7 @@ class SpacesFacade(Type):
     async def ListSpaces(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~Space]<~Space>
+        Returns -> typing.Sequence[~Space]
         '''
 
         # map input types to rpc msg
@@ -6242,8 +6242,8 @@ class StorageFacade(Type):
     @ReturnMapping(ErrorResults)
     async def AddToUnit(self, storages=None):
         '''
-        storages : typing.Sequence<+T_co>[~StorageAddParams]<~StorageAddParams>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        storages : typing.Sequence[~StorageAddParams]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if storages is not None and not isinstance(storages, (bytes, str, list)):
             raise Exception("Expected storages to be a Sequence, received: {}".format(type(storages)))
@@ -6263,8 +6263,8 @@ class StorageFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Attach(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~StorageAttachmentId]<~StorageAttachmentId>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        ids : typing.Sequence[~StorageAttachmentId]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -6284,7 +6284,7 @@ class StorageFacade(Type):
     @ReturnMapping(None)
     async def CreatePool(self, attrs=None, name=None, provider=None):
         '''
-        attrs : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        attrs : typing.Mapping[str, typing.Any]
         name : str
         provider : str
         Returns -> None
@@ -6315,8 +6315,8 @@ class StorageFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Destroy(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6336,8 +6336,8 @@ class StorageFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Detach(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~StorageAttachmentId]<~StorageAttachmentId>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        ids : typing.Sequence[~StorageAttachmentId]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -6357,8 +6357,8 @@ class StorageFacade(Type):
     @ReturnMapping(FilesystemDetailsListResults)
     async def ListFilesystems(self, filters=None):
         '''
-        filters : typing.Sequence<+T_co>[~FilesystemFilter]<~FilesystemFilter>
-        Returns -> typing.Sequence<+T_co>[~FilesystemDetailsListResult]<~FilesystemDetailsListResult>
+        filters : typing.Sequence[~FilesystemFilter]
+        Returns -> typing.Sequence[~FilesystemDetailsListResult]
         '''
         if filters is not None and not isinstance(filters, (bytes, str, list)):
             raise Exception("Expected filters to be a Sequence, received: {}".format(type(filters)))
@@ -6378,8 +6378,8 @@ class StorageFacade(Type):
     @ReturnMapping(StoragePoolsResults)
     async def ListPools(self, filters=None):
         '''
-        filters : typing.Sequence<+T_co>[~StoragePoolFilter]<~StoragePoolFilter>
-        Returns -> typing.Sequence<+T_co>[~StoragePoolsResult]<~StoragePoolsResult>
+        filters : typing.Sequence[~StoragePoolFilter]
+        Returns -> typing.Sequence[~StoragePoolsResult]
         '''
         if filters is not None and not isinstance(filters, (bytes, str, list)):
             raise Exception("Expected filters to be a Sequence, received: {}".format(type(filters)))
@@ -6399,8 +6399,8 @@ class StorageFacade(Type):
     @ReturnMapping(StorageDetailsListResults)
     async def ListStorageDetails(self, filters=None):
         '''
-        filters : typing.Sequence<+T_co>[~StorageFilter]<~StorageFilter>
-        Returns -> typing.Sequence<+T_co>[~StorageDetailsListResult]<~StorageDetailsListResult>
+        filters : typing.Sequence[~StorageFilter]
+        Returns -> typing.Sequence[~StorageDetailsListResult]
         '''
         if filters is not None and not isinstance(filters, (bytes, str, list)):
             raise Exception("Expected filters to be a Sequence, received: {}".format(type(filters)))
@@ -6420,8 +6420,8 @@ class StorageFacade(Type):
     @ReturnMapping(VolumeDetailsListResults)
     async def ListVolumes(self, filters=None):
         '''
-        filters : typing.Sequence<+T_co>[~VolumeFilter]<~VolumeFilter>
-        Returns -> typing.Sequence<+T_co>[~VolumeDetailsListResult]<~VolumeDetailsListResult>
+        filters : typing.Sequence[~VolumeFilter]
+        Returns -> typing.Sequence[~VolumeDetailsListResult]
         '''
         if filters is not None and not isinstance(filters, (bytes, str, list)):
             raise Exception("Expected filters to be a Sequence, received: {}".format(type(filters)))
@@ -6441,8 +6441,8 @@ class StorageFacade(Type):
     @ReturnMapping(StorageDetailsResults)
     async def StorageDetails(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StorageDetailsResult]<~StorageDetailsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StorageDetailsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6892,8 +6892,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(LifeResults)
     async def AttachmentLife(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~MachineStorageId]<~MachineStorageId>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        ids : typing.Sequence[~MachineStorageId]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -6913,8 +6913,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def EnsureDead(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6934,8 +6934,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(FilesystemAttachmentParamsResults)
     async def FilesystemAttachmentParams(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~MachineStorageId]<~MachineStorageId>
-        Returns -> typing.Sequence<+T_co>[~FilesystemAttachmentParamsResult]<~FilesystemAttachmentParamsResult>
+        ids : typing.Sequence[~MachineStorageId]
+        Returns -> typing.Sequence[~FilesystemAttachmentParamsResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -6955,8 +6955,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(FilesystemAttachmentResults)
     async def FilesystemAttachments(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~MachineStorageId]<~MachineStorageId>
-        Returns -> typing.Sequence<+T_co>[~FilesystemAttachmentResult]<~FilesystemAttachmentResult>
+        ids : typing.Sequence[~MachineStorageId]
+        Returns -> typing.Sequence[~FilesystemAttachmentResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -6976,8 +6976,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(FilesystemParamsResults)
     async def FilesystemParams(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~FilesystemParamsResult]<~FilesystemParamsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~FilesystemParamsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6997,8 +6997,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(FilesystemResults)
     async def Filesystems(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~FilesystemResult]<~FilesystemResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~FilesystemResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7018,8 +7018,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(StringResults)
     async def InstanceId(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7039,8 +7039,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(LifeResults)
     async def Life(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7060,8 +7060,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Remove(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7081,8 +7081,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RemoveAttachment(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~MachineStorageId]<~MachineStorageId>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        ids : typing.Sequence[~MachineStorageId]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -7102,8 +7102,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetFilesystemAttachmentInfo(self, filesystem_attachments=None):
         '''
-        filesystem_attachments : typing.Sequence<+T_co>[~FilesystemAttachment]<~FilesystemAttachment>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        filesystem_attachments : typing.Sequence[~FilesystemAttachment]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if filesystem_attachments is not None and not isinstance(filesystem_attachments, (bytes, str, list)):
             raise Exception("Expected filesystem_attachments to be a Sequence, received: {}".format(type(filesystem_attachments)))
@@ -7123,8 +7123,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetFilesystemInfo(self, filesystems=None):
         '''
-        filesystems : typing.Sequence<+T_co>[~Filesystem]<~Filesystem>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        filesystems : typing.Sequence[~Filesystem]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if filesystems is not None and not isinstance(filesystems, (bytes, str, list)):
             raise Exception("Expected filesystems to be a Sequence, received: {}".format(type(filesystems)))
@@ -7144,8 +7144,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7165,8 +7165,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetVolumeAttachmentInfo(self, volume_attachments=None):
         '''
-        volume_attachments : typing.Sequence<+T_co>[~VolumeAttachment]<~VolumeAttachment>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        volume_attachments : typing.Sequence[~VolumeAttachment]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if volume_attachments is not None and not isinstance(volume_attachments, (bytes, str, list)):
             raise Exception("Expected volume_attachments to be a Sequence, received: {}".format(type(volume_attachments)))
@@ -7186,8 +7186,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetVolumeInfo(self, volumes=None):
         '''
-        volumes : typing.Sequence<+T_co>[~Volume]<~Volume>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        volumes : typing.Sequence[~Volume]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if volumes is not None and not isinstance(volumes, (bytes, str, list)):
             raise Exception("Expected volumes to be a Sequence, received: {}".format(type(volumes)))
@@ -7207,8 +7207,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UpdateStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7228,8 +7228,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(VolumeAttachmentParamsResults)
     async def VolumeAttachmentParams(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~MachineStorageId]<~MachineStorageId>
-        Returns -> typing.Sequence<+T_co>[~VolumeAttachmentParamsResult]<~VolumeAttachmentParamsResult>
+        ids : typing.Sequence[~MachineStorageId]
+        Returns -> typing.Sequence[~VolumeAttachmentParamsResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -7249,8 +7249,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(VolumeAttachmentResults)
     async def VolumeAttachments(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~MachineStorageId]<~MachineStorageId>
-        Returns -> typing.Sequence<+T_co>[~VolumeAttachmentResult]<~VolumeAttachmentResult>
+        ids : typing.Sequence[~MachineStorageId]
+        Returns -> typing.Sequence[~VolumeAttachmentResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -7270,8 +7270,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(BlockDeviceResults)
     async def VolumeBlockDevices(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~MachineStorageId]<~MachineStorageId>
-        Returns -> typing.Sequence<+T_co>[~BlockDeviceResult]<~BlockDeviceResult>
+        ids : typing.Sequence[~MachineStorageId]
+        Returns -> typing.Sequence[~BlockDeviceResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -7291,8 +7291,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(VolumeParamsResults)
     async def VolumeParams(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~VolumeParamsResult]<~VolumeParamsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~VolumeParamsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7312,8 +7312,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(VolumeResults)
     async def Volumes(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~VolumeResult]<~VolumeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~VolumeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7333,8 +7333,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchBlockDevices(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7354,8 +7354,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(MachineStorageIdsWatchResults)
     async def WatchFilesystemAttachments(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MachineStorageIdsWatchResult]<~MachineStorageIdsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MachineStorageIdsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7375,8 +7375,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchFilesystems(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7396,8 +7396,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchMachines(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7417,8 +7417,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(MachineStorageIdsWatchResults)
     async def WatchVolumeAttachments(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MachineStorageIdsWatchResult]<~MachineStorageIdsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MachineStorageIdsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7438,8 +7438,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchVolumes(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -7553,8 +7553,8 @@ class SubnetsFacade(Type):
     @ReturnMapping(ErrorResults)
     async def AddSubnets(self, subnets=None):
         '''
-        subnets : typing.Sequence<+T_co>[~AddSubnetParams]<~AddSubnetParams>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        subnets : typing.Sequence[~AddSubnetParams]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if subnets is not None and not isinstance(subnets, (bytes, str, list)):
             raise Exception("Expected subnets to be a Sequence, received: {}".format(type(subnets)))
@@ -7575,7 +7575,7 @@ class SubnetsFacade(Type):
     async def AllSpaces(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~SpaceResult]<~SpaceResult>
+        Returns -> typing.Sequence[~SpaceResult]
         '''
 
         # map input types to rpc msg
@@ -7594,7 +7594,7 @@ class SubnetsFacade(Type):
     async def AllZones(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~ZoneResult]<~ZoneResult>
+        Returns -> typing.Sequence[~ZoneResult]
         '''
 
         # map input types to rpc msg
@@ -7614,7 +7614,7 @@ class SubnetsFacade(Type):
         '''
         space_tag : str
         zone : str
-        Returns -> typing.Sequence<+T_co>[~Subnet]<~Subnet>
+        Returns -> typing.Sequence[~Subnet]
         '''
         if space_tag is not None and not isinstance(space_tag, (bytes, str)):
             raise Exception("Expected space_tag to be a str, received: {}".format(type(space_tag)))

--- a/juju/client/_client4.py
+++ b/juju/client/_client4.py
@@ -163,8 +163,8 @@ class ActionFacade(Type):
     @ReturnMapping(ActionResults)
     async def Actions(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ActionResult]<~ActionResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ActionResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -184,8 +184,8 @@ class ActionFacade(Type):
     @ReturnMapping(ApplicationsCharmActionsResults)
     async def ApplicationsCharmsActions(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ApplicationCharmActionsResult]<~ApplicationCharmActionsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ApplicationCharmActionsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -205,8 +205,8 @@ class ActionFacade(Type):
     @ReturnMapping(ActionResults)
     async def Cancel(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ActionResult]<~ActionResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ActionResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -226,8 +226,8 @@ class ActionFacade(Type):
     @ReturnMapping(ActionResults)
     async def Enqueue(self, actions=None):
         '''
-        actions : typing.Sequence<+T_co>[~Action]<~Action>
-        Returns -> typing.Sequence<+T_co>[~ActionResult]<~ActionResult>
+        actions : typing.Sequence[~Action]
+        Returns -> typing.Sequence[~ActionResult]
         '''
         if actions is not None and not isinstance(actions, (bytes, str, list)):
             raise Exception("Expected actions to be a Sequence, received: {}".format(type(actions)))
@@ -247,8 +247,8 @@ class ActionFacade(Type):
     @ReturnMapping(FindTagsResults)
     async def FindActionTagsByPrefix(self, prefixes=None):
         '''
-        prefixes : typing.Sequence<+T_co>[str]
-        Returns -> typing.Sequence<+T_co>[~Entity]<~Entity>
+        prefixes : typing.Sequence[str]
+        Returns -> typing.Sequence[~Entity]
         '''
         if prefixes is not None and not isinstance(prefixes, (bytes, str, list)):
             raise Exception("Expected prefixes to be a Sequence, received: {}".format(type(prefixes)))
@@ -268,8 +268,8 @@ class ActionFacade(Type):
     @ReturnMapping(ActionsByNames)
     async def FindActionsByNames(self, names=None):
         '''
-        names : typing.Sequence<+T_co>[str]
-        Returns -> typing.Sequence<+T_co>[~ActionsByName]<~ActionsByName>
+        names : typing.Sequence[str]
+        Returns -> typing.Sequence[~ActionsByName]
         '''
         if names is not None and not isinstance(names, (bytes, str, list)):
             raise Exception("Expected names to be a Sequence, received: {}".format(type(names)))
@@ -289,8 +289,8 @@ class ActionFacade(Type):
     @ReturnMapping(ActionsByReceivers)
     async def ListAll(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ActionsByReceiver]<~ActionsByReceiver>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ActionsByReceiver]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -310,8 +310,8 @@ class ActionFacade(Type):
     @ReturnMapping(ActionsByReceivers)
     async def ListCompleted(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ActionsByReceiver]<~ActionsByReceiver>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ActionsByReceiver]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -331,8 +331,8 @@ class ActionFacade(Type):
     @ReturnMapping(ActionsByReceivers)
     async def ListPending(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ActionsByReceiver]<~ActionsByReceiver>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ActionsByReceiver]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -352,8 +352,8 @@ class ActionFacade(Type):
     @ReturnMapping(ActionsByReceivers)
     async def ListRunning(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ActionsByReceiver]<~ActionsByReceiver>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ActionsByReceiver]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -373,13 +373,13 @@ class ActionFacade(Type):
     @ReturnMapping(ActionResults)
     async def Run(self, applications=None, commands=None, machines=None, timeout=None, units=None, workload_context=None):
         '''
-        applications : typing.Sequence<+T_co>[str]
+        applications : typing.Sequence[str]
         commands : str
-        machines : typing.Sequence<+T_co>[str]
+        machines : typing.Sequence[str]
         timeout : int
-        units : typing.Sequence<+T_co>[str]
+        units : typing.Sequence[str]
         workload_context : bool
-        Returns -> typing.Sequence<+T_co>[~ActionResult]<~ActionResult>
+        Returns -> typing.Sequence[~ActionResult]
         '''
         if applications is not None and not isinstance(applications, (bytes, str, list)):
             raise Exception("Expected applications to be a Sequence, received: {}".format(type(applications)))
@@ -419,13 +419,13 @@ class ActionFacade(Type):
     @ReturnMapping(ActionResults)
     async def RunOnAllMachines(self, applications=None, commands=None, machines=None, timeout=None, units=None, workload_context=None):
         '''
-        applications : typing.Sequence<+T_co>[str]
+        applications : typing.Sequence[str]
         commands : str
-        machines : typing.Sequence<+T_co>[str]
+        machines : typing.Sequence[str]
         timeout : int
-        units : typing.Sequence<+T_co>[str]
+        units : typing.Sequence[str]
         workload_context : bool
-        Returns -> typing.Sequence<+T_co>[~ActionResult]<~ActionResult>
+        Returns -> typing.Sequence[~ActionResult]
         '''
         if applications is not None and not isinstance(applications, (bytes, str, list)):
             raise Exception("Expected applications to be a Sequence, received: {}".format(type(applications)))
@@ -869,8 +869,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(AddRelationResults)
     async def AddRelation(self, endpoints=None):
         '''
-        endpoints : typing.Sequence<+T_co>[str]
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~CharmRelation]<~CharmRelation>
+        endpoints : typing.Sequence[str]
+        Returns -> typing.Mapping[str, ~CharmRelation]
         '''
         if endpoints is not None and not isinstance(endpoints, (bytes, str, list)):
             raise Exception("Expected endpoints to be a Sequence, received: {}".format(type(endpoints)))
@@ -892,8 +892,8 @@ class ApplicationFacade(Type):
         '''
         application : str
         num_units : int
-        placement : typing.Sequence<+T_co>[~Placement]<~Placement>
-        Returns -> typing.Sequence<+T_co>[str]
+        placement : typing.Sequence[~Placement]
+        Returns -> typing.Sequence[str]
         '''
         if application is not None and not isinstance(application, (bytes, str)):
             raise Exception("Expected application to be a str, received: {}".format(type(application)))
@@ -922,7 +922,7 @@ class ApplicationFacade(Type):
     async def CharmRelations(self, application=None):
         '''
         application : str
-        Returns -> typing.Sequence<+T_co>[str]
+        Returns -> typing.Sequence[str]
         '''
         if application is not None and not isinstance(application, (bytes, str)):
             raise Exception("Expected application to be a str, received: {}".format(type(application)))
@@ -942,8 +942,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ConsumeApplicationResults)
     async def Consume(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~ConsumeApplicationArg]<~ConsumeApplicationArg>
-        Returns -> typing.Sequence<+T_co>[~ConsumeApplicationResult]<~ConsumeApplicationResult>
+        args : typing.Sequence[~ConsumeApplicationArg]
+        Returns -> typing.Sequence[~ConsumeApplicationResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -963,8 +963,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Deploy(self, applications=None):
         '''
-        applications : typing.Sequence<+T_co>[~ApplicationDeploy]<~ApplicationDeploy>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        applications : typing.Sequence[~ApplicationDeploy]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if applications is not None and not isinstance(applications, (bytes, str, list)):
             raise Exception("Expected applications to be a Sequence, received: {}".format(type(applications)))
@@ -1005,8 +1005,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(DestroyApplicationResults)
     async def DestroyApplication(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~DestroyApplicationResult]<~DestroyApplicationResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~DestroyApplicationResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1026,7 +1026,7 @@ class ApplicationFacade(Type):
     @ReturnMapping(None)
     async def DestroyRelation(self, endpoints=None):
         '''
-        endpoints : typing.Sequence<+T_co>[str]
+        endpoints : typing.Sequence[str]
         Returns -> None
         '''
         if endpoints is not None and not isinstance(endpoints, (bytes, str, list)):
@@ -1047,8 +1047,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(DestroyUnitResults)
     async def DestroyUnit(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~DestroyUnitResult]<~DestroyUnitResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~DestroyUnitResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1068,7 +1068,7 @@ class ApplicationFacade(Type):
     @ReturnMapping(None)
     async def DestroyUnits(self, unit_names=None):
         '''
-        unit_names : typing.Sequence<+T_co>[str]
+        unit_names : typing.Sequence[str]
         Returns -> None
         '''
         if unit_names is not None and not isinstance(unit_names, (bytes, str, list)):
@@ -1111,7 +1111,7 @@ class ApplicationFacade(Type):
     async def Get(self, application=None):
         '''
         application : str
-        Returns -> typing.Union[str, typing.Mapping<~KT, +VT_co>[str, typing.Any], _ForwardRef('Value')]
+        Returns -> typing.Union[str, typing.Mapping[str, typing.Any], _ForwardRef('Value')]
         '''
         if application is not None and not isinstance(application, (bytes, str)):
             raise Exception("Expected application to be a str, received: {}".format(type(application)))
@@ -1173,8 +1173,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(RemoteApplicationInfoResults)
     async def RemoteApplicationInfo(self, application_urls=None):
         '''
-        application_urls : typing.Sequence<+T_co>[str]
-        Returns -> typing.Sequence<+T_co>[~RemoteApplicationInfoResult]<~RemoteApplicationInfoResult>
+        application_urls : typing.Sequence[str]
+        Returns -> typing.Sequence[~RemoteApplicationInfoResult]
         '''
         if application_urls is not None and not isinstance(application_urls, (bytes, str, list)):
             raise Exception("Expected application_urls to be a Sequence, received: {}".format(type(application_urls)))
@@ -1195,7 +1195,7 @@ class ApplicationFacade(Type):
     async def Set(self, application=None, options=None):
         '''
         application : str
-        options : typing.Mapping<~KT, +VT_co>[str, str]
+        options : typing.Mapping[str, str]
         Returns -> None
         '''
         if application is not None and not isinstance(application, (bytes, str)):
@@ -1223,12 +1223,12 @@ class ApplicationFacade(Type):
         application : str
         channel : str
         charm_url : str
-        config_settings : typing.Mapping<~KT, +VT_co>[str, str]
+        config_settings : typing.Mapping[str, str]
         config_settings_yaml : str
         force_series : bool
         force_units : bool
-        resource_ids : typing.Mapping<~KT, +VT_co>[str, str]
-        storage_constraints : typing.Mapping<~KT, +VT_co>[str, ~StorageConstraints]<~StorageConstraints>
+        resource_ids : typing.Mapping[str, str]
+        storage_constraints : typing.Mapping[str, ~StorageConstraints]
         Returns -> None
         '''
         if application is not None and not isinstance(application, (bytes, str)):
@@ -1307,8 +1307,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetMetricCredentials(self, creds=None):
         '''
-        creds : typing.Sequence<+T_co>[~ApplicationMetricCredential]<~ApplicationMetricCredential>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        creds : typing.Sequence[~ApplicationMetricCredential]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if creds is not None and not isinstance(creds, (bytes, str, list)):
             raise Exception("Expected creds to be a Sequence, received: {}".format(type(creds)))
@@ -1350,7 +1350,7 @@ class ApplicationFacade(Type):
     async def Unset(self, application=None, options=None):
         '''
         application : str
-        options : typing.Sequence<+T_co>[str]
+        options : typing.Sequence[str]
         Returns -> None
         '''
         if application is not None and not isinstance(application, (bytes, str)):
@@ -1381,7 +1381,7 @@ class ApplicationFacade(Type):
         force_charm_url : bool
         force_series : bool
         min_units : int
-        settings : typing.Mapping<~KT, +VT_co>[str, str]
+        settings : typing.Mapping[str, str]
         settings_yaml : str
         Returns -> None
         '''
@@ -1522,7 +1522,7 @@ class BundleFacade(Type):
         '''
         bundleurl : str
         yaml : str
-        Returns -> typing.Sequence<+T_co>[~BundleChange]<~BundleChange>
+        Returns -> typing.Union[typing.Sequence[~BundleChange], typing.Sequence[str]]
         '''
         if bundleurl is not None and not isinstance(bundleurl, (bytes, str)):
             raise Exception("Expected bundleurl to be a str, received: {}".format(type(bundleurl)))
@@ -1548,7 +1548,7 @@ class BundleFacade(Type):
         '''
         bundleurl : str
         yaml : str
-        Returns -> typing.Sequence<+T_co>[~BundleChangesMapArgs]<~BundleChangesMapArgs>
+        Returns -> typing.Union[typing.Sequence[~BundleChangesMapArgs], typing.Sequence[str]]
         '''
         if bundleurl is not None and not isinstance(bundleurl, (bytes, str)):
             raise Exception("Expected bundleurl to be a str, received: {}".format(type(bundleurl)))
@@ -1907,8 +1907,8 @@ class StorageFacade(Type):
     @ReturnMapping(AddStorageResults)
     async def AddToUnit(self, storages=None):
         '''
-        storages : typing.Sequence<+T_co>[~StorageAddParams]<~StorageAddParams>
-        Returns -> typing.Sequence<+T_co>[~AddStorageResult]<~AddStorageResult>
+        storages : typing.Sequence[~StorageAddParams]
+        Returns -> typing.Sequence[~AddStorageResult]
         '''
         if storages is not None and not isinstance(storages, (bytes, str, list)):
             raise Exception("Expected storages to be a Sequence, received: {}".format(type(storages)))
@@ -1928,8 +1928,8 @@ class StorageFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Attach(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~StorageAttachmentId]<~StorageAttachmentId>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        ids : typing.Sequence[~StorageAttachmentId]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -1949,7 +1949,7 @@ class StorageFacade(Type):
     @ReturnMapping(None)
     async def CreatePool(self, attrs=None, name=None, provider=None):
         '''
-        attrs : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        attrs : typing.Mapping[str, typing.Any]
         name : str
         provider : str
         Returns -> None
@@ -1980,8 +1980,8 @@ class StorageFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Detach(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~StorageAttachmentId]<~StorageAttachmentId>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        ids : typing.Sequence[~StorageAttachmentId]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -2001,8 +2001,8 @@ class StorageFacade(Type):
     @ReturnMapping(ImportStorageResults)
     async def Import(self, storage=None):
         '''
-        storage : typing.Sequence<+T_co>[~ImportStorageParams]<~ImportStorageParams>
-        Returns -> typing.Sequence<+T_co>[~ImportStorageResult]<~ImportStorageResult>
+        storage : typing.Sequence[~ImportStorageParams]
+        Returns -> typing.Sequence[~ImportStorageResult]
         '''
         if storage is not None and not isinstance(storage, (bytes, str, list)):
             raise Exception("Expected storage to be a Sequence, received: {}".format(type(storage)))
@@ -2022,8 +2022,8 @@ class StorageFacade(Type):
     @ReturnMapping(FilesystemDetailsListResults)
     async def ListFilesystems(self, filters=None):
         '''
-        filters : typing.Sequence<+T_co>[~FilesystemFilter]<~FilesystemFilter>
-        Returns -> typing.Sequence<+T_co>[~FilesystemDetailsListResult]<~FilesystemDetailsListResult>
+        filters : typing.Sequence[~FilesystemFilter]
+        Returns -> typing.Sequence[~FilesystemDetailsListResult]
         '''
         if filters is not None and not isinstance(filters, (bytes, str, list)):
             raise Exception("Expected filters to be a Sequence, received: {}".format(type(filters)))
@@ -2043,8 +2043,8 @@ class StorageFacade(Type):
     @ReturnMapping(StoragePoolsResults)
     async def ListPools(self, filters=None):
         '''
-        filters : typing.Sequence<+T_co>[~StoragePoolFilter]<~StoragePoolFilter>
-        Returns -> typing.Sequence<+T_co>[~StoragePoolsResult]<~StoragePoolsResult>
+        filters : typing.Sequence[~StoragePoolFilter]
+        Returns -> typing.Sequence[~StoragePoolsResult]
         '''
         if filters is not None and not isinstance(filters, (bytes, str, list)):
             raise Exception("Expected filters to be a Sequence, received: {}".format(type(filters)))
@@ -2064,8 +2064,8 @@ class StorageFacade(Type):
     @ReturnMapping(StorageDetailsListResults)
     async def ListStorageDetails(self, filters=None):
         '''
-        filters : typing.Sequence<+T_co>[~StorageFilter]<~StorageFilter>
-        Returns -> typing.Sequence<+T_co>[~StorageDetailsListResult]<~StorageDetailsListResult>
+        filters : typing.Sequence[~StorageFilter]
+        Returns -> typing.Sequence[~StorageDetailsListResult]
         '''
         if filters is not None and not isinstance(filters, (bytes, str, list)):
             raise Exception("Expected filters to be a Sequence, received: {}".format(type(filters)))
@@ -2085,8 +2085,8 @@ class StorageFacade(Type):
     @ReturnMapping(VolumeDetailsListResults)
     async def ListVolumes(self, filters=None):
         '''
-        filters : typing.Sequence<+T_co>[~VolumeFilter]<~VolumeFilter>
-        Returns -> typing.Sequence<+T_co>[~VolumeDetailsListResult]<~VolumeDetailsListResult>
+        filters : typing.Sequence[~VolumeFilter]
+        Returns -> typing.Sequence[~VolumeDetailsListResult]
         '''
         if filters is not None and not isinstance(filters, (bytes, str, list)):
             raise Exception("Expected filters to be a Sequence, received: {}".format(type(filters)))
@@ -2106,8 +2106,8 @@ class StorageFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Remove(self, storage=None):
         '''
-        storage : typing.Sequence<+T_co>[~RemoveStorageInstance]<~RemoveStorageInstance>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        storage : typing.Sequence[~RemoveStorageInstance]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if storage is not None and not isinstance(storage, (bytes, str, list)):
             raise Exception("Expected storage to be a Sequence, received: {}".format(type(storage)))
@@ -2127,8 +2127,8 @@ class StorageFacade(Type):
     @ReturnMapping(StorageDetailsResults)
     async def StorageDetails(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StorageDetailsResult]<~StorageDetailsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StorageDetailsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2659,8 +2659,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(LifeResults)
     async def AttachmentLife(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~MachineStorageId]<~MachineStorageId>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        ids : typing.Sequence[~MachineStorageId]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -2680,8 +2680,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def CreateVolumeAttachmentPlans(self, volume_plans=None):
         '''
-        volume_plans : typing.Sequence<+T_co>[~VolumeAttachmentPlan]<~VolumeAttachmentPlan>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        volume_plans : typing.Sequence[~VolumeAttachmentPlan]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if volume_plans is not None and not isinstance(volume_plans, (bytes, str, list)):
             raise Exception("Expected volume_plans to be a Sequence, received: {}".format(type(volume_plans)))
@@ -2701,8 +2701,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def EnsureDead(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2722,8 +2722,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(FilesystemAttachmentParamsResults)
     async def FilesystemAttachmentParams(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~MachineStorageId]<~MachineStorageId>
-        Returns -> typing.Sequence<+T_co>[~FilesystemAttachmentParamsResult]<~FilesystemAttachmentParamsResult>
+        ids : typing.Sequence[~MachineStorageId]
+        Returns -> typing.Sequence[~FilesystemAttachmentParamsResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -2743,8 +2743,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(FilesystemAttachmentResults)
     async def FilesystemAttachments(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~MachineStorageId]<~MachineStorageId>
-        Returns -> typing.Sequence<+T_co>[~FilesystemAttachmentResult]<~FilesystemAttachmentResult>
+        ids : typing.Sequence[~MachineStorageId]
+        Returns -> typing.Sequence[~FilesystemAttachmentResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -2764,8 +2764,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(FilesystemParamsResults)
     async def FilesystemParams(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~FilesystemParamsResult]<~FilesystemParamsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~FilesystemParamsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2785,8 +2785,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(FilesystemResults)
     async def Filesystems(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~FilesystemResult]<~FilesystemResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~FilesystemResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2806,8 +2806,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(StringResults)
     async def InstanceId(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2827,8 +2827,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(LifeResults)
     async def Life(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2848,8 +2848,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Remove(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2869,8 +2869,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RemoveAttachment(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~MachineStorageId]<~MachineStorageId>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        ids : typing.Sequence[~MachineStorageId]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -2890,8 +2890,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(RemoveFilesystemParamsResults)
     async def RemoveFilesystemParams(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~RemoveFilesystemParamsResult]<~RemoveFilesystemParamsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~RemoveFilesystemParamsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2911,8 +2911,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RemoveVolumeAttachmentPlan(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~MachineStorageId]<~MachineStorageId>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        ids : typing.Sequence[~MachineStorageId]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -2932,8 +2932,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(RemoveVolumeParamsResults)
     async def RemoveVolumeParams(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~RemoveVolumeParamsResult]<~RemoveVolumeParamsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~RemoveVolumeParamsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2953,8 +2953,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetFilesystemAttachmentInfo(self, filesystem_attachments=None):
         '''
-        filesystem_attachments : typing.Sequence<+T_co>[~FilesystemAttachment]<~FilesystemAttachment>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        filesystem_attachments : typing.Sequence[~FilesystemAttachment]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if filesystem_attachments is not None and not isinstance(filesystem_attachments, (bytes, str, list)):
             raise Exception("Expected filesystem_attachments to be a Sequence, received: {}".format(type(filesystem_attachments)))
@@ -2974,8 +2974,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetFilesystemInfo(self, filesystems=None):
         '''
-        filesystems : typing.Sequence<+T_co>[~Filesystem]<~Filesystem>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        filesystems : typing.Sequence[~Filesystem]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if filesystems is not None and not isinstance(filesystems, (bytes, str, list)):
             raise Exception("Expected filesystems to be a Sequence, received: {}".format(type(filesystems)))
@@ -2995,8 +2995,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3016,8 +3016,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetVolumeAttachmentInfo(self, volume_attachments=None):
         '''
-        volume_attachments : typing.Sequence<+T_co>[~VolumeAttachment]<~VolumeAttachment>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        volume_attachments : typing.Sequence[~VolumeAttachment]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if volume_attachments is not None and not isinstance(volume_attachments, (bytes, str, list)):
             raise Exception("Expected volume_attachments to be a Sequence, received: {}".format(type(volume_attachments)))
@@ -3037,8 +3037,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetVolumeAttachmentPlanBlockInfo(self, volume_plans=None):
         '''
-        volume_plans : typing.Sequence<+T_co>[~VolumeAttachmentPlan]<~VolumeAttachmentPlan>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        volume_plans : typing.Sequence[~VolumeAttachmentPlan]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if volume_plans is not None and not isinstance(volume_plans, (bytes, str, list)):
             raise Exception("Expected volume_plans to be a Sequence, received: {}".format(type(volume_plans)))
@@ -3058,8 +3058,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetVolumeInfo(self, volumes=None):
         '''
-        volumes : typing.Sequence<+T_co>[~Volume]<~Volume>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        volumes : typing.Sequence[~Volume]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if volumes is not None and not isinstance(volumes, (bytes, str, list)):
             raise Exception("Expected volumes to be a Sequence, received: {}".format(type(volumes)))
@@ -3079,8 +3079,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UpdateStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3100,8 +3100,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(VolumeAttachmentParamsResults)
     async def VolumeAttachmentParams(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~MachineStorageId]<~MachineStorageId>
-        Returns -> typing.Sequence<+T_co>[~VolumeAttachmentParamsResult]<~VolumeAttachmentParamsResult>
+        ids : typing.Sequence[~MachineStorageId]
+        Returns -> typing.Sequence[~VolumeAttachmentParamsResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -3121,8 +3121,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(VolumeAttachmentPlanResults)
     async def VolumeAttachmentPlans(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~MachineStorageId]<~MachineStorageId>
-        Returns -> typing.Sequence<+T_co>[~VolumeAttachmentPlanResult]<~VolumeAttachmentPlanResult>
+        ids : typing.Sequence[~MachineStorageId]
+        Returns -> typing.Sequence[~VolumeAttachmentPlanResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -3142,8 +3142,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(VolumeAttachmentResults)
     async def VolumeAttachments(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~MachineStorageId]<~MachineStorageId>
-        Returns -> typing.Sequence<+T_co>[~VolumeAttachmentResult]<~VolumeAttachmentResult>
+        ids : typing.Sequence[~MachineStorageId]
+        Returns -> typing.Sequence[~VolumeAttachmentResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -3163,8 +3163,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(BlockDeviceResults)
     async def VolumeBlockDevices(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~MachineStorageId]<~MachineStorageId>
-        Returns -> typing.Sequence<+T_co>[~BlockDeviceResult]<~BlockDeviceResult>
+        ids : typing.Sequence[~MachineStorageId]
+        Returns -> typing.Sequence[~BlockDeviceResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -3184,8 +3184,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(VolumeParamsResults)
     async def VolumeParams(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~VolumeParamsResult]<~VolumeParamsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~VolumeParamsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3205,8 +3205,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(VolumeResults)
     async def Volumes(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~VolumeResult]<~VolumeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~VolumeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3227,7 +3227,7 @@ class StorageProvisionerFacade(Type):
     async def WatchApplications(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[str], _ForwardRef('Error')]
+        Returns -> typing.Union[typing.Sequence[str], _ForwardRef('Error'), str]
         '''
 
         # map input types to rpc msg
@@ -3245,8 +3245,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchBlockDevices(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3266,8 +3266,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(MachineStorageIdsWatchResults)
     async def WatchFilesystemAttachments(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MachineStorageIdsWatchResult]<~MachineStorageIdsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MachineStorageIdsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3287,8 +3287,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchFilesystems(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3308,8 +3308,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchMachines(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3329,8 +3329,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(MachineStorageIdsWatchResults)
     async def WatchVolumeAttachmentPlans(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MachineStorageIdsWatchResult]<~MachineStorageIdsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MachineStorageIdsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3350,8 +3350,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(MachineStorageIdsWatchResults)
     async def WatchVolumeAttachments(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MachineStorageIdsWatchResult]<~MachineStorageIdsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MachineStorageIdsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3371,8 +3371,8 @@ class StorageProvisionerFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchVolumes(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4234,7 +4234,7 @@ class UniterFacade(Type):
     async def APIAddresses(self):
         '''
 
-        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence<+T_co>[str]]
+        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence[str]]
         '''
 
         # map input types to rpc msg
@@ -4253,7 +4253,7 @@ class UniterFacade(Type):
     async def APIHostPorts(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~HostPort]<~HostPort>
+        Returns -> typing.Sequence[~HostPort]
         '''
 
         # map input types to rpc msg
@@ -4271,8 +4271,8 @@ class UniterFacade(Type):
     @ReturnMapping(ActionResults)
     async def Actions(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ActionResult]<~ActionResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ActionResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4292,8 +4292,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def AddMetricBatches(self, batches=None):
         '''
-        batches : typing.Sequence<+T_co>[~MetricBatchParam]<~MetricBatchParam>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        batches : typing.Sequence[~MetricBatchParam]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if batches is not None and not isinstance(batches, (bytes, str, list)):
             raise Exception("Expected batches to be a Sequence, received: {}".format(type(batches)))
@@ -4313,8 +4313,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def AddUnitStorage(self, storages=None):
         '''
-        storages : typing.Sequence<+T_co>[~StorageAddParams]<~StorageAddParams>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        storages : typing.Sequence[~StorageAddParams]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if storages is not None and not isinstance(storages, (bytes, str, list)):
             raise Exception("Expected storages to be a Sequence, received: {}".format(type(storages)))
@@ -4334,8 +4334,8 @@ class UniterFacade(Type):
     @ReturnMapping(MachinePortsResults)
     async def AllMachinePorts(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MachinePortsResult]<~MachinePortsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MachinePortsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4355,8 +4355,8 @@ class UniterFacade(Type):
     @ReturnMapping(ApplicationStatusResults)
     async def ApplicationStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ApplicationStatusResult]<~ApplicationStatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ApplicationStatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4376,8 +4376,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringResults)
     async def AssignedMachine(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4397,8 +4397,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringResults)
     async def AvailabilityZone(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4418,8 +4418,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def BeginActions(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4440,7 +4440,7 @@ class UniterFacade(Type):
     async def CACert(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[int]
+        Returns -> typing.Sequence[int]
         '''
 
         # map input types to rpc msg
@@ -4458,8 +4458,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringResults)
     async def CharmArchiveSha256(self, urls=None):
         '''
-        urls : typing.Sequence<+T_co>[~CharmURL]<~CharmURL>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        urls : typing.Sequence[~CharmURL]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if urls is not None and not isinstance(urls, (bytes, str, list)):
             raise Exception("Expected urls to be a Sequence, received: {}".format(type(urls)))
@@ -4479,8 +4479,8 @@ class UniterFacade(Type):
     @ReturnMapping(IntResults)
     async def CharmModifiedVersion(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~IntResult]<~IntResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~IntResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4500,8 +4500,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringBoolResults)
     async def CharmURL(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringBoolResult]<~StringBoolResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringBoolResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4521,8 +4521,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ClearResolved(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4542,8 +4542,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ClosePorts(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityPortRange]<~EntityPortRange>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityPortRange]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4563,8 +4563,8 @@ class UniterFacade(Type):
     @ReturnMapping(ConfigSettingsResults)
     async def ConfigSettings(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ConfigSettingsResult]<~ConfigSettingsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ConfigSettingsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4603,8 +4603,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Destroy(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4624,8 +4624,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def DestroyAllSubordinates(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4645,8 +4645,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def DestroyUnitStorageAttachments(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4666,8 +4666,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def EnsureDead(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4687,8 +4687,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def EnterScope(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnit]<~RelationUnit>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        relation_units : typing.Sequence[~RelationUnit]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -4708,8 +4708,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def FinishActions(self, results=None):
         '''
-        results : typing.Sequence<+T_co>[~ActionExecutionResult]<~ActionExecutionResult>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        results : typing.Sequence[~ActionExecutionResult]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if results is not None and not isinstance(results, (bytes, str, list)):
             raise Exception("Expected results to be a Sequence, received: {}".format(type(results)))
@@ -4729,8 +4729,8 @@ class UniterFacade(Type):
     @ReturnMapping(MeterStatusResults)
     async def GetMeterStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MeterStatusResult]<~MeterStatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MeterStatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4750,8 +4750,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringBoolResults)
     async def GetPrincipal(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringBoolResult]<~StringBoolResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringBoolResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4771,8 +4771,8 @@ class UniterFacade(Type):
     @ReturnMapping(BoolResults)
     async def HasSubordinates(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~BoolResult]<~BoolResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~BoolResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4792,8 +4792,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringsResults)
     async def JoinedRelations(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsResult]<~StringsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4813,8 +4813,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def LeaveScope(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnit]<~RelationUnit>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        relation_units : typing.Sequence[~RelationUnit]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -4834,8 +4834,8 @@ class UniterFacade(Type):
     @ReturnMapping(LifeResults)
     async def Life(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4855,8 +4855,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Merge(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~MergeLeadershipSettingsParam]<~MergeLeadershipSettingsParam>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        params : typing.Sequence[~MergeLeadershipSettingsParam]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -4877,7 +4877,7 @@ class UniterFacade(Type):
     async def ModelConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -4914,8 +4914,8 @@ class UniterFacade(Type):
     @ReturnMapping(UnitNetworkConfigResults)
     async def NetworkConfig(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~UnitNetworkConfig]<~UnitNetworkConfig>
-        Returns -> typing.Sequence<+T_co>[~UnitNetworkConfigResult]<~UnitNetworkConfigResult>
+        args : typing.Sequence[~UnitNetworkConfig]
+        Returns -> typing.Sequence[~UnitNetworkConfigResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -4935,8 +4935,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def OpenPorts(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityPortRange]<~EntityPortRange>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityPortRange]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4956,8 +4956,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringResults)
     async def PrivateAddress(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4996,8 +4996,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringResults)
     async def PublicAddress(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5017,8 +5017,8 @@ class UniterFacade(Type):
     @ReturnMapping(GetLeadershipSettingsBulkResults)
     async def Read(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~GetLeadershipSettingsResult]<~GetLeadershipSettingsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~GetLeadershipSettingsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5038,8 +5038,8 @@ class UniterFacade(Type):
     @ReturnMapping(SettingsResults)
     async def ReadRemoteSettings(self, relation_unit_pairs=None):
         '''
-        relation_unit_pairs : typing.Sequence<+T_co>[~RelationUnitPair]<~RelationUnitPair>
-        Returns -> typing.Sequence<+T_co>[~SettingsResult]<~SettingsResult>
+        relation_unit_pairs : typing.Sequence[~RelationUnitPair]
+        Returns -> typing.Sequence[~SettingsResult]
         '''
         if relation_unit_pairs is not None and not isinstance(relation_unit_pairs, (bytes, str, list)):
             raise Exception("Expected relation_unit_pairs to be a Sequence, received: {}".format(type(relation_unit_pairs)))
@@ -5059,8 +5059,8 @@ class UniterFacade(Type):
     @ReturnMapping(SettingsResults)
     async def ReadSettings(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnit]<~RelationUnit>
-        Returns -> typing.Sequence<+T_co>[~SettingsResult]<~SettingsResult>
+        relation_units : typing.Sequence[~RelationUnit]
+        Returns -> typing.Sequence[~SettingsResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -5080,8 +5080,8 @@ class UniterFacade(Type):
     @ReturnMapping(RelationResults)
     async def Relation(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnit]<~RelationUnit>
-        Returns -> typing.Sequence<+T_co>[~RelationResult]<~RelationResult>
+        relation_units : typing.Sequence[~RelationUnit]
+        Returns -> typing.Sequence[~RelationResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -5101,8 +5101,8 @@ class UniterFacade(Type):
     @ReturnMapping(RelationResults)
     async def RelationById(self, relation_ids=None):
         '''
-        relation_ids : typing.Sequence<+T_co>[int]
-        Returns -> typing.Sequence<+T_co>[~RelationResult]<~RelationResult>
+        relation_ids : typing.Sequence[int]
+        Returns -> typing.Sequence[~RelationResult]
         '''
         if relation_ids is not None and not isinstance(relation_ids, (bytes, str, list)):
             raise Exception("Expected relation_ids to be a Sequence, received: {}".format(type(relation_ids)))
@@ -5122,8 +5122,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RemoveStorageAttachments(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~StorageAttachmentId]<~StorageAttachmentId>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        ids : typing.Sequence[~StorageAttachmentId]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -5143,8 +5143,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RequestReboot(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5164,8 +5164,8 @@ class UniterFacade(Type):
     @ReturnMapping(ResolvedModeResults)
     async def Resolved(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ResolvedModeResult]<~ResolvedModeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ResolvedModeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5185,8 +5185,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetAgentStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5206,8 +5206,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetApplicationStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5227,8 +5227,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetCharmURL(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityCharmURL]<~EntityCharmURL>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityCharmURL]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5248,8 +5248,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5269,8 +5269,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetUnitStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5290,8 +5290,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetWorkloadVersion(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityWorkloadVersion]<~EntityWorkloadVersion>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityWorkloadVersion]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5311,8 +5311,8 @@ class UniterFacade(Type):
     @ReturnMapping(LifeResults)
     async def StorageAttachmentLife(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~StorageAttachmentId]<~StorageAttachmentId>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        ids : typing.Sequence[~StorageAttachmentId]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -5332,8 +5332,8 @@ class UniterFacade(Type):
     @ReturnMapping(StorageAttachmentResults)
     async def StorageAttachments(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~StorageAttachmentId]<~StorageAttachmentId>
-        Returns -> typing.Sequence<+T_co>[~StorageAttachmentResult]<~StorageAttachmentResult>
+        ids : typing.Sequence[~StorageAttachmentId]
+        Returns -> typing.Sequence[~StorageAttachmentResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -5353,8 +5353,8 @@ class UniterFacade(Type):
     @ReturnMapping(StatusResults)
     async def UnitStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StatusResult]<~StatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5374,8 +5374,8 @@ class UniterFacade(Type):
     @ReturnMapping(StorageAttachmentIdsResults)
     async def UnitStorageAttachments(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StorageAttachmentIdsResult]<~StorageAttachmentIdsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StorageAttachmentIdsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5395,8 +5395,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UpdateSettings(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnitSettings]<~RelationUnitSettings>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        relation_units : typing.Sequence[~RelationUnitSettings]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -5416,8 +5416,8 @@ class UniterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def Watch(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5456,8 +5456,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchActionNotifications(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5477,8 +5477,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchApplicationRelations(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5498,8 +5498,8 @@ class UniterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchConfigSettings(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5538,8 +5538,8 @@ class UniterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchLeadershipSettings(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5559,8 +5559,8 @@ class UniterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchMeterStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5580,8 +5580,8 @@ class UniterFacade(Type):
     @ReturnMapping(RelationUnitsWatchResults)
     async def WatchRelationUnits(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnit]<~RelationUnit>
-        Returns -> typing.Sequence<+T_co>[~RelationUnitsWatchResult]<~RelationUnitsWatchResult>
+        relation_units : typing.Sequence[~RelationUnit]
+        Returns -> typing.Sequence[~RelationUnitsWatchResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -5601,8 +5601,8 @@ class UniterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchStorageAttachments(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~StorageAttachmentId]<~StorageAttachmentId>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        ids : typing.Sequence[~StorageAttachmentId]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -5622,8 +5622,8 @@ class UniterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchUnitAddresses(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5643,8 +5643,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchUnitStorageAttachments(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5664,8 +5664,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringResults)
     async def WorkloadVersion(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))

--- a/juju/client/_client5.py
+++ b/juju/client/_client5.py
@@ -429,8 +429,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(AddRelationResults)
     async def AddRelation(self, endpoints=None):
         '''
-        endpoints : typing.Sequence<+T_co>[str]
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~CharmRelation]<~CharmRelation>
+        endpoints : typing.Sequence[str]
+        Returns -> typing.Mapping[str, ~CharmRelation]
         '''
         if endpoints is not None and not isinstance(endpoints, (bytes, str, list)):
             raise Exception("Expected endpoints to be a Sequence, received: {}".format(type(endpoints)))
@@ -451,10 +451,10 @@ class ApplicationFacade(Type):
     async def AddUnits(self, application=None, attach_storage=None, num_units=None, placement=None):
         '''
         application : str
-        attach_storage : typing.Sequence<+T_co>[str]
+        attach_storage : typing.Sequence[str]
         num_units : int
-        placement : typing.Sequence<+T_co>[~Placement]<~Placement>
-        Returns -> typing.Sequence<+T_co>[str]
+        placement : typing.Sequence[~Placement]
+        Returns -> typing.Sequence[str]
         '''
         if application is not None and not isinstance(application, (bytes, str)):
             raise Exception("Expected application to be a str, received: {}".format(type(application)))
@@ -487,7 +487,7 @@ class ApplicationFacade(Type):
     async def CharmRelations(self, application=None):
         '''
         application : str
-        Returns -> typing.Sequence<+T_co>[str]
+        Returns -> typing.Sequence[str]
         '''
         if application is not None and not isinstance(application, (bytes, str)):
             raise Exception("Expected application to be a str, received: {}".format(type(application)))
@@ -507,8 +507,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Consume(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~ConsumeApplicationArg]<~ConsumeApplicationArg>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~ConsumeApplicationArg]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -528,8 +528,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Deploy(self, applications=None):
         '''
-        applications : typing.Sequence<+T_co>[~ApplicationDeploy]<~ApplicationDeploy>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        applications : typing.Sequence[~ApplicationDeploy]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if applications is not None and not isinstance(applications, (bytes, str, list)):
             raise Exception("Expected applications to be a Sequence, received: {}".format(type(applications)))
@@ -570,8 +570,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(DestroyApplicationResults)
     async def DestroyApplication(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~DestroyApplicationResult]<~DestroyApplicationResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~DestroyApplicationResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -591,7 +591,7 @@ class ApplicationFacade(Type):
     @ReturnMapping(None)
     async def DestroyRelation(self, endpoints=None):
         '''
-        endpoints : typing.Sequence<+T_co>[str]
+        endpoints : typing.Sequence[str]
         Returns -> None
         '''
         if endpoints is not None and not isinstance(endpoints, (bytes, str, list)):
@@ -612,8 +612,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(DestroyUnitResults)
     async def DestroyUnit(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~DestroyUnitResult]<~DestroyUnitResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~DestroyUnitResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -633,7 +633,7 @@ class ApplicationFacade(Type):
     @ReturnMapping(None)
     async def DestroyUnits(self, unit_names=None):
         '''
-        unit_names : typing.Sequence<+T_co>[str]
+        unit_names : typing.Sequence[str]
         Returns -> None
         '''
         if unit_names is not None and not isinstance(unit_names, (bytes, str, list)):
@@ -676,7 +676,7 @@ class ApplicationFacade(Type):
     async def Get(self, application=None):
         '''
         application : str
-        Returns -> typing.Union[str, typing.Mapping<~KT, +VT_co>[str, typing.Any], _ForwardRef('Value')]
+        Returns -> typing.Union[str, typing.Mapping[str, typing.Any], _ForwardRef('Value')]
         '''
         if application is not None and not isinstance(application, (bytes, str)):
             raise Exception("Expected application to be a str, received: {}".format(type(application)))
@@ -739,7 +739,7 @@ class ApplicationFacade(Type):
     async def Set(self, application=None, options=None):
         '''
         application : str
-        options : typing.Mapping<~KT, +VT_co>[str, str]
+        options : typing.Mapping[str, str]
         Returns -> None
         '''
         if application is not None and not isinstance(application, (bytes, str)):
@@ -767,12 +767,12 @@ class ApplicationFacade(Type):
         application : str
         channel : str
         charm_url : str
-        config_settings : typing.Mapping<~KT, +VT_co>[str, str]
+        config_settings : typing.Mapping[str, str]
         config_settings_yaml : str
         force_series : bool
         force_units : bool
-        resource_ids : typing.Mapping<~KT, +VT_co>[str, str]
-        storage_constraints : typing.Mapping<~KT, +VT_co>[str, ~StorageConstraints]<~StorageConstraints>
+        resource_ids : typing.Mapping[str, str]
+        storage_constraints : typing.Mapping[str, ~StorageConstraints]
         Returns -> None
         '''
         if application is not None and not isinstance(application, (bytes, str)):
@@ -851,8 +851,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetMetricCredentials(self, creds=None):
         '''
-        creds : typing.Sequence<+T_co>[~ApplicationMetricCredential]<~ApplicationMetricCredential>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        creds : typing.Sequence[~ApplicationMetricCredential]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if creds is not None and not isinstance(creds, (bytes, str, list)):
             raise Exception("Expected creds to be a Sequence, received: {}".format(type(creds)))
@@ -894,7 +894,7 @@ class ApplicationFacade(Type):
     async def Unset(self, application=None, options=None):
         '''
         application : str
-        options : typing.Sequence<+T_co>[str]
+        options : typing.Sequence[str]
         Returns -> None
         '''
         if application is not None and not isinstance(application, (bytes, str)):
@@ -925,7 +925,7 @@ class ApplicationFacade(Type):
         force_charm_url : bool
         force_series : bool
         min_units : int
-        settings : typing.Mapping<~KT, +VT_co>[str, str]
+        settings : typing.Mapping[str, str]
         settings_yaml : str
         Returns -> None
         '''
@@ -1367,8 +1367,8 @@ class CloudFacade(Type):
     @ReturnMapping(ErrorResults)
     async def AddCredentials(self, credentials=None):
         '''
-        credentials : typing.Sequence<+T_co>[~TaggedCredential]<~TaggedCredential>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        credentials : typing.Sequence[~TaggedCredential]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if credentials is not None and not isinstance(credentials, (bytes, str, list)):
             raise Exception("Expected credentials to be a Sequence, received: {}".format(type(credentials)))
@@ -1388,8 +1388,8 @@ class CloudFacade(Type):
     @ReturnMapping(UpdateCredentialResults)
     async def CheckCredentialsModels(self, credentials=None):
         '''
-        credentials : typing.Sequence<+T_co>[~TaggedCredential]<~TaggedCredential>
-        Returns -> typing.Sequence<+T_co>[~UpdateCredentialResult]<~UpdateCredentialResult>
+        credentials : typing.Sequence[~TaggedCredential]
+        Returns -> typing.Sequence[~UpdateCredentialResult]
         '''
         if credentials is not None and not isinstance(credentials, (bytes, str, list)):
             raise Exception("Expected credentials to be a Sequence, received: {}".format(type(credentials)))
@@ -1409,8 +1409,8 @@ class CloudFacade(Type):
     @ReturnMapping(CloudResults)
     async def Cloud(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~CloudResult]<~CloudResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~CloudResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1430,8 +1430,8 @@ class CloudFacade(Type):
     @ReturnMapping(CloudInfoResults)
     async def CloudInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~CloudInfoResult]<~CloudInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~CloudInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1452,7 +1452,7 @@ class CloudFacade(Type):
     async def Clouds(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~Cloud]<~Cloud>
+        Returns -> typing.Mapping[str, ~Cloud]
         '''
 
         # map input types to rpc msg
@@ -1470,8 +1470,8 @@ class CloudFacade(Type):
     @ReturnMapping(CloudCredentialResults)
     async def Credential(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~CloudCredentialResult]<~CloudCredentialResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~CloudCredentialResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1491,9 +1491,9 @@ class CloudFacade(Type):
     @ReturnMapping(CredentialContentResults)
     async def CredentialContents(self, credentials=None, include_secrets=None):
         '''
-        credentials : typing.Sequence<+T_co>[~CloudCredentialArg]<~CloudCredentialArg>
+        credentials : typing.Sequence[~CloudCredentialArg]
         include_secrets : bool
-        Returns -> typing.Sequence<+T_co>[~CredentialContentResult]<~CredentialContentResult>
+        Returns -> typing.Sequence[~CredentialContentResult]
         '''
         if credentials is not None and not isinstance(credentials, (bytes, str, list)):
             raise Exception("Expected credentials to be a Sequence, received: {}".format(type(credentials)))
@@ -1517,8 +1517,8 @@ class CloudFacade(Type):
     @ReturnMapping(InstanceTypesResults)
     async def InstanceTypes(self, constraints=None):
         '''
-        constraints : typing.Sequence<+T_co>[~CloudInstanceTypesConstraint]<~CloudInstanceTypesConstraint>
-        Returns -> typing.Sequence<+T_co>[~InstanceTypesResult]<~InstanceTypesResult>
+        constraints : typing.Sequence[~CloudInstanceTypesConstraint]
+        Returns -> typing.Sequence[~InstanceTypesResult]
         '''
         if constraints is not None and not isinstance(constraints, (bytes, str, list)):
             raise Exception("Expected constraints to be a Sequence, received: {}".format(type(constraints)))
@@ -1540,7 +1540,7 @@ class CloudFacade(Type):
         '''
         all_ : bool
         user_tag : str
-        Returns -> typing.Sequence<+T_co>[~ListCloudInfoResult]<~ListCloudInfoResult>
+        Returns -> typing.Sequence[~ListCloudInfoResult]
         '''
         if all_ is not None and not isinstance(all_, bool):
             raise Exception("Expected all_ to be a bool, received: {}".format(type(all_)))
@@ -1564,8 +1564,8 @@ class CloudFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ModifyCloudAccess(self, changes=None):
         '''
-        changes : typing.Sequence<+T_co>[~ModifyCloudAccess]<~ModifyCloudAccess>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        changes : typing.Sequence[~ModifyCloudAccess]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if changes is not None and not isinstance(changes, (bytes, str, list)):
             raise Exception("Expected changes to be a Sequence, received: {}".format(type(changes)))
@@ -1585,8 +1585,8 @@ class CloudFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RemoveClouds(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1606,8 +1606,8 @@ class CloudFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RevokeCredentialsCheckModels(self, credentials=None):
         '''
-        credentials : typing.Sequence<+T_co>[~RevokeCredentialArg]<~RevokeCredentialArg>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        credentials : typing.Sequence[~RevokeCredentialArg]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if credentials is not None and not isinstance(credentials, (bytes, str, list)):
             raise Exception("Expected credentials to be a Sequence, received: {}".format(type(credentials)))
@@ -1627,8 +1627,8 @@ class CloudFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UpdateCloud(self, clouds=None):
         '''
-        clouds : typing.Sequence<+T_co>[~AddCloudArgs]<~AddCloudArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        clouds : typing.Sequence[~AddCloudArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if clouds is not None and not isinstance(clouds, (bytes, str, list)):
             raise Exception("Expected clouds to be a Sequence, received: {}".format(type(clouds)))
@@ -1648,9 +1648,9 @@ class CloudFacade(Type):
     @ReturnMapping(UpdateCredentialResults)
     async def UpdateCredentialsCheckModels(self, credentials=None, force=None):
         '''
-        credentials : typing.Sequence<+T_co>[~TaggedCredential]<~TaggedCredential>
+        credentials : typing.Sequence[~TaggedCredential]
         force : bool
-        Returns -> typing.Sequence<+T_co>[~UpdateCredentialResult]<~UpdateCredentialResult>
+        Returns -> typing.Sequence[~UpdateCredentialResult]
         '''
         if credentials is not None and not isinstance(credentials, (bytes, str, list)):
             raise Exception("Expected credentials to be a Sequence, received: {}".format(type(credentials)))
@@ -1674,8 +1674,8 @@ class CloudFacade(Type):
     @ReturnMapping(StringsResults)
     async def UserCredentials(self, user_clouds=None):
         '''
-        user_clouds : typing.Sequence<+T_co>[~UserCloud]<~UserCloud>
-        Returns -> typing.Sequence<+T_co>[~StringsResult]<~StringsResult>
+        user_clouds : typing.Sequence[~UserCloud]
+        Returns -> typing.Sequence[~StringsResult]
         '''
         if user_clouds is not None and not isinstance(user_clouds, (bytes, str, list)):
             raise Exception("Expected user_clouds to be a Sequence, received: {}".format(type(user_clouds)))
@@ -2016,7 +2016,7 @@ class ControllerFacade(Type):
     async def AllModels(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~UserModel]<~UserModel>
+        Returns -> typing.Sequence[~UserModel]
         '''
 
         # map input types to rpc msg
@@ -2034,8 +2034,8 @@ class ControllerFacade(Type):
     @ReturnMapping(CloudSpecResults)
     async def CloudSpec(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~CloudSpecResult]<~CloudSpecResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~CloudSpecResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2055,7 +2055,7 @@ class ControllerFacade(Type):
     @ReturnMapping(None)
     async def ConfigSet(self, config=None):
         '''
-        config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        config : typing.Mapping[str, typing.Any]
         Returns -> None
         '''
         if config is not None and not isinstance(config, dict):
@@ -2076,8 +2076,8 @@ class ControllerFacade(Type):
     @ReturnMapping(ControllerAPIInfoResults)
     async def ControllerAPIInfoForModels(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ControllerAPIInfoResult]<~ControllerAPIInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ControllerAPIInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2098,7 +2098,7 @@ class ControllerFacade(Type):
     async def ControllerConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -2161,8 +2161,8 @@ class ControllerFacade(Type):
     @ReturnMapping(UserAccessResults)
     async def GetControllerAccess(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~UserAccessResult]<~UserAccessResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~UserAccessResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2183,7 +2183,7 @@ class ControllerFacade(Type):
     async def HostedModelConfigs(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~HostedModelConfig]<~HostedModelConfig>
+        Returns -> typing.Sequence[~HostedModelConfig]
         '''
 
         # map input types to rpc msg
@@ -2201,8 +2201,8 @@ class ControllerFacade(Type):
     @ReturnMapping(InitiateMigrationResults)
     async def InitiateMigration(self, specs=None):
         '''
-        specs : typing.Sequence<+T_co>[~MigrationSpec]<~MigrationSpec>
-        Returns -> typing.Sequence<+T_co>[~InitiateMigrationResult]<~InitiateMigrationResult>
+        specs : typing.Sequence[~MigrationSpec]
+        Returns -> typing.Sequence[~InitiateMigrationResult]
         '''
         if specs is not None and not isinstance(specs, (bytes, str, list)):
             raise Exception("Expected specs to be a Sequence, received: {}".format(type(specs)))
@@ -2223,7 +2223,7 @@ class ControllerFacade(Type):
     async def ListBlockedModels(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~ModelBlockInfo]<~ModelBlockInfo>
+        Returns -> typing.Sequence[~ModelBlockInfo]
         '''
 
         # map input types to rpc msg
@@ -2242,7 +2242,7 @@ class ControllerFacade(Type):
     async def ModelConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~ConfigValue]<~ConfigValue>
+        Returns -> typing.Mapping[str, ~ConfigValue]
         '''
 
         # map input types to rpc msg
@@ -2260,8 +2260,8 @@ class ControllerFacade(Type):
     @ReturnMapping(ModelStatusResults)
     async def ModelStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ModelStatus]<~ModelStatus>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ModelStatus]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2281,8 +2281,8 @@ class ControllerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ModifyControllerAccess(self, changes=None):
         '''
-        changes : typing.Sequence<+T_co>[~ModifyControllerAccess]<~ModifyControllerAccess>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        changes : typing.Sequence[~ModifyControllerAccess]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if changes is not None and not isinstance(changes, (bytes, str, list)):
             raise Exception("Expected changes to be a Sequence, received: {}".format(type(changes)))
@@ -2632,8 +2632,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(BoolResults)
     async def AreManuallyProvisioned(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~BoolResult]<~BoolResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~BoolResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2653,8 +2653,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(CloudSpecResults)
     async def CloudSpec(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~CloudSpecResult]<~CloudSpecResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~CloudSpecResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2674,8 +2674,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(ControllerAPIInfoResults)
     async def ControllerAPIInfoForModels(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ControllerAPIInfoResult]<~ControllerAPIInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ControllerAPIInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2696,7 +2696,7 @@ class FirewallerFacade(Type):
     async def ControllerConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -2714,8 +2714,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(ListFirewallRulesResults)
     async def FirewallRules(self, known_services=None):
         '''
-        known_services : typing.Sequence<+T_co>[str]
-        Returns -> typing.Sequence<+T_co>[~FirewallRule]<~FirewallRule>
+        known_services : typing.Sequence[str]
+        Returns -> typing.Sequence[~FirewallRule]
         '''
         if known_services is not None and not isinstance(known_services, (bytes, str, list)):
             raise Exception("Expected known_services to be a Sequence, received: {}".format(type(known_services)))
@@ -2735,8 +2735,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(StringResults)
     async def GetAssignedMachine(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2775,8 +2775,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(BoolResults)
     async def GetExposed(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~BoolResult]<~BoolResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~BoolResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2796,8 +2796,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(StringsResults)
     async def GetMachineActiveSubnets(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsResult]<~StringsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2817,8 +2817,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(MachinePortsResults)
     async def GetMachinePorts(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~MachinePorts]<~MachinePorts>
-        Returns -> typing.Sequence<+T_co>[~MachinePortsResult]<~MachinePortsResult>
+        params : typing.Sequence[~MachinePorts]
+        Returns -> typing.Sequence[~MachinePortsResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -2838,8 +2838,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(StringResults)
     async def InstanceId(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2859,8 +2859,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(LifeResults)
     async def Life(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2880,8 +2880,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(MacaroonResults)
     async def MacaroonForRelations(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MacaroonResult]<~MacaroonResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MacaroonResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2902,7 +2902,7 @@ class FirewallerFacade(Type):
     async def ModelConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -2920,8 +2920,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetRelationsStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2941,8 +2941,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def Watch(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2962,8 +2962,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchCloudSpecsChanges(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2983,8 +2983,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchEgressAddressesForRelations(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3023,8 +3023,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchIngressAddressesForRelations(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3045,7 +3045,7 @@ class FirewallerFacade(Type):
     async def WatchModelMachines(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[str], _ForwardRef('Error')]
+        Returns -> typing.Union[typing.Sequence[str], _ForwardRef('Error'), str]
         '''
 
         # map input types to rpc msg
@@ -3063,8 +3063,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchOpenedPorts(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3084,8 +3084,8 @@ class FirewallerFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchUnits(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3357,8 +3357,8 @@ class MachineManagerFacade(Type):
     @ReturnMapping(AddMachinesResults)
     async def AddMachines(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~AddMachineParams]<~AddMachineParams>
-        Returns -> typing.Sequence<+T_co>[~AddMachinesResult]<~AddMachinesResult>
+        params : typing.Sequence[~AddMachineParams]
+        Returns -> typing.Sequence[~AddMachinesResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -3378,8 +3378,8 @@ class MachineManagerFacade(Type):
     @ReturnMapping(DestroyMachineResults)
     async def DestroyMachine(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~DestroyMachineResult]<~DestroyMachineResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~DestroyMachineResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3401,8 +3401,8 @@ class MachineManagerFacade(Type):
         '''
         force : bool
         keep : bool
-        machine_tags : typing.Sequence<+T_co>[str]
-        Returns -> typing.Sequence<+T_co>[~DestroyMachineResult]<~DestroyMachineResult>
+        machine_tags : typing.Sequence[str]
+        Returns -> typing.Sequence[~DestroyMachineResult]
         '''
         if force is not None and not isinstance(force, bool):
             raise Exception("Expected force to be a bool, received: {}".format(type(force)))
@@ -3430,8 +3430,8 @@ class MachineManagerFacade(Type):
     @ReturnMapping(DestroyMachineResults)
     async def ForceDestroyMachine(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~DestroyMachineResult]<~DestroyMachineResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~DestroyMachineResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3451,8 +3451,8 @@ class MachineManagerFacade(Type):
     @ReturnMapping(StringsResults)
     async def GetUpgradeSeriesMessages(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~UpgradeSeriesNotificationParam]<~UpgradeSeriesNotificationParam>
-        Returns -> typing.Sequence<+T_co>[~StringsResult]<~StringsResult>
+        params : typing.Sequence[~UpgradeSeriesNotificationParam]
+        Returns -> typing.Sequence[~StringsResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -3472,8 +3472,8 @@ class MachineManagerFacade(Type):
     @ReturnMapping(InstanceTypesResults)
     async def InstanceTypes(self, constraints=None):
         '''
-        constraints : typing.Sequence<+T_co>[~ModelInstanceTypesConstraint]<~ModelInstanceTypesConstraint>
-        Returns -> typing.Sequence<+T_co>[~InstanceTypesResult]<~InstanceTypesResult>
+        constraints : typing.Sequence[~ModelInstanceTypesConstraint]
+        Returns -> typing.Sequence[~InstanceTypesResult]
         '''
         if constraints is not None and not isinstance(constraints, (bytes, str, list)):
             raise Exception("Expected constraints to be a Sequence, received: {}".format(type(constraints)))
@@ -3555,8 +3555,8 @@ class MachineManagerFacade(Type):
     @ReturnMapping(UpgradeSeriesUnitsResults)
     async def UpgradeSeriesValidate(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~UpdateSeriesArg]<~UpdateSeriesArg>
-        Returns -> typing.Sequence<+T_co>[~UpgradeSeriesUnitsResult]<~UpgradeSeriesUnitsResult>
+        args : typing.Sequence[~UpdateSeriesArg]
+        Returns -> typing.Sequence[~UpgradeSeriesUnitsResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -3576,8 +3576,8 @@ class MachineManagerFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchUpgradeSeriesNotifications(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4006,8 +4006,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ChangeModelCredential(self, model_credentials=None):
         '''
-        model_credentials : typing.Sequence<+T_co>[~ChangeModelCredentialParams]<~ChangeModelCredentialParams>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        model_credentials : typing.Sequence[~ChangeModelCredentialParams]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if model_credentials is not None and not isinstance(model_credentials, (bytes, str, list)):
             raise Exception("Expected model_credentials to be a Sequence, received: {}".format(type(model_credentials)))
@@ -4028,12 +4028,12 @@ class ModelManagerFacade(Type):
     async def CreateModel(self, cloud_tag=None, config=None, credential=None, name=None, owner_tag=None, region=None):
         '''
         cloud_tag : str
-        config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        config : typing.Mapping[str, typing.Any]
         credential : str
         name : str
         owner_tag : str
         region : str
-        Returns -> typing.Union[_ForwardRef('Number'), _ForwardRef('ModelMigrationStatus'), _ForwardRef('ModelSLAInfo'), _ForwardRef('EntityStatus'), typing.Sequence<+T_co>[~ModelUserInfo]<~ModelUserInfo>]
+        Returns -> typing.Union[_ForwardRef('Number'), str, typing.Sequence[~ModelMachineInfo], _ForwardRef('ModelMigrationStatus'), _ForwardRef('ModelSLAInfo'), _ForwardRef('EntityStatus'), typing.Sequence[~ModelUserInfo]]
         '''
         if cloud_tag is not None and not isinstance(cloud_tag, (bytes, str)):
             raise Exception("Expected cloud_tag to be a str, received: {}".format(type(cloud_tag)))
@@ -4073,8 +4073,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def DestroyModels(self, models=None):
         '''
-        models : typing.Sequence<+T_co>[~DestroyModelParams]<~DestroyModelParams>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        models : typing.Sequence[~DestroyModelParams]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if models is not None and not isinstance(models, (bytes, str, list)):
             raise Exception("Expected models to be a Sequence, received: {}".format(type(models)))
@@ -4094,9 +4094,9 @@ class ModelManagerFacade(Type):
     @ReturnMapping(StringResults)
     async def DumpModels(self, entities=None, simplified=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
+        entities : typing.Sequence[~Entity]
         simplified : bool
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4120,8 +4120,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(MapResults)
     async def DumpModelsDB(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MapResult]<~MapResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MapResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4143,7 +4143,7 @@ class ModelManagerFacade(Type):
         '''
         all_ : bool
         user_tag : str
-        Returns -> typing.Sequence<+T_co>[~ModelSummaryResult]<~ModelSummaryResult>
+        Returns -> typing.Sequence[~ModelSummaryResult]
         '''
         if all_ is not None and not isinstance(all_, bool):
             raise Exception("Expected all_ to be a bool, received: {}".format(type(all_)))
@@ -4168,7 +4168,7 @@ class ModelManagerFacade(Type):
     async def ListModels(self, tag=None):
         '''
         tag : str
-        Returns -> typing.Sequence<+T_co>[~UserModel]<~UserModel>
+        Returns -> typing.Sequence[~UserModel]
         '''
         if tag is not None and not isinstance(tag, (bytes, str)):
             raise Exception("Expected tag to be a str, received: {}".format(type(tag)))
@@ -4189,7 +4189,7 @@ class ModelManagerFacade(Type):
     async def ModelDefaults(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~ModelDefaults]<~ModelDefaults>
+        Returns -> typing.Mapping[str, ~ModelDefaults]
         '''
 
         # map input types to rpc msg
@@ -4207,8 +4207,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ModelInfoResults)
     async def ModelInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ModelInfoResult]<~ModelInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ModelInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4228,8 +4228,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ModelStatusResults)
     async def ModelStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ModelStatus]<~ModelStatus>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ModelStatus]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4249,8 +4249,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ModifyModelAccess(self, changes=None):
         '''
-        changes : typing.Sequence<+T_co>[~ModifyModelAccess]<~ModifyModelAccess>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        changes : typing.Sequence[~ModifyModelAccess]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if changes is not None and not isinstance(changes, (bytes, str, list)):
             raise Exception("Expected changes to be a Sequence, received: {}".format(type(changes)))
@@ -4270,8 +4270,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetModelDefaults(self, config=None):
         '''
-        config : typing.Sequence<+T_co>[~ModelDefaultValues]<~ModelDefaultValues>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        config : typing.Sequence[~ModelDefaultValues]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if config is not None and not isinstance(config, (bytes, str, list)):
             raise Exception("Expected config to be a Sequence, received: {}".format(type(config)))
@@ -4291,8 +4291,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UnsetModelDefaults(self, keys=None):
         '''
-        keys : typing.Sequence<+T_co>[~ModelUnsetKeys]<~ModelUnsetKeys>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        keys : typing.Sequence[~ModelUnsetKeys]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if keys is not None and not isinstance(keys, (bytes, str, list)):
             raise Exception("Expected keys to be a Sequence, received: {}".format(type(keys)))
@@ -4385,8 +4385,8 @@ class SpacesFacade(Type):
     @ReturnMapping(ErrorResults)
     async def CreateSpaces(self, spaces=None):
         '''
-        spaces : typing.Sequence<+T_co>[~CreateSpaceParams]<~CreateSpaceParams>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        spaces : typing.Sequence[~CreateSpaceParams]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if spaces is not None and not isinstance(spaces, (bytes, str, list)):
             raise Exception("Expected spaces to be a Sequence, received: {}".format(type(spaces)))
@@ -4407,7 +4407,7 @@ class SpacesFacade(Type):
     async def ListSpaces(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~Space]<~Space>
+        Returns -> typing.Sequence[~Space]
         '''
 
         # map input types to rpc msg
@@ -5250,7 +5250,7 @@ class UniterFacade(Type):
     async def APIAddresses(self):
         '''
 
-        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence<+T_co>[str]]
+        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence[str]]
         '''
 
         # map input types to rpc msg
@@ -5269,7 +5269,7 @@ class UniterFacade(Type):
     async def APIHostPorts(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~HostPort]<~HostPort>
+        Returns -> typing.Sequence[~HostPort]
         '''
 
         # map input types to rpc msg
@@ -5287,8 +5287,8 @@ class UniterFacade(Type):
     @ReturnMapping(ActionResults)
     async def Actions(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ActionResult]<~ActionResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ActionResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5308,8 +5308,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def AddMetricBatches(self, batches=None):
         '''
-        batches : typing.Sequence<+T_co>[~MetricBatchParam]<~MetricBatchParam>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        batches : typing.Sequence[~MetricBatchParam]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if batches is not None and not isinstance(batches, (bytes, str, list)):
             raise Exception("Expected batches to be a Sequence, received: {}".format(type(batches)))
@@ -5329,8 +5329,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def AddUnitStorage(self, storages=None):
         '''
-        storages : typing.Sequence<+T_co>[~StorageAddParams]<~StorageAddParams>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        storages : typing.Sequence[~StorageAddParams]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if storages is not None and not isinstance(storages, (bytes, str, list)):
             raise Exception("Expected storages to be a Sequence, received: {}".format(type(storages)))
@@ -5350,8 +5350,8 @@ class UniterFacade(Type):
     @ReturnMapping(MachinePortsResults)
     async def AllMachinePorts(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MachinePortsResult]<~MachinePortsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MachinePortsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5371,8 +5371,8 @@ class UniterFacade(Type):
     @ReturnMapping(ApplicationStatusResults)
     async def ApplicationStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ApplicationStatusResult]<~ApplicationStatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ApplicationStatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5392,8 +5392,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringResults)
     async def AssignedMachine(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5413,8 +5413,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringResults)
     async def AvailabilityZone(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5434,8 +5434,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def BeginActions(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5456,7 +5456,7 @@ class UniterFacade(Type):
     async def CACert(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[int]
+        Returns -> typing.Sequence[int]
         '''
 
         # map input types to rpc msg
@@ -5474,8 +5474,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringResults)
     async def CharmArchiveSha256(self, urls=None):
         '''
-        urls : typing.Sequence<+T_co>[~CharmURL]<~CharmURL>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        urls : typing.Sequence[~CharmURL]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if urls is not None and not isinstance(urls, (bytes, str, list)):
             raise Exception("Expected urls to be a Sequence, received: {}".format(type(urls)))
@@ -5495,8 +5495,8 @@ class UniterFacade(Type):
     @ReturnMapping(IntResults)
     async def CharmModifiedVersion(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~IntResult]<~IntResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~IntResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5516,8 +5516,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringBoolResults)
     async def CharmURL(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringBoolResult]<~StringBoolResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringBoolResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5537,8 +5537,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ClearResolved(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5558,8 +5558,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ClosePorts(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityPortRange]<~EntityPortRange>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityPortRange]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5579,8 +5579,8 @@ class UniterFacade(Type):
     @ReturnMapping(ConfigSettingsResults)
     async def ConfigSettings(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ConfigSettingsResult]<~ConfigSettingsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ConfigSettingsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5619,8 +5619,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Destroy(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5640,8 +5640,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def DestroyAllSubordinates(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5661,8 +5661,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def DestroyUnitStorageAttachments(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5682,8 +5682,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def EnsureDead(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5703,8 +5703,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def EnterScope(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnit]<~RelationUnit>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        relation_units : typing.Sequence[~RelationUnit]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -5724,8 +5724,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def FinishActions(self, results=None):
         '''
-        results : typing.Sequence<+T_co>[~ActionExecutionResult]<~ActionExecutionResult>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        results : typing.Sequence[~ActionExecutionResult]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if results is not None and not isinstance(results, (bytes, str, list)):
             raise Exception("Expected results to be a Sequence, received: {}".format(type(results)))
@@ -5745,8 +5745,8 @@ class UniterFacade(Type):
     @ReturnMapping(MeterStatusResults)
     async def GetMeterStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MeterStatusResult]<~MeterStatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MeterStatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5766,8 +5766,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringBoolResults)
     async def GetPrincipal(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringBoolResult]<~StringBoolResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringBoolResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5787,8 +5787,8 @@ class UniterFacade(Type):
     @ReturnMapping(BoolResults)
     async def HasSubordinates(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~BoolResult]<~BoolResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~BoolResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5808,8 +5808,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringsResults)
     async def JoinedRelations(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsResult]<~StringsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5829,8 +5829,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def LeaveScope(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnit]<~RelationUnit>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        relation_units : typing.Sequence[~RelationUnit]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -5850,8 +5850,8 @@ class UniterFacade(Type):
     @ReturnMapping(LifeResults)
     async def Life(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5871,8 +5871,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Merge(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~MergeLeadershipSettingsParam]<~MergeLeadershipSettingsParam>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        params : typing.Sequence[~MergeLeadershipSettingsParam]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -5893,7 +5893,7 @@ class UniterFacade(Type):
     async def ModelConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -5930,9 +5930,9 @@ class UniterFacade(Type):
     @ReturnMapping(NetworkInfoResults)
     async def NetworkInfo(self, bindings=None, unit=None):
         '''
-        bindings : typing.Sequence<+T_co>[str]
+        bindings : typing.Sequence[str]
         unit : str
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~NetworkInfoResult]<~NetworkInfoResult>
+        Returns -> typing.Mapping[str, ~NetworkInfoResult]
         '''
         if bindings is not None and not isinstance(bindings, (bytes, str, list)):
             raise Exception("Expected bindings to be a Sequence, received: {}".format(type(bindings)))
@@ -5956,8 +5956,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def OpenPorts(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityPortRange]<~EntityPortRange>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityPortRange]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5977,8 +5977,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringResults)
     async def PrivateAddress(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6017,8 +6017,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringResults)
     async def PublicAddress(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6038,8 +6038,8 @@ class UniterFacade(Type):
     @ReturnMapping(GetLeadershipSettingsBulkResults)
     async def Read(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~GetLeadershipSettingsResult]<~GetLeadershipSettingsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~GetLeadershipSettingsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6059,8 +6059,8 @@ class UniterFacade(Type):
     @ReturnMapping(SettingsResults)
     async def ReadRemoteSettings(self, relation_unit_pairs=None):
         '''
-        relation_unit_pairs : typing.Sequence<+T_co>[~RelationUnitPair]<~RelationUnitPair>
-        Returns -> typing.Sequence<+T_co>[~SettingsResult]<~SettingsResult>
+        relation_unit_pairs : typing.Sequence[~RelationUnitPair]
+        Returns -> typing.Sequence[~SettingsResult]
         '''
         if relation_unit_pairs is not None and not isinstance(relation_unit_pairs, (bytes, str, list)):
             raise Exception("Expected relation_unit_pairs to be a Sequence, received: {}".format(type(relation_unit_pairs)))
@@ -6080,8 +6080,8 @@ class UniterFacade(Type):
     @ReturnMapping(SettingsResults)
     async def ReadSettings(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnit]<~RelationUnit>
-        Returns -> typing.Sequence<+T_co>[~SettingsResult]<~SettingsResult>
+        relation_units : typing.Sequence[~RelationUnit]
+        Returns -> typing.Sequence[~SettingsResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -6101,8 +6101,8 @@ class UniterFacade(Type):
     @ReturnMapping(RelationResults)
     async def Relation(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnit]<~RelationUnit>
-        Returns -> typing.Sequence<+T_co>[~RelationResult]<~RelationResult>
+        relation_units : typing.Sequence[~RelationUnit]
+        Returns -> typing.Sequence[~RelationResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -6122,8 +6122,8 @@ class UniterFacade(Type):
     @ReturnMapping(RelationResults)
     async def RelationById(self, relation_ids=None):
         '''
-        relation_ids : typing.Sequence<+T_co>[int]
-        Returns -> typing.Sequence<+T_co>[~RelationResult]<~RelationResult>
+        relation_ids : typing.Sequence[int]
+        Returns -> typing.Sequence[~RelationResult]
         '''
         if relation_ids is not None and not isinstance(relation_ids, (bytes, str, list)):
             raise Exception("Expected relation_ids to be a Sequence, received: {}".format(type(relation_ids)))
@@ -6143,8 +6143,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RemoveStorageAttachments(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~StorageAttachmentId]<~StorageAttachmentId>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        ids : typing.Sequence[~StorageAttachmentId]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -6164,8 +6164,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RequestReboot(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6185,8 +6185,8 @@ class UniterFacade(Type):
     @ReturnMapping(ResolvedModeResults)
     async def Resolved(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ResolvedModeResult]<~ResolvedModeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ResolvedModeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6225,8 +6225,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetAgentStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6246,8 +6246,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetApplicationStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6267,8 +6267,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetCharmURL(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityCharmURL]<~EntityCharmURL>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityCharmURL]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6288,8 +6288,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6309,8 +6309,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetUnitStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6330,8 +6330,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetWorkloadVersion(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityWorkloadVersion]<~EntityWorkloadVersion>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityWorkloadVersion]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6351,8 +6351,8 @@ class UniterFacade(Type):
     @ReturnMapping(LifeResults)
     async def StorageAttachmentLife(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~StorageAttachmentId]<~StorageAttachmentId>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        ids : typing.Sequence[~StorageAttachmentId]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -6372,8 +6372,8 @@ class UniterFacade(Type):
     @ReturnMapping(StorageAttachmentResults)
     async def StorageAttachments(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~StorageAttachmentId]<~StorageAttachmentId>
-        Returns -> typing.Sequence<+T_co>[~StorageAttachmentResult]<~StorageAttachmentResult>
+        ids : typing.Sequence[~StorageAttachmentId]
+        Returns -> typing.Sequence[~StorageAttachmentResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -6393,8 +6393,8 @@ class UniterFacade(Type):
     @ReturnMapping(StatusResults)
     async def UnitStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StatusResult]<~StatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6414,8 +6414,8 @@ class UniterFacade(Type):
     @ReturnMapping(StorageAttachmentIdsResults)
     async def UnitStorageAttachments(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StorageAttachmentIdsResult]<~StorageAttachmentIdsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StorageAttachmentIdsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6435,8 +6435,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UpdateSettings(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnitSettings]<~RelationUnitSettings>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        relation_units : typing.Sequence[~RelationUnitSettings]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -6456,8 +6456,8 @@ class UniterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def Watch(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6496,8 +6496,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchActionNotifications(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6517,8 +6517,8 @@ class UniterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchConfigSettings(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6557,8 +6557,8 @@ class UniterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchLeadershipSettings(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6578,8 +6578,8 @@ class UniterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchMeterStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6599,8 +6599,8 @@ class UniterFacade(Type):
     @ReturnMapping(RelationUnitsWatchResults)
     async def WatchRelationUnits(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnit]<~RelationUnit>
-        Returns -> typing.Sequence<+T_co>[~RelationUnitsWatchResult]<~RelationUnitsWatchResult>
+        relation_units : typing.Sequence[~RelationUnit]
+        Returns -> typing.Sequence[~RelationUnitsWatchResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -6620,8 +6620,8 @@ class UniterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchStorageAttachments(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~StorageAttachmentId]<~StorageAttachmentId>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        ids : typing.Sequence[~StorageAttachmentId]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -6641,8 +6641,8 @@ class UniterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchUnitAddresses(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6662,8 +6662,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchUnitRelations(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6683,8 +6683,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchUnitStorageAttachments(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -6704,8 +6704,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringResults)
     async def WorkloadVersion(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))

--- a/juju/client/_client6.py
+++ b/juju/client/_client6.py
@@ -407,8 +407,8 @@ class CloudFacade(Type):
     @ReturnMapping(ErrorResults)
     async def AddCredentials(self, credentials=None):
         '''
-        credentials : typing.Sequence<+T_co>[~TaggedCredential]<~TaggedCredential>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        credentials : typing.Sequence[~TaggedCredential]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if credentials is not None and not isinstance(credentials, (bytes, str, list)):
             raise Exception("Expected credentials to be a Sequence, received: {}".format(type(credentials)))
@@ -428,8 +428,8 @@ class CloudFacade(Type):
     @ReturnMapping(UpdateCredentialResults)
     async def CheckCredentialsModels(self, credentials=None):
         '''
-        credentials : typing.Sequence<+T_co>[~TaggedCredential]<~TaggedCredential>
-        Returns -> typing.Sequence<+T_co>[~UpdateCredentialResult]<~UpdateCredentialResult>
+        credentials : typing.Sequence[~TaggedCredential]
+        Returns -> typing.Sequence[~UpdateCredentialResult]
         '''
         if credentials is not None and not isinstance(credentials, (bytes, str, list)):
             raise Exception("Expected credentials to be a Sequence, received: {}".format(type(credentials)))
@@ -449,8 +449,8 @@ class CloudFacade(Type):
     @ReturnMapping(CloudResults)
     async def Cloud(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~CloudResult]<~CloudResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~CloudResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -470,8 +470,8 @@ class CloudFacade(Type):
     @ReturnMapping(CloudInfoResults)
     async def CloudInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~CloudInfoResult]<~CloudInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~CloudInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -492,7 +492,7 @@ class CloudFacade(Type):
     async def Clouds(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~Cloud]<~Cloud>
+        Returns -> typing.Mapping[str, ~Cloud]
         '''
 
         # map input types to rpc msg
@@ -510,8 +510,8 @@ class CloudFacade(Type):
     @ReturnMapping(CloudCredentialResults)
     async def Credential(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~CloudCredentialResult]<~CloudCredentialResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~CloudCredentialResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -531,9 +531,9 @@ class CloudFacade(Type):
     @ReturnMapping(CredentialContentResults)
     async def CredentialContents(self, credentials=None, include_secrets=None):
         '''
-        credentials : typing.Sequence<+T_co>[~CloudCredentialArg]<~CloudCredentialArg>
+        credentials : typing.Sequence[~CloudCredentialArg]
         include_secrets : bool
-        Returns -> typing.Sequence<+T_co>[~CredentialContentResult]<~CredentialContentResult>
+        Returns -> typing.Sequence[~CredentialContentResult]
         '''
         if credentials is not None and not isinstance(credentials, (bytes, str, list)):
             raise Exception("Expected credentials to be a Sequence, received: {}".format(type(credentials)))
@@ -557,8 +557,8 @@ class CloudFacade(Type):
     @ReturnMapping(InstanceTypesResults)
     async def InstanceTypes(self, constraints=None):
         '''
-        constraints : typing.Sequence<+T_co>[~CloudInstanceTypesConstraint]<~CloudInstanceTypesConstraint>
-        Returns -> typing.Sequence<+T_co>[~InstanceTypesResult]<~InstanceTypesResult>
+        constraints : typing.Sequence[~CloudInstanceTypesConstraint]
+        Returns -> typing.Sequence[~InstanceTypesResult]
         '''
         if constraints is not None and not isinstance(constraints, (bytes, str, list)):
             raise Exception("Expected constraints to be a Sequence, received: {}".format(type(constraints)))
@@ -580,7 +580,7 @@ class CloudFacade(Type):
         '''
         all_ : bool
         user_tag : str
-        Returns -> typing.Sequence<+T_co>[~ListCloudInfoResult]<~ListCloudInfoResult>
+        Returns -> typing.Sequence[~ListCloudInfoResult]
         '''
         if all_ is not None and not isinstance(all_, bool):
             raise Exception("Expected all_ to be a bool, received: {}".format(type(all_)))
@@ -604,8 +604,8 @@ class CloudFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ModifyCloudAccess(self, changes=None):
         '''
-        changes : typing.Sequence<+T_co>[~ModifyCloudAccess]<~ModifyCloudAccess>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        changes : typing.Sequence[~ModifyCloudAccess]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if changes is not None and not isinstance(changes, (bytes, str, list)):
             raise Exception("Expected changes to be a Sequence, received: {}".format(type(changes)))
@@ -625,8 +625,8 @@ class CloudFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RemoveClouds(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -646,8 +646,8 @@ class CloudFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RevokeCredentialsCheckModels(self, credentials=None):
         '''
-        credentials : typing.Sequence<+T_co>[~RevokeCredentialArg]<~RevokeCredentialArg>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        credentials : typing.Sequence[~RevokeCredentialArg]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if credentials is not None and not isinstance(credentials, (bytes, str, list)):
             raise Exception("Expected credentials to be a Sequence, received: {}".format(type(credentials)))
@@ -667,8 +667,8 @@ class CloudFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UpdateCloud(self, clouds=None):
         '''
-        clouds : typing.Sequence<+T_co>[~AddCloudArgs]<~AddCloudArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        clouds : typing.Sequence[~AddCloudArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if clouds is not None and not isinstance(clouds, (bytes, str, list)):
             raise Exception("Expected clouds to be a Sequence, received: {}".format(type(clouds)))
@@ -688,9 +688,9 @@ class CloudFacade(Type):
     @ReturnMapping(UpdateCredentialResults)
     async def UpdateCredentialsCheckModels(self, credentials=None, force=None):
         '''
-        credentials : typing.Sequence<+T_co>[~TaggedCredential]<~TaggedCredential>
+        credentials : typing.Sequence[~TaggedCredential]
         force : bool
-        Returns -> typing.Sequence<+T_co>[~UpdateCredentialResult]<~UpdateCredentialResult>
+        Returns -> typing.Sequence[~UpdateCredentialResult]
         '''
         if credentials is not None and not isinstance(credentials, (bytes, str, list)):
             raise Exception("Expected credentials to be a Sequence, received: {}".format(type(credentials)))
@@ -714,8 +714,8 @@ class CloudFacade(Type):
     @ReturnMapping(StringsResults)
     async def UserCredentials(self, user_clouds=None):
         '''
-        user_clouds : typing.Sequence<+T_co>[~UserCloud]<~UserCloud>
-        Returns -> typing.Sequence<+T_co>[~StringsResult]<~StringsResult>
+        user_clouds : typing.Sequence[~UserCloud]
+        Returns -> typing.Sequence[~StringsResult]
         '''
         if user_clouds is not None and not isinstance(user_clouds, (bytes, str, list)):
             raise Exception("Expected user_clouds to be a Sequence, received: {}".format(type(user_clouds)))
@@ -988,8 +988,8 @@ class MachineManagerFacade(Type):
     @ReturnMapping(AddMachinesResults)
     async def AddMachines(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~AddMachineParams]<~AddMachineParams>
-        Returns -> typing.Sequence<+T_co>[~AddMachinesResult]<~AddMachinesResult>
+        params : typing.Sequence[~AddMachineParams]
+        Returns -> typing.Sequence[~AddMachinesResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -1009,8 +1009,8 @@ class MachineManagerFacade(Type):
     @ReturnMapping(DestroyMachineResults)
     async def DestroyMachine(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~DestroyMachineResult]<~DestroyMachineResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~DestroyMachineResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1032,9 +1032,9 @@ class MachineManagerFacade(Type):
         '''
         force : bool
         keep : bool
-        machine_tags : typing.Sequence<+T_co>[str]
+        machine_tags : typing.Sequence[str]
         max_wait : int
-        Returns -> typing.Sequence<+T_co>[~DestroyMachineResult]<~DestroyMachineResult>
+        Returns -> typing.Sequence[~DestroyMachineResult]
         '''
         if force is not None and not isinstance(force, bool):
             raise Exception("Expected force to be a bool, received: {}".format(type(force)))
@@ -1066,8 +1066,8 @@ class MachineManagerFacade(Type):
     @ReturnMapping(DestroyMachineResults)
     async def ForceDestroyMachine(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~DestroyMachineResult]<~DestroyMachineResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~DestroyMachineResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1087,8 +1087,8 @@ class MachineManagerFacade(Type):
     @ReturnMapping(StringsResults)
     async def GetUpgradeSeriesMessages(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~UpgradeSeriesNotificationParam]<~UpgradeSeriesNotificationParam>
-        Returns -> typing.Sequence<+T_co>[~StringsResult]<~StringsResult>
+        params : typing.Sequence[~UpgradeSeriesNotificationParam]
+        Returns -> typing.Sequence[~StringsResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -1108,8 +1108,8 @@ class MachineManagerFacade(Type):
     @ReturnMapping(InstanceTypesResults)
     async def InstanceTypes(self, constraints=None):
         '''
-        constraints : typing.Sequence<+T_co>[~ModelInstanceTypesConstraint]<~ModelInstanceTypesConstraint>
-        Returns -> typing.Sequence<+T_co>[~InstanceTypesResult]<~InstanceTypesResult>
+        constraints : typing.Sequence[~ModelInstanceTypesConstraint]
+        Returns -> typing.Sequence[~InstanceTypesResult]
         '''
         if constraints is not None and not isinstance(constraints, (bytes, str, list)):
             raise Exception("Expected constraints to be a Sequence, received: {}".format(type(constraints)))
@@ -1191,8 +1191,8 @@ class MachineManagerFacade(Type):
     @ReturnMapping(UpgradeSeriesUnitsResults)
     async def UpgradeSeriesValidate(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~UpdateSeriesArg]<~UpdateSeriesArg>
-        Returns -> typing.Sequence<+T_co>[~UpgradeSeriesUnitsResult]<~UpgradeSeriesUnitsResult>
+        args : typing.Sequence[~UpdateSeriesArg]
+        Returns -> typing.Sequence[~UpgradeSeriesUnitsResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -1212,8 +1212,8 @@ class MachineManagerFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchUpgradeSeriesNotifications(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1601,8 +1601,8 @@ class StorageFacade(Type):
     @ReturnMapping(AddStorageResults)
     async def AddToUnit(self, storages=None):
         '''
-        storages : typing.Sequence<+T_co>[~StorageAddParams]<~StorageAddParams>
-        Returns -> typing.Sequence<+T_co>[~AddStorageResult]<~AddStorageResult>
+        storages : typing.Sequence[~StorageAddParams]
+        Returns -> typing.Sequence[~AddStorageResult]
         '''
         if storages is not None and not isinstance(storages, (bytes, str, list)):
             raise Exception("Expected storages to be a Sequence, received: {}".format(type(storages)))
@@ -1622,8 +1622,8 @@ class StorageFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Attach(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~StorageAttachmentId]<~StorageAttachmentId>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        ids : typing.Sequence[~StorageAttachmentId]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -1643,8 +1643,8 @@ class StorageFacade(Type):
     @ReturnMapping(ErrorResults)
     async def CreatePool(self, pools=None):
         '''
-        pools : typing.Sequence<+T_co>[~StoragePool]<~StoragePool>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        pools : typing.Sequence[~StoragePool]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if pools is not None and not isinstance(pools, (bytes, str, list)):
             raise Exception("Expected pools to be a Sequence, received: {}".format(type(pools)))
@@ -1667,7 +1667,7 @@ class StorageFacade(Type):
         force : bool
         ids : StorageAttachmentIds
         max_wait : int
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if force is not None and not isinstance(force, bool):
             raise Exception("Expected force to be a bool, received: {}".format(type(force)))
@@ -1695,8 +1695,8 @@ class StorageFacade(Type):
     @ReturnMapping(ImportStorageResults)
     async def Import(self, storage=None):
         '''
-        storage : typing.Sequence<+T_co>[~ImportStorageParams]<~ImportStorageParams>
-        Returns -> typing.Sequence<+T_co>[~ImportStorageResult]<~ImportStorageResult>
+        storage : typing.Sequence[~ImportStorageParams]
+        Returns -> typing.Sequence[~ImportStorageResult]
         '''
         if storage is not None and not isinstance(storage, (bytes, str, list)):
             raise Exception("Expected storage to be a Sequence, received: {}".format(type(storage)))
@@ -1716,8 +1716,8 @@ class StorageFacade(Type):
     @ReturnMapping(FilesystemDetailsListResults)
     async def ListFilesystems(self, filters=None):
         '''
-        filters : typing.Sequence<+T_co>[~FilesystemFilter]<~FilesystemFilter>
-        Returns -> typing.Sequence<+T_co>[~FilesystemDetailsListResult]<~FilesystemDetailsListResult>
+        filters : typing.Sequence[~FilesystemFilter]
+        Returns -> typing.Sequence[~FilesystemDetailsListResult]
         '''
         if filters is not None and not isinstance(filters, (bytes, str, list)):
             raise Exception("Expected filters to be a Sequence, received: {}".format(type(filters)))
@@ -1737,8 +1737,8 @@ class StorageFacade(Type):
     @ReturnMapping(StoragePoolsResults)
     async def ListPools(self, filters=None):
         '''
-        filters : typing.Sequence<+T_co>[~StoragePoolFilter]<~StoragePoolFilter>
-        Returns -> typing.Sequence<+T_co>[~StoragePoolsResult]<~StoragePoolsResult>
+        filters : typing.Sequence[~StoragePoolFilter]
+        Returns -> typing.Sequence[~StoragePoolsResult]
         '''
         if filters is not None and not isinstance(filters, (bytes, str, list)):
             raise Exception("Expected filters to be a Sequence, received: {}".format(type(filters)))
@@ -1758,8 +1758,8 @@ class StorageFacade(Type):
     @ReturnMapping(StorageDetailsListResults)
     async def ListStorageDetails(self, filters=None):
         '''
-        filters : typing.Sequence<+T_co>[~StorageFilter]<~StorageFilter>
-        Returns -> typing.Sequence<+T_co>[~StorageDetailsListResult]<~StorageDetailsListResult>
+        filters : typing.Sequence[~StorageFilter]
+        Returns -> typing.Sequence[~StorageDetailsListResult]
         '''
         if filters is not None and not isinstance(filters, (bytes, str, list)):
             raise Exception("Expected filters to be a Sequence, received: {}".format(type(filters)))
@@ -1779,8 +1779,8 @@ class StorageFacade(Type):
     @ReturnMapping(VolumeDetailsListResults)
     async def ListVolumes(self, filters=None):
         '''
-        filters : typing.Sequence<+T_co>[~VolumeFilter]<~VolumeFilter>
-        Returns -> typing.Sequence<+T_co>[~VolumeDetailsListResult]<~VolumeDetailsListResult>
+        filters : typing.Sequence[~VolumeFilter]
+        Returns -> typing.Sequence[~VolumeDetailsListResult]
         '''
         if filters is not None and not isinstance(filters, (bytes, str, list)):
             raise Exception("Expected filters to be a Sequence, received: {}".format(type(filters)))
@@ -1800,8 +1800,8 @@ class StorageFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Remove(self, storage=None):
         '''
-        storage : typing.Sequence<+T_co>[~RemoveStorageInstance]<~RemoveStorageInstance>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        storage : typing.Sequence[~RemoveStorageInstance]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if storage is not None and not isinstance(storage, (bytes, str, list)):
             raise Exception("Expected storage to be a Sequence, received: {}".format(type(storage)))
@@ -1821,8 +1821,8 @@ class StorageFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RemovePool(self, pools=None):
         '''
-        pools : typing.Sequence<+T_co>[~StoragePoolDeleteArg]<~StoragePoolDeleteArg>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        pools : typing.Sequence[~StoragePoolDeleteArg]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if pools is not None and not isinstance(pools, (bytes, str, list)):
             raise Exception("Expected pools to be a Sequence, received: {}".format(type(pools)))
@@ -1842,8 +1842,8 @@ class StorageFacade(Type):
     @ReturnMapping(StorageDetailsResults)
     async def StorageDetails(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StorageDetailsResult]<~StorageDetailsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StorageDetailsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1863,8 +1863,8 @@ class StorageFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UpdatePool(self, pools=None):
         '''
-        pools : typing.Sequence<+T_co>[~StoragePool]<~StoragePool>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        pools : typing.Sequence[~StoragePool]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if pools is not None and not isinstance(pools, (bytes, str, list)):
             raise Exception("Expected pools to be a Sequence, received: {}".format(type(pools)))

--- a/juju/client/_client7.py
+++ b/juju/client/_client7.py
@@ -354,7 +354,7 @@ class ControllerFacade(Type):
     async def AllModels(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~UserModel]<~UserModel>
+        Returns -> typing.Sequence[~UserModel]
         '''
 
         # map input types to rpc msg
@@ -372,8 +372,8 @@ class ControllerFacade(Type):
     @ReturnMapping(CloudSpecResults)
     async def CloudSpec(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~CloudSpecResult]<~CloudSpecResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~CloudSpecResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -393,7 +393,7 @@ class ControllerFacade(Type):
     @ReturnMapping(None)
     async def ConfigSet(self, config=None):
         '''
-        config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        config : typing.Mapping[str, typing.Any]
         Returns -> None
         '''
         if config is not None and not isinstance(config, dict):
@@ -414,8 +414,8 @@ class ControllerFacade(Type):
     @ReturnMapping(ControllerAPIInfoResults)
     async def ControllerAPIInfoForModels(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ControllerAPIInfoResult]<~ControllerAPIInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ControllerAPIInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -436,7 +436,7 @@ class ControllerFacade(Type):
     async def ControllerConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -499,8 +499,8 @@ class ControllerFacade(Type):
     @ReturnMapping(UserAccessResults)
     async def GetControllerAccess(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~UserAccessResult]<~UserAccessResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~UserAccessResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -521,7 +521,7 @@ class ControllerFacade(Type):
     async def HostedModelConfigs(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~HostedModelConfig]<~HostedModelConfig>
+        Returns -> typing.Sequence[~HostedModelConfig]
         '''
 
         # map input types to rpc msg
@@ -558,8 +558,8 @@ class ControllerFacade(Type):
     @ReturnMapping(InitiateMigrationResults)
     async def InitiateMigration(self, specs=None):
         '''
-        specs : typing.Sequence<+T_co>[~MigrationSpec]<~MigrationSpec>
-        Returns -> typing.Sequence<+T_co>[~InitiateMigrationResult]<~InitiateMigrationResult>
+        specs : typing.Sequence[~MigrationSpec]
+        Returns -> typing.Sequence[~InitiateMigrationResult]
         '''
         if specs is not None and not isinstance(specs, (bytes, str, list)):
             raise Exception("Expected specs to be a Sequence, received: {}".format(type(specs)))
@@ -580,7 +580,7 @@ class ControllerFacade(Type):
     async def ListBlockedModels(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~ModelBlockInfo]<~ModelBlockInfo>
+        Returns -> typing.Sequence[~ModelBlockInfo]
         '''
 
         # map input types to rpc msg
@@ -599,7 +599,7 @@ class ControllerFacade(Type):
     async def ModelConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~ConfigValue]<~ConfigValue>
+        Returns -> typing.Mapping[str, ~ConfigValue]
         '''
 
         # map input types to rpc msg
@@ -617,8 +617,8 @@ class ControllerFacade(Type):
     @ReturnMapping(ModelStatusResults)
     async def ModelStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ModelStatus]<~ModelStatus>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ModelStatus]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -638,8 +638,8 @@ class ControllerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ModifyControllerAccess(self, changes=None):
         '''
-        changes : typing.Sequence<+T_co>[~ModifyControllerAccess]<~ModifyControllerAccess>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        changes : typing.Sequence[~ModifyControllerAccess]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if changes is not None and not isinstance(changes, (bytes, str, list)):
             raise Exception("Expected changes to be a Sequence, received: {}".format(type(changes)))
@@ -718,8 +718,8 @@ class ControllerFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchCloudSpecsChanges(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1163,8 +1163,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ChangeModelCredential(self, model_credentials=None):
         '''
-        model_credentials : typing.Sequence<+T_co>[~ChangeModelCredentialParams]<~ChangeModelCredentialParams>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        model_credentials : typing.Sequence[~ChangeModelCredentialParams]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if model_credentials is not None and not isinstance(model_credentials, (bytes, str, list)):
             raise Exception("Expected model_credentials to be a Sequence, received: {}".format(type(model_credentials)))
@@ -1185,12 +1185,12 @@ class ModelManagerFacade(Type):
     async def CreateModel(self, cloud_tag=None, config=None, credential=None, name=None, owner_tag=None, region=None):
         '''
         cloud_tag : str
-        config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        config : typing.Mapping[str, typing.Any]
         credential : str
         name : str
         owner_tag : str
         region : str
-        Returns -> typing.Union[_ForwardRef('Number'), bool, _ForwardRef('ModelMigrationStatus'), _ForwardRef('ModelSLAInfo'), _ForwardRef('EntityStatus'), typing.Sequence<+T_co>[~ModelUserInfo]<~ModelUserInfo>]
+        Returns -> typing.Union[_ForwardRef('Number'), str, bool, typing.Sequence[~ModelMachineInfo], _ForwardRef('ModelMigrationStatus'), _ForwardRef('ModelSLAInfo'), _ForwardRef('EntityStatus'), typing.Sequence[~ModelUserInfo]]
         '''
         if cloud_tag is not None and not isinstance(cloud_tag, (bytes, str)):
             raise Exception("Expected cloud_tag to be a str, received: {}".format(type(cloud_tag)))
@@ -1230,8 +1230,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def DestroyModels(self, models=None):
         '''
-        models : typing.Sequence<+T_co>[~DestroyModelParams]<~DestroyModelParams>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        models : typing.Sequence[~DestroyModelParams]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if models is not None and not isinstance(models, (bytes, str, list)):
             raise Exception("Expected models to be a Sequence, received: {}".format(type(models)))
@@ -1251,9 +1251,9 @@ class ModelManagerFacade(Type):
     @ReturnMapping(StringResults)
     async def DumpModels(self, entities=None, simplified=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
+        entities : typing.Sequence[~Entity]
         simplified : bool
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1277,8 +1277,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(MapResults)
     async def DumpModelsDB(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MapResult]<~MapResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MapResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1300,7 +1300,7 @@ class ModelManagerFacade(Type):
         '''
         all_ : bool
         user_tag : str
-        Returns -> typing.Sequence<+T_co>[~ModelSummaryResult]<~ModelSummaryResult>
+        Returns -> typing.Sequence[~ModelSummaryResult]
         '''
         if all_ is not None and not isinstance(all_, bool):
             raise Exception("Expected all_ to be a bool, received: {}".format(type(all_)))
@@ -1325,7 +1325,7 @@ class ModelManagerFacade(Type):
     async def ListModels(self, tag=None):
         '''
         tag : str
-        Returns -> typing.Sequence<+T_co>[~UserModel]<~UserModel>
+        Returns -> typing.Sequence[~UserModel]
         '''
         if tag is not None and not isinstance(tag, (bytes, str)):
             raise Exception("Expected tag to be a str, received: {}".format(type(tag)))
@@ -1345,8 +1345,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ModelDefaultsResults)
     async def ModelDefaultsForClouds(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ModelDefaultsResult]<~ModelDefaultsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ModelDefaultsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1366,8 +1366,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ModelInfoResults)
     async def ModelInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ModelInfoResult]<~ModelInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ModelInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1387,8 +1387,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ModelStatusResults)
     async def ModelStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ModelStatus]<~ModelStatus>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ModelStatus]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1408,8 +1408,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ModifyModelAccess(self, changes=None):
         '''
-        changes : typing.Sequence<+T_co>[~ModifyModelAccess]<~ModifyModelAccess>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        changes : typing.Sequence[~ModifyModelAccess]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if changes is not None and not isinstance(changes, (bytes, str, list)):
             raise Exception("Expected changes to be a Sequence, received: {}".format(type(changes)))
@@ -1429,8 +1429,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetModelDefaults(self, config=None):
         '''
-        config : typing.Sequence<+T_co>[~ModelDefaultValues]<~ModelDefaultValues>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        config : typing.Sequence[~ModelDefaultValues]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if config is not None and not isinstance(config, (bytes, str, list)):
             raise Exception("Expected config to be a Sequence, received: {}".format(type(config)))
@@ -1450,8 +1450,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UnsetModelDefaults(self, keys=None):
         '''
-        keys : typing.Sequence<+T_co>[~ModelUnsetKeys]<~ModelUnsetKeys>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        keys : typing.Sequence[~ModelUnsetKeys]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if keys is not None and not isinstance(keys, (bytes, str, list)):
             raise Exception("Expected keys to be a Sequence, received: {}".format(type(keys)))
@@ -2270,7 +2270,7 @@ class ProvisionerFacade(Type):
     async def APIAddresses(self):
         '''
 
-        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence<+T_co>[str]]
+        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence[str]]
         '''
 
         # map input types to rpc msg
@@ -2289,7 +2289,7 @@ class ProvisionerFacade(Type):
     async def APIHostPorts(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~HostPort]<~HostPort>
+        Returns -> typing.Sequence[~HostPort]
         '''
 
         # map input types to rpc msg
@@ -2307,8 +2307,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(StringResults)
     async def AvailabilityZone(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2329,7 +2329,7 @@ class ProvisionerFacade(Type):
     async def CACert(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[int]
+        Returns -> typing.Sequence[int]
         '''
 
         # map input types to rpc msg
@@ -2347,8 +2347,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ProfileChangeResults)
     async def CharmProfileChangeInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ProfileChangeResult]<~ProfileChangeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ProfileChangeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2368,8 +2368,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ConstraintsResults)
     async def Constraints(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ConstraintsResult]<~ConstraintsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ConstraintsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2390,7 +2390,7 @@ class ProvisionerFacade(Type):
     async def ContainerConfig(self):
         '''
 
-        Returns -> typing.Union[_ForwardRef('UpdateBehavior'), str, _ForwardRef('Settings'), typing.Mapping<~KT, +VT_co>[str, typing.Any], _ForwardRef('Settings'), _ForwardRef('Settings'), _ForwardRef('Settings'), bool]
+        Returns -> typing.Union[_ForwardRef('UpdateBehavior'), str, _ForwardRef('Settings'), typing.Mapping[str, typing.Any], bool]
         '''
 
         # map input types to rpc msg
@@ -2409,7 +2409,7 @@ class ProvisionerFacade(Type):
     async def ContainerManagerConfig(self, type_=None):
         '''
         type_ : str
-        Returns -> typing.Mapping<~KT, +VT_co>[str, str]
+        Returns -> typing.Mapping[str, str]
         '''
         if type_ is not None and not isinstance(type_, (bytes, str)):
             raise Exception("Expected type_ to be a str, received: {}".format(type(type_)))
@@ -2429,8 +2429,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ControllerAPIInfoResults)
     async def ControllerAPIInfoForModels(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ControllerAPIInfoResult]<~ControllerAPIInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ControllerAPIInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2451,7 +2451,7 @@ class ProvisionerFacade(Type):
     async def ControllerConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -2469,8 +2469,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(DistributionGroupResults)
     async def DistributionGroup(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~DistributionGroupResult]<~DistributionGroupResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~DistributionGroupResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2490,8 +2490,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(StringsResults)
     async def DistributionGroupByMachineId(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsResult]<~StringsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2511,8 +2511,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def EnsureDead(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2538,7 +2538,7 @@ class ProvisionerFacade(Type):
         minor : int
         number : Number
         series : str
-        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence<+T_co>[~Tools]<~Tools>]
+        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence[~Tools]]
         '''
         if agentstream is not None and not isinstance(agentstream, (bytes, str)):
             raise Exception("Expected agentstream to be a str, received: {}".format(type(agentstream)))
@@ -2578,8 +2578,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(MachineNetworkConfigResults)
     async def GetContainerInterfaceInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MachineNetworkConfigResult]<~MachineNetworkConfigResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MachineNetworkConfigResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2599,8 +2599,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ContainerProfileResults)
     async def GetContainerProfileInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ContainerProfileResult]<~ContainerProfileResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ContainerProfileResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2620,8 +2620,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(HostNetworkChangeResults)
     async def HostChangesForContainers(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~HostNetworkChange]<~HostNetworkChange>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~HostNetworkChange]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2641,8 +2641,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(StringResults)
     async def InstanceId(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2662,8 +2662,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(StatusResults)
     async def InstanceStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StatusResult]<~StatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2683,8 +2683,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(BoolResults)
     async def KeepInstance(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~BoolResult]<~BoolResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~BoolResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2704,8 +2704,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(LifeResults)
     async def Life(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2726,7 +2726,7 @@ class ProvisionerFacade(Type):
     async def MachinesWithTransientErrors(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~StatusResult]<~StatusResult>
+        Returns -> typing.Sequence[~StatusResult]
         '''
 
         # map input types to rpc msg
@@ -2744,8 +2744,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def MarkMachinesForRemoval(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2766,7 +2766,7 @@ class ProvisionerFacade(Type):
     async def ModelConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -2803,8 +2803,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(MachineNetworkConfigResults)
     async def PrepareContainerInterfaceInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MachineNetworkConfigResult]<~MachineNetworkConfigResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MachineNetworkConfigResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2824,8 +2824,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ProvisioningInfoResults)
     async def ProvisioningInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ProvisioningInfoResult]<~ProvisioningInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ProvisioningInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2845,8 +2845,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ReleaseContainerAddresses(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2866,8 +2866,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Remove(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2887,8 +2887,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RemoveUpgradeCharmProfileData(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2908,8 +2908,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(StringResults)
     async def Series(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2929,8 +2929,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetCharmProfiles(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~SetProfileArg]<~SetProfileArg>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~SetProfileArg]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -2950,7 +2950,7 @@ class ProvisionerFacade(Type):
     @ReturnMapping(None)
     async def SetHostMachineNetworkConfig(self, config=None, tag=None):
         '''
-        config : typing.Sequence<+T_co>[~NetworkConfig]<~NetworkConfig>
+        config : typing.Sequence[~NetworkConfig]
         tag : str
         Returns -> None
         '''
@@ -2976,8 +2976,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetInstanceInfo(self, machines=None):
         '''
-        machines : typing.Sequence<+T_co>[~InstanceInfo]<~InstanceInfo>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        machines : typing.Sequence[~InstanceInfo]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if machines is not None and not isinstance(machines, (bytes, str, list)):
             raise Exception("Expected machines to be a Sequence, received: {}".format(type(machines)))
@@ -2997,8 +2997,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetInstanceStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3018,7 +3018,7 @@ class ProvisionerFacade(Type):
     @ReturnMapping(None)
     async def SetObservedNetworkConfig(self, config=None, tag=None):
         '''
-        config : typing.Sequence<+T_co>[~NetworkConfig]<~NetworkConfig>
+        config : typing.Sequence[~NetworkConfig]
         tag : str
         Returns -> None
         '''
@@ -3044,8 +3044,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetPasswords(self, changes=None):
         '''
-        changes : typing.Sequence<+T_co>[~EntityPassword]<~EntityPassword>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        changes : typing.Sequence[~EntityPassword]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if changes is not None and not isinstance(changes, (bytes, str, list)):
             raise Exception("Expected changes to be a Sequence, received: {}".format(type(changes)))
@@ -3065,8 +3065,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetProviderNetworkConfig(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3086,8 +3086,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3107,8 +3107,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetSupportedContainers(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~MachineContainers]<~MachineContainers>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        params : typing.Sequence[~MachineContainers]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -3128,8 +3128,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetUpgradeCharmProfileComplete(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~SetProfileUpgradeCompleteArg]<~SetProfileUpgradeCompleteArg>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~SetProfileUpgradeCompleteArg]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -3150,7 +3150,7 @@ class ProvisionerFacade(Type):
     async def StateAddresses(self):
         '''
 
-        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence<+T_co>[str]]
+        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence[str]]
         '''
 
         # map input types to rpc msg
@@ -3168,8 +3168,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(StatusResults)
     async def Status(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StatusResult]<~StatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3189,8 +3189,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ToolsResults)
     async def Tools(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ToolsResult]<~ToolsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ToolsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3210,8 +3210,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UpdateStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3250,8 +3250,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchAllContainers(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~WatchContainer]<~WatchContainer>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        params : typing.Sequence[~WatchContainer]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -3271,8 +3271,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchContainers(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~WatchContainer]<~WatchContainer>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        params : typing.Sequence[~WatchContainer]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -3292,8 +3292,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchContainersCharmProfiles(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~WatchContainer]<~WatchContainer>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        params : typing.Sequence[~WatchContainer]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -3352,7 +3352,7 @@ class ProvisionerFacade(Type):
     async def WatchModelMachines(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[str], _ForwardRef('Error')]
+        Returns -> typing.Union[typing.Sequence[str], _ForwardRef('Error'), str]
         '''
 
         # map input types to rpc msg
@@ -3371,7 +3371,7 @@ class ProvisionerFacade(Type):
     async def WatchModelMachinesCharmProfiles(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[str], _ForwardRef('Error')]
+        Returns -> typing.Union[typing.Sequence[str], _ForwardRef('Error'), str]
         '''
 
         # map input types to rpc msg

--- a/juju/client/_client8.py
+++ b/juju/client/_client8.py
@@ -638,9 +638,9 @@ class ApplicationFacade(Type):
     @ReturnMapping(AddRelationResults)
     async def AddRelation(self, endpoints=None, via_cidrs=None):
         '''
-        endpoints : typing.Sequence<+T_co>[str]
-        via_cidrs : typing.Sequence<+T_co>[str]
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~CharmRelation]<~CharmRelation>
+        endpoints : typing.Sequence[str]
+        via_cidrs : typing.Sequence[str]
+        Returns -> typing.Mapping[str, ~CharmRelation]
         '''
         if endpoints is not None and not isinstance(endpoints, (bytes, str, list)):
             raise Exception("Expected endpoints to be a Sequence, received: {}".format(type(endpoints)))
@@ -665,11 +665,11 @@ class ApplicationFacade(Type):
     async def AddUnits(self, application=None, attach_storage=None, num_units=None, placement=None, policy=None):
         '''
         application : str
-        attach_storage : typing.Sequence<+T_co>[str]
+        attach_storage : typing.Sequence[str]
         num_units : int
-        placement : typing.Sequence<+T_co>[~Placement]<~Placement>
+        placement : typing.Sequence[~Placement]
         policy : str
-        Returns -> typing.Sequence<+T_co>[str]
+        Returns -> typing.Sequence[str]
         '''
         if application is not None and not isinstance(application, (bytes, str)):
             raise Exception("Expected application to be a str, received: {}".format(type(application)))
@@ -705,8 +705,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ApplicationGetConfigResults)
     async def CharmConfig(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ConfigResult]<~ConfigResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ConfigResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -727,7 +727,7 @@ class ApplicationFacade(Type):
     async def CharmRelations(self, application=None):
         '''
         application : str
-        Returns -> typing.Sequence<+T_co>[str]
+        Returns -> typing.Sequence[str]
         '''
         if application is not None and not isinstance(application, (bytes, str)):
             raise Exception("Expected application to be a str, received: {}".format(type(application)))
@@ -747,8 +747,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Consume(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~ConsumeApplicationArg]<~ConsumeApplicationArg>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~ConsumeApplicationArg]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -768,8 +768,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Deploy(self, applications=None):
         '''
-        applications : typing.Sequence<+T_co>[~ApplicationDeploy]<~ApplicationDeploy>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        applications : typing.Sequence[~ApplicationDeploy]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if applications is not None and not isinstance(applications, (bytes, str, list)):
             raise Exception("Expected applications to be a Sequence, received: {}".format(type(applications)))
@@ -810,8 +810,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(DestroyApplicationResults)
     async def DestroyApplication(self, applications=None):
         '''
-        applications : typing.Sequence<+T_co>[~DestroyApplicationParams]<~DestroyApplicationParams>
-        Returns -> typing.Sequence<+T_co>[~DestroyApplicationResult]<~DestroyApplicationResult>
+        applications : typing.Sequence[~DestroyApplicationParams]
+        Returns -> typing.Sequence[~DestroyApplicationResult]
         '''
         if applications is not None and not isinstance(applications, (bytes, str, list)):
             raise Exception("Expected applications to be a Sequence, received: {}".format(type(applications)))
@@ -831,8 +831,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def DestroyConsumedApplications(self, applications=None):
         '''
-        applications : typing.Sequence<+T_co>[~DestroyConsumedApplicationParams]<~DestroyConsumedApplicationParams>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        applications : typing.Sequence[~DestroyConsumedApplicationParams]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if applications is not None and not isinstance(applications, (bytes, str, list)):
             raise Exception("Expected applications to be a Sequence, received: {}".format(type(applications)))
@@ -852,7 +852,7 @@ class ApplicationFacade(Type):
     @ReturnMapping(None)
     async def DestroyRelation(self, endpoints=None, relation_id=None):
         '''
-        endpoints : typing.Sequence<+T_co>[str]
+        endpoints : typing.Sequence[str]
         relation_id : int
         Returns -> None
         '''
@@ -878,8 +878,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(DestroyUnitResults)
     async def DestroyUnit(self, units=None):
         '''
-        units : typing.Sequence<+T_co>[~DestroyUnitParams]<~DestroyUnitParams>
-        Returns -> typing.Sequence<+T_co>[~DestroyUnitResult]<~DestroyUnitResult>
+        units : typing.Sequence[~DestroyUnitParams]
+        Returns -> typing.Sequence[~DestroyUnitResult]
         '''
         if units is not None and not isinstance(units, (bytes, str, list)):
             raise Exception("Expected units to be a Sequence, received: {}".format(type(units)))
@@ -899,7 +899,7 @@ class ApplicationFacade(Type):
     @ReturnMapping(None)
     async def DestroyUnits(self, unit_names=None):
         '''
-        unit_names : typing.Sequence<+T_co>[str]
+        unit_names : typing.Sequence[str]
         Returns -> None
         '''
         if unit_names is not None and not isinstance(unit_names, (bytes, str, list)):
@@ -942,7 +942,7 @@ class ApplicationFacade(Type):
     async def Get(self, application=None):
         '''
         application : str
-        Returns -> typing.Union[str, typing.Mapping<~KT, +VT_co>[str, typing.Any], _ForwardRef('Value')]
+        Returns -> typing.Union[str, typing.Mapping[str, typing.Any], _ForwardRef('Value')]
         '''
         if application is not None and not isinstance(application, (bytes, str)):
             raise Exception("Expected application to be a str, received: {}".format(type(application)))
@@ -983,8 +983,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ApplicationGetConfigResults)
     async def GetConfig(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ConfigResult]<~ConfigResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ConfigResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1004,8 +1004,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ApplicationGetConstraintsResults)
     async def GetConstraints(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ApplicationConstraint]<~ApplicationConstraint>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ApplicationConstraint]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1027,7 +1027,7 @@ class ApplicationFacade(Type):
         '''
         application : Entity
         watcher_id : str
-        Returns -> typing.Sequence<+T_co>[~LXDProfileUpgradeMessagesResult]<~LXDProfileUpgradeMessagesResult>
+        Returns -> typing.Sequence[~LXDProfileUpgradeMessagesResult]
         '''
         if application is not None and not isinstance(application, (dict, Entity)):
             raise Exception("Expected application to be a Entity, received: {}".format(type(application)))
@@ -1054,7 +1054,7 @@ class ApplicationFacade(Type):
         all_ : bool
         retry : bool
         tags : Entities
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if all_ is not None and not isinstance(all_, bool):
             raise Exception("Expected all_ to be a bool, received: {}".format(type(all_)))
@@ -1082,8 +1082,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ScaleApplicationResults)
     async def ScaleApplications(self, applications=None):
         '''
-        applications : typing.Sequence<+T_co>[~ScaleApplicationParams]<~ScaleApplicationParams>
-        Returns -> typing.Sequence<+T_co>[~ScaleApplicationResult]<~ScaleApplicationResult>
+        applications : typing.Sequence[~ScaleApplicationParams]
+        Returns -> typing.Sequence[~ScaleApplicationResult]
         '''
         if applications is not None and not isinstance(applications, (bytes, str, list)):
             raise Exception("Expected applications to be a Sequence, received: {}".format(type(applications)))
@@ -1104,7 +1104,7 @@ class ApplicationFacade(Type):
     async def Set(self, application=None, options=None):
         '''
         application : str
-        options : typing.Mapping<~KT, +VT_co>[str, str]
+        options : typing.Mapping[str, str]
         Returns -> None
         '''
         if application is not None and not isinstance(application, (bytes, str)):
@@ -1129,8 +1129,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetApplicationsConfig(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~ApplicationConfigSet]<~ApplicationConfigSet>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~ApplicationConfigSet]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -1153,13 +1153,13 @@ class ApplicationFacade(Type):
         application : str
         channel : str
         charm_url : str
-        config_settings : typing.Mapping<~KT, +VT_co>[str, str]
+        config_settings : typing.Mapping[str, str]
         config_settings_yaml : str
         force : bool
         force_series : bool
         force_units : bool
-        resource_ids : typing.Mapping<~KT, +VT_co>[str, str]
-        storage_constraints : typing.Mapping<~KT, +VT_co>[str, ~StorageConstraints]<~StorageConstraints>
+        resource_ids : typing.Mapping[str, str]
+        storage_constraints : typing.Mapping[str, ~StorageConstraints]
         Returns -> None
         '''
         if application is not None and not isinstance(application, (bytes, str)):
@@ -1268,8 +1268,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetMetricCredentials(self, creds=None):
         '''
-        creds : typing.Sequence<+T_co>[~ApplicationMetricCredential]<~ApplicationMetricCredential>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        creds : typing.Sequence[~ApplicationMetricCredential]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if creds is not None and not isinstance(creds, (bytes, str, list)):
             raise Exception("Expected creds to be a Sequence, received: {}".format(type(creds)))
@@ -1289,8 +1289,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetRelationsSuspended(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~RelationSuspendedArg]<~RelationSuspendedArg>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~RelationSuspendedArg]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -1332,7 +1332,7 @@ class ApplicationFacade(Type):
     async def Unset(self, application=None, options=None):
         '''
         application : str
-        options : typing.Sequence<+T_co>[str]
+        options : typing.Sequence[str]
         Returns -> None
         '''
         if application is not None and not isinstance(application, (bytes, str)):
@@ -1357,8 +1357,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UnsetApplicationsConfig(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~ApplicationUnset]<~ApplicationUnset>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~ApplicationUnset]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -1385,7 +1385,7 @@ class ApplicationFacade(Type):
         force_charm_url : bool
         force_series : bool
         min_units : int
-        settings : typing.Mapping<~KT, +VT_co>[str, str]
+        settings : typing.Mapping[str, str]
         settings_yaml : str
         Returns -> None
         '''
@@ -1439,8 +1439,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UpdateApplicationSeries(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~UpdateSeriesArg]<~UpdateSeriesArg>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~UpdateSeriesArg]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -1835,7 +1835,7 @@ class ControllerFacade(Type):
     async def AllModels(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~UserModel]<~UserModel>
+        Returns -> typing.Sequence[~UserModel]
         '''
 
         # map input types to rpc msg
@@ -1853,8 +1853,8 @@ class ControllerFacade(Type):
     @ReturnMapping(CloudSpecResults)
     async def CloudSpec(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~CloudSpecResult]<~CloudSpecResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~CloudSpecResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1874,7 +1874,7 @@ class ControllerFacade(Type):
     @ReturnMapping(None)
     async def ConfigSet(self, config=None):
         '''
-        config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        config : typing.Mapping[str, typing.Any]
         Returns -> None
         '''
         if config is not None and not isinstance(config, dict):
@@ -1895,8 +1895,8 @@ class ControllerFacade(Type):
     @ReturnMapping(ControllerAPIInfoResults)
     async def ControllerAPIInfoForModels(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ControllerAPIInfoResult]<~ControllerAPIInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ControllerAPIInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1917,7 +1917,7 @@ class ControllerFacade(Type):
     async def ControllerConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -1999,8 +1999,8 @@ class ControllerFacade(Type):
     @ReturnMapping(UserAccessResults)
     async def GetControllerAccess(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~UserAccessResult]<~UserAccessResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~UserAccessResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2021,7 +2021,7 @@ class ControllerFacade(Type):
     async def HostedModelConfigs(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~HostedModelConfig]<~HostedModelConfig>
+        Returns -> typing.Sequence[~HostedModelConfig]
         '''
 
         # map input types to rpc msg
@@ -2058,8 +2058,8 @@ class ControllerFacade(Type):
     @ReturnMapping(InitiateMigrationResults)
     async def InitiateMigration(self, specs=None):
         '''
-        specs : typing.Sequence<+T_co>[~MigrationSpec]<~MigrationSpec>
-        Returns -> typing.Sequence<+T_co>[~InitiateMigrationResult]<~InitiateMigrationResult>
+        specs : typing.Sequence[~MigrationSpec]
+        Returns -> typing.Sequence[~InitiateMigrationResult]
         '''
         if specs is not None and not isinstance(specs, (bytes, str, list)):
             raise Exception("Expected specs to be a Sequence, received: {}".format(type(specs)))
@@ -2080,7 +2080,7 @@ class ControllerFacade(Type):
     async def ListBlockedModels(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~ModelBlockInfo]<~ModelBlockInfo>
+        Returns -> typing.Sequence[~ModelBlockInfo]
         '''
 
         # map input types to rpc msg
@@ -2099,7 +2099,7 @@ class ControllerFacade(Type):
     async def ModelConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~ConfigValue]<~ConfigValue>
+        Returns -> typing.Mapping[str, ~ConfigValue]
         '''
 
         # map input types to rpc msg
@@ -2117,8 +2117,8 @@ class ControllerFacade(Type):
     @ReturnMapping(ModelStatusResults)
     async def ModelStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ModelStatus]<~ModelStatus>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ModelStatus]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2138,8 +2138,8 @@ class ControllerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ModifyControllerAccess(self, changes=None):
         '''
-        changes : typing.Sequence<+T_co>[~ModifyControllerAccess]<~ModifyControllerAccess>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        changes : typing.Sequence[~ModifyControllerAccess]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if changes is not None and not isinstance(changes, (bytes, str, list)):
             raise Exception("Expected changes to be a Sequence, received: {}".format(type(changes)))
@@ -2218,8 +2218,8 @@ class ControllerFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchCloudSpecsChanges(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2664,8 +2664,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ChangeModelCredential(self, model_credentials=None):
         '''
-        model_credentials : typing.Sequence<+T_co>[~ChangeModelCredentialParams]<~ChangeModelCredentialParams>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        model_credentials : typing.Sequence[~ChangeModelCredentialParams]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if model_credentials is not None and not isinstance(model_credentials, (bytes, str, list)):
             raise Exception("Expected model_credentials to be a Sequence, received: {}".format(type(model_credentials)))
@@ -2686,12 +2686,12 @@ class ModelManagerFacade(Type):
     async def CreateModel(self, cloud_tag=None, config=None, credential=None, name=None, owner_tag=None, region=None):
         '''
         cloud_tag : str
-        config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        config : typing.Mapping[str, typing.Any]
         credential : str
         name : str
         owner_tag : str
         region : str
-        Returns -> typing.Union[_ForwardRef('Number'), bool, _ForwardRef('ModelMigrationStatus'), _ForwardRef('ModelSLAInfo'), _ForwardRef('EntityStatus'), typing.Sequence<+T_co>[~ModelUserInfo]<~ModelUserInfo>]
+        Returns -> typing.Union[_ForwardRef('Number'), str, bool, typing.Sequence[~ModelMachineInfo], _ForwardRef('ModelMigrationStatus'), _ForwardRef('ModelSLAInfo'), _ForwardRef('EntityStatus'), typing.Sequence[~ModelUserInfo]]
         '''
         if cloud_tag is not None and not isinstance(cloud_tag, (bytes, str)):
             raise Exception("Expected cloud_tag to be a str, received: {}".format(type(cloud_tag)))
@@ -2731,8 +2731,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def DestroyModels(self, models=None):
         '''
-        models : typing.Sequence<+T_co>[~DestroyModelParams]<~DestroyModelParams>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        models : typing.Sequence[~DestroyModelParams]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if models is not None and not isinstance(models, (bytes, str, list)):
             raise Exception("Expected models to be a Sequence, received: {}".format(type(models)))
@@ -2752,9 +2752,9 @@ class ModelManagerFacade(Type):
     @ReturnMapping(StringResults)
     async def DumpModels(self, entities=None, simplified=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
+        entities : typing.Sequence[~Entity]
         simplified : bool
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2778,8 +2778,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(MapResults)
     async def DumpModelsDB(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MapResult]<~MapResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MapResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2801,7 +2801,7 @@ class ModelManagerFacade(Type):
         '''
         all_ : bool
         user_tag : str
-        Returns -> typing.Sequence<+T_co>[~ModelSummaryResult]<~ModelSummaryResult>
+        Returns -> typing.Sequence[~ModelSummaryResult]
         '''
         if all_ is not None and not isinstance(all_, bool):
             raise Exception("Expected all_ to be a bool, received: {}".format(type(all_)))
@@ -2826,7 +2826,7 @@ class ModelManagerFacade(Type):
     async def ListModels(self, tag=None):
         '''
         tag : str
-        Returns -> typing.Sequence<+T_co>[~UserModel]<~UserModel>
+        Returns -> typing.Sequence[~UserModel]
         '''
         if tag is not None and not isinstance(tag, (bytes, str)):
             raise Exception("Expected tag to be a str, received: {}".format(type(tag)))
@@ -2846,8 +2846,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ModelDefaultsResults)
     async def ModelDefaultsForClouds(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ModelDefaultsResult]<~ModelDefaultsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ModelDefaultsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2867,8 +2867,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ModelInfoResults)
     async def ModelInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ModelInfoResult]<~ModelInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ModelInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2888,8 +2888,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ModelStatusResults)
     async def ModelStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ModelStatus]<~ModelStatus>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ModelStatus]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2909,8 +2909,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ModifyModelAccess(self, changes=None):
         '''
-        changes : typing.Sequence<+T_co>[~ModifyModelAccess]<~ModifyModelAccess>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        changes : typing.Sequence[~ModifyModelAccess]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if changes is not None and not isinstance(changes, (bytes, str, list)):
             raise Exception("Expected changes to be a Sequence, received: {}".format(type(changes)))
@@ -2930,8 +2930,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetModelDefaults(self, config=None):
         '''
-        config : typing.Sequence<+T_co>[~ModelDefaultValues]<~ModelDefaultValues>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        config : typing.Sequence[~ModelDefaultValues]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if config is not None and not isinstance(config, (bytes, str, list)):
             raise Exception("Expected config to be a Sequence, received: {}".format(type(config)))
@@ -2951,8 +2951,8 @@ class ModelManagerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UnsetModelDefaults(self, keys=None):
         '''
-        keys : typing.Sequence<+T_co>[~ModelUnsetKeys]<~ModelUnsetKeys>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        keys : typing.Sequence[~ModelUnsetKeys]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if keys is not None and not isinstance(keys, (bytes, str, list)):
             raise Exception("Expected keys to be a Sequence, received: {}".format(type(keys)))

--- a/juju/client/_client9.py
+++ b/juju/client/_client9.py
@@ -676,9 +676,9 @@ class ApplicationFacade(Type):
     @ReturnMapping(AddRelationResults)
     async def AddRelation(self, endpoints=None, via_cidrs=None):
         '''
-        endpoints : typing.Sequence<+T_co>[str]
-        via_cidrs : typing.Sequence<+T_co>[str]
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~CharmRelation]<~CharmRelation>
+        endpoints : typing.Sequence[str]
+        via_cidrs : typing.Sequence[str]
+        Returns -> typing.Mapping[str, ~CharmRelation]
         '''
         if endpoints is not None and not isinstance(endpoints, (bytes, str, list)):
             raise Exception("Expected endpoints to be a Sequence, received: {}".format(type(endpoints)))
@@ -703,11 +703,11 @@ class ApplicationFacade(Type):
     async def AddUnits(self, application=None, attach_storage=None, num_units=None, placement=None, policy=None):
         '''
         application : str
-        attach_storage : typing.Sequence<+T_co>[str]
+        attach_storage : typing.Sequence[str]
         num_units : int
-        placement : typing.Sequence<+T_co>[~Placement]<~Placement>
+        placement : typing.Sequence[~Placement]
         policy : str
-        Returns -> typing.Sequence<+T_co>[str]
+        Returns -> typing.Sequence[str]
         '''
         if application is not None and not isinstance(application, (bytes, str)):
             raise Exception("Expected application to be a str, received: {}".format(type(application)))
@@ -743,8 +743,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ApplicationInfoResults)
     async def ApplicationsInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ApplicationInfoResult]<~ApplicationInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ApplicationInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -764,8 +764,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ApplicationGetConfigResults)
     async def CharmConfig(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~ApplicationGet]<~ApplicationGet>
-        Returns -> typing.Sequence<+T_co>[~ConfigResult]<~ConfigResult>
+        args : typing.Sequence[~ApplicationGet]
+        Returns -> typing.Sequence[~ConfigResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -786,7 +786,7 @@ class ApplicationFacade(Type):
     async def CharmRelations(self, application=None):
         '''
         application : str
-        Returns -> typing.Sequence<+T_co>[str]
+        Returns -> typing.Sequence[str]
         '''
         if application is not None and not isinstance(application, (bytes, str)):
             raise Exception("Expected application to be a str, received: {}".format(type(application)))
@@ -806,8 +806,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Consume(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~ConsumeApplicationArg]<~ConsumeApplicationArg>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~ConsumeApplicationArg]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -827,8 +827,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Deploy(self, applications=None):
         '''
-        applications : typing.Sequence<+T_co>[~ApplicationDeploy]<~ApplicationDeploy>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        applications : typing.Sequence[~ApplicationDeploy]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if applications is not None and not isinstance(applications, (bytes, str, list)):
             raise Exception("Expected applications to be a Sequence, received: {}".format(type(applications)))
@@ -869,8 +869,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(DestroyApplicationResults)
     async def DestroyApplication(self, applications=None):
         '''
-        applications : typing.Sequence<+T_co>[~DestroyApplicationParams]<~DestroyApplicationParams>
-        Returns -> typing.Sequence<+T_co>[~DestroyApplicationResult]<~DestroyApplicationResult>
+        applications : typing.Sequence[~DestroyApplicationParams]
+        Returns -> typing.Sequence[~DestroyApplicationResult]
         '''
         if applications is not None and not isinstance(applications, (bytes, str, list)):
             raise Exception("Expected applications to be a Sequence, received: {}".format(type(applications)))
@@ -890,8 +890,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def DestroyConsumedApplications(self, applications=None):
         '''
-        applications : typing.Sequence<+T_co>[~DestroyConsumedApplicationParams]<~DestroyConsumedApplicationParams>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        applications : typing.Sequence[~DestroyConsumedApplicationParams]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if applications is not None and not isinstance(applications, (bytes, str, list)):
             raise Exception("Expected applications to be a Sequence, received: {}".format(type(applications)))
@@ -911,7 +911,7 @@ class ApplicationFacade(Type):
     @ReturnMapping(None)
     async def DestroyRelation(self, endpoints=None, force=None, max_wait=None, relation_id=None):
         '''
-        endpoints : typing.Sequence<+T_co>[str]
+        endpoints : typing.Sequence[str]
         force : bool
         max_wait : int
         relation_id : int
@@ -947,8 +947,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(DestroyUnitResults)
     async def DestroyUnit(self, units=None):
         '''
-        units : typing.Sequence<+T_co>[~DestroyUnitParams]<~DestroyUnitParams>
-        Returns -> typing.Sequence<+T_co>[~DestroyUnitResult]<~DestroyUnitResult>
+        units : typing.Sequence[~DestroyUnitParams]
+        Returns -> typing.Sequence[~DestroyUnitResult]
         '''
         if units is not None and not isinstance(units, (bytes, str, list)):
             raise Exception("Expected units to be a Sequence, received: {}".format(type(units)))
@@ -968,7 +968,7 @@ class ApplicationFacade(Type):
     @ReturnMapping(None)
     async def DestroyUnits(self, unit_names=None):
         '''
-        unit_names : typing.Sequence<+T_co>[str]
+        unit_names : typing.Sequence[str]
         Returns -> None
         '''
         if unit_names is not None and not isinstance(unit_names, (bytes, str, list)):
@@ -1012,7 +1012,7 @@ class ApplicationFacade(Type):
         '''
         application : str
         branch : str
-        Returns -> typing.Union[str, typing.Mapping<~KT, +VT_co>[str, typing.Any], _ForwardRef('Value')]
+        Returns -> typing.Union[str, typing.Mapping[str, typing.Any], _ForwardRef('Value')]
         '''
         if application is not None and not isinstance(application, (bytes, str)):
             raise Exception("Expected application to be a str, received: {}".format(type(application)))
@@ -1062,8 +1062,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ApplicationGetConfigResults)
     async def GetConfig(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ConfigResult]<~ConfigResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ConfigResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1083,8 +1083,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ApplicationGetConstraintsResults)
     async def GetConstraints(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ApplicationConstraint]<~ApplicationConstraint>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ApplicationConstraint]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -1107,7 +1107,7 @@ class ApplicationFacade(Type):
         all_ : bool
         retry : bool
         tags : Entities
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if all_ is not None and not isinstance(all_, bool):
             raise Exception("Expected all_ to be a bool, received: {}".format(type(all_)))
@@ -1135,8 +1135,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ScaleApplicationResults)
     async def ScaleApplications(self, applications=None):
         '''
-        applications : typing.Sequence<+T_co>[~ScaleApplicationParams]<~ScaleApplicationParams>
-        Returns -> typing.Sequence<+T_co>[~ScaleApplicationResult]<~ScaleApplicationResult>
+        applications : typing.Sequence[~ScaleApplicationParams]
+        Returns -> typing.Sequence[~ScaleApplicationResult]
         '''
         if applications is not None and not isinstance(applications, (bytes, str, list)):
             raise Exception("Expected applications to be a Sequence, received: {}".format(type(applications)))
@@ -1158,7 +1158,7 @@ class ApplicationFacade(Type):
         '''
         application : str
         branch : str
-        options : typing.Mapping<~KT, +VT_co>[str, str]
+        options : typing.Mapping[str, str]
         Returns -> None
         '''
         if application is not None and not isinstance(application, (bytes, str)):
@@ -1187,8 +1187,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetApplicationsConfig(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~ApplicationConfigSet]<~ApplicationConfigSet>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~ApplicationConfigSet]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -1211,14 +1211,14 @@ class ApplicationFacade(Type):
         application : str
         channel : str
         charm_url : str
-        config_settings : typing.Mapping<~KT, +VT_co>[str, str]
+        config_settings : typing.Mapping[str, str]
         config_settings_yaml : str
         force : bool
         force_series : bool
         force_units : bool
         generation : str
-        resource_ids : typing.Mapping<~KT, +VT_co>[str, str]
-        storage_constraints : typing.Mapping<~KT, +VT_co>[str, ~StorageConstraints]<~StorageConstraints>
+        resource_ids : typing.Mapping[str, str]
+        storage_constraints : typing.Mapping[str, ~StorageConstraints]
         Returns -> None
         '''
         if application is not None and not isinstance(application, (bytes, str)):
@@ -1305,8 +1305,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetMetricCredentials(self, creds=None):
         '''
-        creds : typing.Sequence<+T_co>[~ApplicationMetricCredential]<~ApplicationMetricCredential>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        creds : typing.Sequence[~ApplicationMetricCredential]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if creds is not None and not isinstance(creds, (bytes, str, list)):
             raise Exception("Expected creds to be a Sequence, received: {}".format(type(creds)))
@@ -1326,8 +1326,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetRelationsSuspended(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~RelationSuspendedArg]<~RelationSuspendedArg>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~RelationSuspendedArg]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -1370,7 +1370,7 @@ class ApplicationFacade(Type):
         '''
         application : str
         branch : str
-        options : typing.Sequence<+T_co>[str]
+        options : typing.Sequence[str]
         Returns -> None
         '''
         if application is not None and not isinstance(application, (bytes, str)):
@@ -1399,8 +1399,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UnsetApplicationsConfig(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~ApplicationUnset]<~ApplicationUnset>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~ApplicationUnset]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -1428,7 +1428,7 @@ class ApplicationFacade(Type):
         force_series : bool
         generation : str
         min_units : int
-        settings : typing.Mapping<~KT, +VT_co>[str, str]
+        settings : typing.Mapping[str, str]
         settings_yaml : str
         Returns -> None
         '''
@@ -1486,8 +1486,8 @@ class ApplicationFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UpdateApplicationSeries(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~UpdateSeriesArg]<~UpdateSeriesArg>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~UpdateSeriesArg]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -2311,7 +2311,7 @@ class ProvisionerFacade(Type):
     async def APIAddresses(self):
         '''
 
-        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence<+T_co>[str]]
+        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence[str]]
         '''
 
         # map input types to rpc msg
@@ -2330,7 +2330,7 @@ class ProvisionerFacade(Type):
     async def APIHostPorts(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~HostPort]<~HostPort>
+        Returns -> typing.Sequence[~HostPort]
         '''
 
         # map input types to rpc msg
@@ -2348,8 +2348,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(StringResults)
     async def AvailabilityZone(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2370,7 +2370,7 @@ class ProvisionerFacade(Type):
     async def CACert(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[int]
+        Returns -> typing.Sequence[int]
         '''
 
         # map input types to rpc msg
@@ -2388,8 +2388,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ConstraintsResults)
     async def Constraints(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ConstraintsResult]<~ConstraintsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ConstraintsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2410,7 +2410,7 @@ class ProvisionerFacade(Type):
     async def ContainerConfig(self):
         '''
 
-        Returns -> typing.Union[_ForwardRef('UpdateBehavior'), str, _ForwardRef('Settings'), typing.Mapping<~KT, +VT_co>[str, typing.Any], _ForwardRef('Settings'), _ForwardRef('Settings'), _ForwardRef('Settings'), bool]
+        Returns -> typing.Union[_ForwardRef('UpdateBehavior'), str, _ForwardRef('Settings'), typing.Mapping[str, typing.Any], bool]
         '''
 
         # map input types to rpc msg
@@ -2429,7 +2429,7 @@ class ProvisionerFacade(Type):
     async def ContainerManagerConfig(self, type_=None):
         '''
         type_ : str
-        Returns -> typing.Mapping<~KT, +VT_co>[str, str]
+        Returns -> typing.Mapping[str, str]
         '''
         if type_ is not None and not isinstance(type_, (bytes, str)):
             raise Exception("Expected type_ to be a str, received: {}".format(type(type_)))
@@ -2449,8 +2449,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ControllerAPIInfoResults)
     async def ControllerAPIInfoForModels(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ControllerAPIInfoResult]<~ControllerAPIInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ControllerAPIInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2471,7 +2471,7 @@ class ProvisionerFacade(Type):
     async def ControllerConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -2489,8 +2489,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(DistributionGroupResults)
     async def DistributionGroup(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~DistributionGroupResult]<~DistributionGroupResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~DistributionGroupResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2510,8 +2510,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(StringsResults)
     async def DistributionGroupByMachineId(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsResult]<~StringsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2531,8 +2531,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def EnsureDead(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2558,7 +2558,7 @@ class ProvisionerFacade(Type):
         minor : int
         number : Number
         series : str
-        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence<+T_co>[~Tools]<~Tools>]
+        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence[~Tools]]
         '''
         if agentstream is not None and not isinstance(agentstream, (bytes, str)):
             raise Exception("Expected agentstream to be a str, received: {}".format(type(agentstream)))
@@ -2598,8 +2598,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(MachineNetworkConfigResults)
     async def GetContainerInterfaceInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MachineNetworkConfigResult]<~MachineNetworkConfigResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MachineNetworkConfigResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2619,8 +2619,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ContainerProfileResults)
     async def GetContainerProfileInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ContainerProfileResult]<~ContainerProfileResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ContainerProfileResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2640,8 +2640,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(HostNetworkChangeResults)
     async def HostChangesForContainers(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~HostNetworkChange]<~HostNetworkChange>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~HostNetworkChange]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2661,8 +2661,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(StringResults)
     async def InstanceId(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2682,8 +2682,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(StatusResults)
     async def InstanceStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StatusResult]<~StatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2703,8 +2703,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(BoolResults)
     async def KeepInstance(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~BoolResult]<~BoolResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~BoolResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2724,8 +2724,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(LifeResults)
     async def Life(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2746,7 +2746,7 @@ class ProvisionerFacade(Type):
     async def MachinesWithTransientErrors(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~StatusResult]<~StatusResult>
+        Returns -> typing.Sequence[~StatusResult]
         '''
 
         # map input types to rpc msg
@@ -2764,8 +2764,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def MarkMachinesForRemoval(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2786,7 +2786,7 @@ class ProvisionerFacade(Type):
     async def ModelConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -2823,8 +2823,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(MachineNetworkConfigResults)
     async def PrepareContainerInterfaceInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MachineNetworkConfigResult]<~MachineNetworkConfigResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MachineNetworkConfigResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2844,8 +2844,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ProvisioningInfoResults)
     async def ProvisioningInfo(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ProvisioningInfoResult]<~ProvisioningInfoResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ProvisioningInfoResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2865,8 +2865,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ReleaseContainerAddresses(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2886,8 +2886,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Remove(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2907,8 +2907,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(StringResults)
     async def Series(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -2928,8 +2928,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetCharmProfiles(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~SetProfileArg]<~SetProfileArg>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~SetProfileArg]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -2949,7 +2949,7 @@ class ProvisionerFacade(Type):
     @ReturnMapping(None)
     async def SetHostMachineNetworkConfig(self, config=None, tag=None):
         '''
-        config : typing.Sequence<+T_co>[~NetworkConfig]<~NetworkConfig>
+        config : typing.Sequence[~NetworkConfig]
         tag : str
         Returns -> None
         '''
@@ -2975,8 +2975,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetInstanceInfo(self, machines=None):
         '''
-        machines : typing.Sequence<+T_co>[~InstanceInfo]<~InstanceInfo>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        machines : typing.Sequence[~InstanceInfo]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if machines is not None and not isinstance(machines, (bytes, str, list)):
             raise Exception("Expected machines to be a Sequence, received: {}".format(type(machines)))
@@ -2996,8 +2996,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetInstanceStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3017,8 +3017,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetModificationStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3038,7 +3038,7 @@ class ProvisionerFacade(Type):
     @ReturnMapping(None)
     async def SetObservedNetworkConfig(self, config=None, tag=None):
         '''
-        config : typing.Sequence<+T_co>[~NetworkConfig]<~NetworkConfig>
+        config : typing.Sequence[~NetworkConfig]
         tag : str
         Returns -> None
         '''
@@ -3064,8 +3064,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetPasswords(self, changes=None):
         '''
-        changes : typing.Sequence<+T_co>[~EntityPassword]<~EntityPassword>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        changes : typing.Sequence[~EntityPassword]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if changes is not None and not isinstance(changes, (bytes, str, list)):
             raise Exception("Expected changes to be a Sequence, received: {}".format(type(changes)))
@@ -3085,8 +3085,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetProviderNetworkConfig(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3106,8 +3106,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3127,8 +3127,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetSupportedContainers(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~MachineContainers]<~MachineContainers>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        params : typing.Sequence[~MachineContainers]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -3149,7 +3149,7 @@ class ProvisionerFacade(Type):
     async def StateAddresses(self):
         '''
 
-        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence<+T_co>[str]]
+        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence[str]]
         '''
 
         # map input types to rpc msg
@@ -3167,8 +3167,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(StatusResults)
     async def Status(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StatusResult]<~StatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3188,8 +3188,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(MachineContainerResults)
     async def SupportedContainers(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MachineContainerResult]<~MachineContainerResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MachineContainerResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3209,8 +3209,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ToolsResults)
     async def Tools(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ToolsResult]<~ToolsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ToolsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3230,8 +3230,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UpdateStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -3270,8 +3270,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchAllContainers(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~WatchContainer]<~WatchContainer>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        params : typing.Sequence[~WatchContainer]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -3291,8 +3291,8 @@ class ProvisionerFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchContainers(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~WatchContainer]<~WatchContainer>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        params : typing.Sequence[~WatchContainer]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -3351,7 +3351,7 @@ class ProvisionerFacade(Type):
     async def WatchModelMachines(self):
         '''
 
-        Returns -> typing.Union[typing.Sequence<+T_co>[str], _ForwardRef('Error')]
+        Returns -> typing.Union[typing.Sequence[str], _ForwardRef('Error'), str]
         '''
 
         # map input types to rpc msg
@@ -4325,7 +4325,7 @@ class UniterFacade(Type):
     async def APIAddresses(self):
         '''
 
-        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence<+T_co>[str]]
+        Returns -> typing.Union[_ForwardRef('Error'), typing.Sequence[str]]
         '''
 
         # map input types to rpc msg
@@ -4344,7 +4344,7 @@ class UniterFacade(Type):
     async def APIHostPorts(self):
         '''
 
-        Returns -> typing.Sequence<+T_co>[~HostPort]<~HostPort>
+        Returns -> typing.Sequence[~HostPort]
         '''
 
         # map input types to rpc msg
@@ -4362,8 +4362,8 @@ class UniterFacade(Type):
     @ReturnMapping(ActionResults)
     async def Actions(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ActionResult]<~ActionResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ActionResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4383,8 +4383,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def AddMetricBatches(self, batches=None):
         '''
-        batches : typing.Sequence<+T_co>[~MetricBatchParam]<~MetricBatchParam>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        batches : typing.Sequence[~MetricBatchParam]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if batches is not None and not isinstance(batches, (bytes, str, list)):
             raise Exception("Expected batches to be a Sequence, received: {}".format(type(batches)))
@@ -4404,8 +4404,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def AddUnitStorage(self, storages=None):
         '''
-        storages : typing.Sequence<+T_co>[~StorageAddParams]<~StorageAddParams>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        storages : typing.Sequence[~StorageAddParams]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if storages is not None and not isinstance(storages, (bytes, str, list)):
             raise Exception("Expected storages to be a Sequence, received: {}".format(type(storages)))
@@ -4425,8 +4425,8 @@ class UniterFacade(Type):
     @ReturnMapping(MachinePortsResults)
     async def AllMachinePorts(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MachinePortsResult]<~MachinePortsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MachinePortsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4446,8 +4446,8 @@ class UniterFacade(Type):
     @ReturnMapping(ApplicationStatusResults)
     async def ApplicationStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ApplicationStatusResult]<~ApplicationStatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ApplicationStatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4467,8 +4467,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringResults)
     async def AssignedMachine(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4488,8 +4488,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringResults)
     async def AvailabilityZone(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4509,8 +4509,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def BeginActions(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4530,8 +4530,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringResults)
     async def CharmArchiveSha256(self, urls=None):
         '''
-        urls : typing.Sequence<+T_co>[~CharmURL]<~CharmURL>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        urls : typing.Sequence[~CharmURL]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if urls is not None and not isinstance(urls, (bytes, str, list)):
             raise Exception("Expected urls to be a Sequence, received: {}".format(type(urls)))
@@ -4551,8 +4551,8 @@ class UniterFacade(Type):
     @ReturnMapping(IntResults)
     async def CharmModifiedVersion(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~IntResult]<~IntResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~IntResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4572,8 +4572,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringBoolResults)
     async def CharmURL(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringBoolResult]<~StringBoolResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringBoolResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4593,8 +4593,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ClearResolved(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4614,8 +4614,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def ClosePorts(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityPortRange]<~EntityPortRange>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityPortRange]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4654,8 +4654,8 @@ class UniterFacade(Type):
     @ReturnMapping(ConfigSettingsResults)
     async def ConfigSettings(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ConfigSettingsResult]<~ConfigSettingsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ConfigSettingsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4694,8 +4694,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Destroy(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4715,8 +4715,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def DestroyAllSubordinates(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4736,8 +4736,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def DestroyUnitStorageAttachments(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4757,8 +4757,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def EnsureDead(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4778,8 +4778,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def EnterScope(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnit]<~RelationUnit>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        relation_units : typing.Sequence[~RelationUnit]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -4799,8 +4799,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def FinishActions(self, results=None):
         '''
-        results : typing.Sequence<+T_co>[~ActionExecutionResult]<~ActionExecutionResult>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        results : typing.Sequence[~ActionExecutionResult]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if results is not None and not isinstance(results, (bytes, str, list)):
             raise Exception("Expected results to be a Sequence, received: {}".format(type(results)))
@@ -4820,8 +4820,8 @@ class UniterFacade(Type):
     @ReturnMapping(MeterStatusResults)
     async def GetMeterStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~MeterStatusResult]<~MeterStatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~MeterStatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4841,8 +4841,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringBoolResults)
     async def GetPrincipal(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringBoolResult]<~StringBoolResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringBoolResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4862,8 +4862,8 @@ class UniterFacade(Type):
     @ReturnMapping(GoalStateResults)
     async def GoalStates(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~GoalStateResult]<~GoalStateResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~GoalStateResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4883,8 +4883,8 @@ class UniterFacade(Type):
     @ReturnMapping(BoolResults)
     async def HasSubordinates(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~BoolResult]<~BoolResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~BoolResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4904,8 +4904,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def LeaveScope(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnit]<~RelationUnit>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        relation_units : typing.Sequence[~RelationUnit]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -4925,8 +4925,8 @@ class UniterFacade(Type):
     @ReturnMapping(LifeResults)
     async def Life(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -4946,8 +4946,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def Merge(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~MergeLeadershipSettingsParam]<~MergeLeadershipSettingsParam>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        params : typing.Sequence[~MergeLeadershipSettingsParam]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -4968,7 +4968,7 @@ class UniterFacade(Type):
     async def ModelConfig(self):
         '''
 
-        Returns -> typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        Returns -> typing.Mapping[str, typing.Any]
         '''
 
         # map input types to rpc msg
@@ -5005,10 +5005,10 @@ class UniterFacade(Type):
     @ReturnMapping(NetworkInfoResults)
     async def NetworkInfo(self, bindings=None, relation_id=None, unit=None):
         '''
-        bindings : typing.Sequence<+T_co>[str]
+        bindings : typing.Sequence[str]
         relation_id : int
         unit : str
-        Returns -> typing.Mapping<~KT, +VT_co>[str, ~NetworkInfoResult]<~NetworkInfoResult>
+        Returns -> typing.Mapping[str, ~NetworkInfoResult]
         '''
         if bindings is not None and not isinstance(bindings, (bytes, str, list)):
             raise Exception("Expected bindings to be a Sequence, received: {}".format(type(bindings)))
@@ -5036,8 +5036,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def OpenPorts(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityPortRange]<~EntityPortRange>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityPortRange]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5057,8 +5057,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringResults)
     async def PrivateAddress(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5097,8 +5097,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringResults)
     async def PublicAddress(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5118,8 +5118,8 @@ class UniterFacade(Type):
     @ReturnMapping(GetLeadershipSettingsBulkResults)
     async def Read(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~GetLeadershipSettingsResult]<~GetLeadershipSettingsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~GetLeadershipSettingsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5139,8 +5139,8 @@ class UniterFacade(Type):
     @ReturnMapping(SettingsResults)
     async def ReadRemoteSettings(self, relation_unit_pairs=None):
         '''
-        relation_unit_pairs : typing.Sequence<+T_co>[~RelationUnitPair]<~RelationUnitPair>
-        Returns -> typing.Sequence<+T_co>[~SettingsResult]<~SettingsResult>
+        relation_unit_pairs : typing.Sequence[~RelationUnitPair]
+        Returns -> typing.Sequence[~SettingsResult]
         '''
         if relation_unit_pairs is not None and not isinstance(relation_unit_pairs, (bytes, str, list)):
             raise Exception("Expected relation_unit_pairs to be a Sequence, received: {}".format(type(relation_unit_pairs)))
@@ -5160,8 +5160,8 @@ class UniterFacade(Type):
     @ReturnMapping(SettingsResults)
     async def ReadSettings(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnit]<~RelationUnit>
-        Returns -> typing.Sequence<+T_co>[~SettingsResult]<~SettingsResult>
+        relation_units : typing.Sequence[~RelationUnit]
+        Returns -> typing.Sequence[~SettingsResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -5181,8 +5181,8 @@ class UniterFacade(Type):
     @ReturnMapping(UnitRefreshResults)
     async def Refresh(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~UnitRefreshResult]<~UnitRefreshResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~UnitRefreshResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5202,8 +5202,8 @@ class UniterFacade(Type):
     @ReturnMapping(RelationResults)
     async def Relation(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnit]<~RelationUnit>
-        Returns -> typing.Sequence<+T_co>[~RelationResult]<~RelationResult>
+        relation_units : typing.Sequence[~RelationUnit]
+        Returns -> typing.Sequence[~RelationResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -5223,8 +5223,8 @@ class UniterFacade(Type):
     @ReturnMapping(RelationResults)
     async def RelationById(self, relation_ids=None):
         '''
-        relation_ids : typing.Sequence<+T_co>[int]
-        Returns -> typing.Sequence<+T_co>[~RelationResult]<~RelationResult>
+        relation_ids : typing.Sequence[int]
+        Returns -> typing.Sequence[~RelationResult]
         '''
         if relation_ids is not None and not isinstance(relation_ids, (bytes, str, list)):
             raise Exception("Expected relation_ids to be a Sequence, received: {}".format(type(relation_ids)))
@@ -5244,8 +5244,8 @@ class UniterFacade(Type):
     @ReturnMapping(RelationUnitStatusResults)
     async def RelationsStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~RelationUnitStatusResult]<~RelationUnitStatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~RelationUnitStatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5265,8 +5265,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RemoveStorageAttachments(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~StorageAttachmentId]<~StorageAttachmentId>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        ids : typing.Sequence[~StorageAttachmentId]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -5286,8 +5286,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def RequestReboot(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5307,8 +5307,8 @@ class UniterFacade(Type):
     @ReturnMapping(ResolvedModeResults)
     async def Resolved(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~ResolvedModeResult]<~ResolvedModeResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~ResolvedModeResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5347,8 +5347,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetAgentStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5368,8 +5368,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetApplicationStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5389,8 +5389,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetCharmURL(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityCharmURL]<~EntityCharmURL>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityCharmURL]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5410,8 +5410,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetPodSpec(self, specs=None):
         '''
-        specs : typing.Sequence<+T_co>[~EntityString]<~EntityString>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        specs : typing.Sequence[~EntityString]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if specs is not None and not isinstance(specs, (bytes, str, list)):
             raise Exception("Expected specs to be a Sequence, received: {}".format(type(specs)))
@@ -5431,8 +5431,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetRelationStatus(self, args=None):
         '''
-        args : typing.Sequence<+T_co>[~RelationStatusArg]<~RelationStatusArg>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        args : typing.Sequence[~RelationStatusArg]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if args is not None and not isinstance(args, (bytes, str, list)):
             raise Exception("Expected args to be a Sequence, received: {}".format(type(args)))
@@ -5452,8 +5452,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5473,8 +5473,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetUnitStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityStatusArgs]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5494,8 +5494,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetUpgradeSeriesUnitStatus(self, params=None):
         '''
-        params : typing.Sequence<+T_co>[~UpgradeSeriesStatusParam]<~UpgradeSeriesStatusParam>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        params : typing.Sequence[~UpgradeSeriesStatusParam]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if params is not None and not isinstance(params, (bytes, str, list)):
             raise Exception("Expected params to be a Sequence, received: {}".format(type(params)))
@@ -5515,8 +5515,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def SetWorkloadVersion(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~EntityWorkloadVersion]<~EntityWorkloadVersion>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        entities : typing.Sequence[~EntityWorkloadVersion]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5536,8 +5536,8 @@ class UniterFacade(Type):
     @ReturnMapping(LifeResults)
     async def StorageAttachmentLife(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~StorageAttachmentId]<~StorageAttachmentId>
-        Returns -> typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        ids : typing.Sequence[~StorageAttachmentId]
+        Returns -> typing.Sequence[~LifeResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -5557,8 +5557,8 @@ class UniterFacade(Type):
     @ReturnMapping(StorageAttachmentResults)
     async def StorageAttachments(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~StorageAttachmentId]<~StorageAttachmentId>
-        Returns -> typing.Sequence<+T_co>[~StorageAttachmentResult]<~StorageAttachmentResult>
+        ids : typing.Sequence[~StorageAttachmentId]
+        Returns -> typing.Sequence[~StorageAttachmentResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -5578,8 +5578,8 @@ class UniterFacade(Type):
     @ReturnMapping(StatusResults)
     async def UnitStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StatusResult]<~StatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5599,8 +5599,8 @@ class UniterFacade(Type):
     @ReturnMapping(StorageAttachmentIdsResults)
     async def UnitStorageAttachments(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StorageAttachmentIdsResult]<~StorageAttachmentIdsResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StorageAttachmentIdsResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5620,8 +5620,8 @@ class UniterFacade(Type):
     @ReturnMapping(ErrorResults)
     async def UpdateSettings(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnitSettings]<~RelationUnitSettings>
-        Returns -> typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        relation_units : typing.Sequence[~RelationUnitSettings]
+        Returns -> typing.Sequence[~ErrorResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -5641,8 +5641,8 @@ class UniterFacade(Type):
     @ReturnMapping(UpgradeSeriesStatusResults)
     async def UpgradeSeriesUnitStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~UpgradeSeriesStatusResult]<~UpgradeSeriesStatusResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~UpgradeSeriesStatusResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5662,8 +5662,8 @@ class UniterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def Watch(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5702,8 +5702,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchActionNotifications(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5723,8 +5723,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchConfigSettingsHash(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5763,8 +5763,8 @@ class UniterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchLeadershipSettings(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5784,8 +5784,8 @@ class UniterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchMeterStatus(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5805,8 +5805,8 @@ class UniterFacade(Type):
     @ReturnMapping(RelationUnitsWatchResults)
     async def WatchRelationUnits(self, relation_units=None):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnit]<~RelationUnit>
-        Returns -> typing.Sequence<+T_co>[~RelationUnitsWatchResult]<~RelationUnitsWatchResult>
+        relation_units : typing.Sequence[~RelationUnit]
+        Returns -> typing.Sequence[~RelationUnitsWatchResult]
         '''
         if relation_units is not None and not isinstance(relation_units, (bytes, str, list)):
             raise Exception("Expected relation_units to be a Sequence, received: {}".format(type(relation_units)))
@@ -5826,8 +5826,8 @@ class UniterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchStorageAttachments(self, ids=None):
         '''
-        ids : typing.Sequence<+T_co>[~StorageAttachmentId]<~StorageAttachmentId>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        ids : typing.Sequence[~StorageAttachmentId]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if ids is not None and not isinstance(ids, (bytes, str, list)):
             raise Exception("Expected ids to be a Sequence, received: {}".format(type(ids)))
@@ -5847,8 +5847,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchTrustConfigSettingsHash(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5868,8 +5868,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchUnitAddressesHash(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5889,8 +5889,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchUnitRelations(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5910,8 +5910,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringsWatchResults)
     async def WatchUnitStorageAttachments(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringsWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5931,8 +5931,8 @@ class UniterFacade(Type):
     @ReturnMapping(NotifyWatchResults)
     async def WatchUpgradeSeriesNotifications(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~NotifyWatchResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))
@@ -5952,8 +5952,8 @@ class UniterFacade(Type):
     @ReturnMapping(StringResults)
     async def WorkloadVersion(self, entities=None):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
-        Returns -> typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        entities : typing.Sequence[~Entity]
+        Returns -> typing.Sequence[~StringResult]
         '''
         if entities is not None and not isinstance(entities, (bytes, str, list)):
             raise Exception("Expected entities to be a Sequence, received: {}".format(type(entities)))

--- a/juju/client/_definitions.py
+++ b/juju/client/_definitions.py
@@ -9,7 +9,7 @@ class APIHostPortsResult(Type):
     _toPy = {'servers': 'servers'}
     def __init__(self, servers=None, **unknown_fields):
         '''
-        servers : typing.Sequence<+T_co>[~HostPort]<~HostPort>
+        servers : typing.Sequence[~HostPort]
         '''
         servers_ = [HostPort.from_json(o) for o in servers or []]
 
@@ -28,7 +28,7 @@ class Action(Type):
     def __init__(self, name=None, parameters=None, receiver=None, tag=None, **unknown_fields):
         '''
         name : str
-        parameters : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        parameters : typing.Mapping[str, typing.Any]
         receiver : str
         tag : str
         '''
@@ -65,7 +65,7 @@ class ActionExecutionResult(Type):
         '''
         action_tag : str
         message : str
-        results : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        results : typing.Mapping[str, typing.Any]
         status : str
         '''
         action_tag_ = action_tag
@@ -99,7 +99,7 @@ class ActionExecutionResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ActionExecutionResult]<~ActionExecutionResult>
+        results : typing.Sequence[~ActionExecutionResult]
         '''
         results_ = [ActionExecutionResult.from_json(o) for o in results or []]
 
@@ -146,7 +146,7 @@ class ActionResult(Type):
         enqueued : str
         error : Error
         message : str
-        output : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        output : typing.Mapping[str, typing.Any]
         started : str
         status : str
         '''
@@ -201,7 +201,7 @@ class ActionResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ActionResult]<~ActionResult>
+        results : typing.Sequence[~ActionResult]
         '''
         results_ = [ActionResult.from_json(o) for o in results or []]
 
@@ -220,7 +220,7 @@ class ActionSpec(Type):
     def __init__(self, description=None, params=None, **unknown_fields):
         '''
         description : str
-        params : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        params : typing.Mapping[str, typing.Any]
         '''
         description_ = description
         params_ = params
@@ -243,7 +243,7 @@ class Actions(Type):
     _toPy = {'actions': 'actions'}
     def __init__(self, actions=None, **unknown_fields):
         '''
-        actions : typing.Sequence<+T_co>[~Action]<~Action>
+        actions : typing.Sequence[~Action]
         '''
         actions_ = [Action.from_json(o) for o in actions or []]
 
@@ -261,7 +261,7 @@ class ActionsByName(Type):
     _toPy = {'actions': 'actions', 'error': 'error', 'name': 'name'}
     def __init__(self, actions=None, error=None, name=None, **unknown_fields):
         '''
-        actions : typing.Sequence<+T_co>[~ActionResult]<~ActionResult>
+        actions : typing.Sequence[~ActionResult]
         error : Error
         name : str
         '''
@@ -291,7 +291,7 @@ class ActionsByNames(Type):
     _toPy = {'actions': 'actions'}
     def __init__(self, actions=None, **unknown_fields):
         '''
-        actions : typing.Sequence<+T_co>[~ActionsByName]<~ActionsByName>
+        actions : typing.Sequence[~ActionsByName]
         '''
         actions_ = [ActionsByName.from_json(o) for o in actions or []]
 
@@ -309,7 +309,7 @@ class ActionsByReceiver(Type):
     _toPy = {'actions': 'actions', 'error': 'error', 'receiver': 'receiver'}
     def __init__(self, actions=None, error=None, receiver=None, **unknown_fields):
         '''
-        actions : typing.Sequence<+T_co>[~ActionResult]<~ActionResult>
+        actions : typing.Sequence[~ActionResult]
         error : Error
         receiver : str
         '''
@@ -339,7 +339,7 @@ class ActionsByReceivers(Type):
     _toPy = {'actions': 'actions'}
     def __init__(self, actions=None, **unknown_fields):
         '''
-        actions : typing.Sequence<+T_co>[~ActionsByReceiver]<~ActionsByReceiver>
+        actions : typing.Sequence[~ActionsByReceiver]
         '''
         actions_ = [ActionsByReceiver.from_json(o) for o in actions or []]
 
@@ -359,7 +359,7 @@ class AddApplicationOffer(Type):
         '''
         application_description : str
         application_name : str
-        endpoints : typing.Mapping<~KT, +VT_co>[str, str]
+        endpoints : typing.Mapping[str, str]
         model_tag : str
         offer_name : str
         '''
@@ -399,7 +399,7 @@ class AddApplicationOffers(Type):
     _toPy = {'Offers': 'offers'}
     def __init__(self, offers=None, **unknown_fields):
         '''
-        offers : typing.Sequence<+T_co>[~AddApplicationOffer]<~AddApplicationOffer>
+        offers : typing.Sequence[~AddApplicationOffer]
         '''
         offers_ = [AddApplicationOffer.from_json(o) for o in offers or []]
 
@@ -418,9 +418,9 @@ class AddApplicationUnits(Type):
     def __init__(self, application=None, attach_storage=None, num_units=None, placement=None, policy=None, **unknown_fields):
         '''
         application : str
-        attach_storage : typing.Sequence<+T_co>[str]
+        attach_storage : typing.Sequence[str]
         num_units : int
-        placement : typing.Sequence<+T_co>[~Placement]<~Placement>
+        placement : typing.Sequence[~Placement]
         policy : str
         '''
         application_ = application
@@ -459,7 +459,7 @@ class AddApplicationUnitsResults(Type):
     _toPy = {'units': 'units'}
     def __init__(self, units=None, **unknown_fields):
         '''
-        units : typing.Sequence<+T_co>[str]
+        units : typing.Sequence[str]
         '''
         units_ = units
 
@@ -573,13 +573,13 @@ class AddMachineParams(Type):
     _toPy = {'addresses': 'addresses', 'constraints': 'constraints', 'container-type': 'container_type', 'disks': 'disks', 'hardware-characteristics': 'hardware_characteristics', 'instance-id': 'instance_id', 'jobs': 'jobs', 'nonce': 'nonce', 'parent-id': 'parent_id', 'placement': 'placement', 'series': 'series'}
     def __init__(self, addresses=None, constraints=None, container_type=None, disks=None, hardware_characteristics=None, instance_id=None, jobs=None, nonce=None, parent_id=None, placement=None, series=None, **unknown_fields):
         '''
-        addresses : typing.Sequence<+T_co>[~Address]<~Address>
+        addresses : typing.Sequence[~Address]
         constraints : Value
         container_type : str
-        disks : typing.Sequence<+T_co>[~Constraints]<~Constraints>
+        disks : typing.Sequence[~Constraints]
         hardware_characteristics : HardwareCharacteristics
         instance_id : str
-        jobs : typing.Sequence<+T_co>[str]
+        jobs : typing.Sequence[str]
         nonce : str
         parent_id : str
         placement : Placement
@@ -651,7 +651,7 @@ class AddMachines(Type):
     _toPy = {'params': 'params'}
     def __init__(self, params=None, **unknown_fields):
         '''
-        params : typing.Sequence<+T_co>[~AddMachineParams]<~AddMachineParams>
+        params : typing.Sequence[~AddMachineParams]
         '''
         params_ = [AddMachineParams.from_json(o) for o in params or []]
 
@@ -693,7 +693,7 @@ class AddMachinesResults(Type):
     _toPy = {'machines': 'machines'}
     def __init__(self, machines=None, **unknown_fields):
         '''
-        machines : typing.Sequence<+T_co>[~AddMachinesResult]<~AddMachinesResult>
+        machines : typing.Sequence[~AddMachinesResult]
         '''
         machines_ = [AddMachinesResult.from_json(o) for o in machines or []]
 
@@ -716,7 +716,7 @@ class AddPendingResourcesArgs(Type):
         channel : str
         force : bool
         macaroon : Macaroon
-        resources : typing.Sequence<+T_co>[~CharmResource]<~CharmResource>
+        resources : typing.Sequence[~CharmResource]
         tag : str
         url : str
         '''
@@ -773,7 +773,7 @@ class AddPendingResourcesResult(Type):
         '''
         errorresult : ErrorResult
         error : Error
-        pending_ids : typing.Sequence<+T_co>[str]
+        pending_ids : typing.Sequence[str]
         '''
         errorresult_ = ErrorResult.from_json(errorresult) if errorresult else None
         error_ = Error.from_json(error) if error else None
@@ -801,8 +801,8 @@ class AddRelation(Type):
     _toPy = {'endpoints': 'endpoints', 'via-cidrs': 'via_cidrs'}
     def __init__(self, endpoints=None, via_cidrs=None, **unknown_fields):
         '''
-        endpoints : typing.Sequence<+T_co>[str]
-        via_cidrs : typing.Sequence<+T_co>[str]
+        endpoints : typing.Sequence[str]
+        via_cidrs : typing.Sequence[str]
         '''
         endpoints_ = endpoints
         via_cidrs_ = via_cidrs
@@ -825,7 +825,7 @@ class AddRelationResults(Type):
     _toPy = {'endpoints': 'endpoints'}
     def __init__(self, endpoints=None, **unknown_fields):
         '''
-        endpoints : typing.Mapping<~KT, +VT_co>[str, ~CharmRelation]<~CharmRelation>
+        endpoints : typing.Mapping[str, ~CharmRelation]
         '''
         endpoints_ = endpoints
 
@@ -843,7 +843,7 @@ class AddStorageDetails(Type):
     _toPy = {'storage-tags': 'storage_tags'}
     def __init__(self, storage_tags=None, **unknown_fields):
         '''
-        storage_tags : typing.Sequence<+T_co>[str]
+        storage_tags : typing.Sequence[str]
         '''
         storage_tags_ = storage_tags
 
@@ -885,7 +885,7 @@ class AddStorageResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~AddStorageResult]<~AddStorageResult>
+        results : typing.Sequence[~AddStorageResult]
         '''
         results_ = [AddStorageResult.from_json(o) for o in results or []]
 
@@ -908,7 +908,7 @@ class AddSubnetParams(Type):
         space_tag : str
         subnet_provider_id : str
         vlan_tag : int
-        zones : typing.Sequence<+T_co>[str]
+        zones : typing.Sequence[str]
         '''
         cidr_ = cidr
         provider_network_id_ = provider_network_id
@@ -951,7 +951,7 @@ class AddSubnetsParams(Type):
     _toPy = {'subnets': 'subnets'}
     def __init__(self, subnets=None, **unknown_fields):
         '''
-        subnets : typing.Sequence<+T_co>[~AddSubnetParams]<~AddSubnetParams>
+        subnets : typing.Sequence[~AddSubnetParams]
         '''
         subnets_ = [AddSubnetParams.from_json(o) for o in subnets or []]
 
@@ -1000,7 +1000,7 @@ class AddUserResult(Type):
     def __init__(self, error=None, secret_key=None, tag=None, **unknown_fields):
         '''
         error : Error
-        secret_key : typing.Sequence<+T_co>[int]
+        secret_key : typing.Sequence[int]
         tag : str
         '''
         error_ = Error.from_json(error) if error else None
@@ -1029,7 +1029,7 @@ class AddUserResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~AddUserResult]<~AddUserResult>
+        results : typing.Sequence[~AddUserResult]
         '''
         results_ = [AddUserResult.from_json(o) for o in results or []]
 
@@ -1047,7 +1047,7 @@ class AddUsers(Type):
     _toPy = {'users': 'users'}
     def __init__(self, users=None, **unknown_fields):
         '''
-        users : typing.Sequence<+T_co>[~AddUser]<~AddUser>
+        users : typing.Sequence[~AddUser]
         '''
         users_ = [AddUser.from_json(o) for o in users or []]
 
@@ -1133,7 +1133,7 @@ class AgentGetEntitiesResult(Type):
         '''
         container_type : str
         error : Error
-        jobs : typing.Sequence<+T_co>[str]
+        jobs : typing.Sequence[str]
         life : str
         '''
         container_type_ = container_type
@@ -1167,7 +1167,7 @@ class AgentGetEntitiesResults(Type):
     _toPy = {'entities': 'entities'}
     def __init__(self, entities=None, **unknown_fields):
         '''
-        entities : typing.Sequence<+T_co>[~AgentGetEntitiesResult]<~AgentGetEntitiesResult>
+        entities : typing.Sequence[~AgentGetEntitiesResult]
         '''
         entities_ = [AgentGetEntitiesResult.from_json(o) for o in entities or []]
 
@@ -1221,7 +1221,7 @@ class AllWatcherNextResults(Type):
     _toPy = {'deltas': 'deltas'}
     def __init__(self, deltas=None, **unknown_fields):
         '''
-        deltas : typing.Sequence<+T_co>[~Delta]<~Delta>
+        deltas : typing.Sequence[~Delta]
         '''
         deltas_ = [Delta.from_json(o) for o in deltas or []]
 
@@ -1239,7 +1239,7 @@ class AnnotationsGetResult(Type):
     _toPy = {'annotations': 'annotations', 'entity': 'entity', 'error': 'error'}
     def __init__(self, annotations=None, entity=None, error=None, **unknown_fields):
         '''
-        annotations : typing.Mapping<~KT, +VT_co>[str, str]
+        annotations : typing.Mapping[str, str]
         entity : str
         error : ErrorResult
         '''
@@ -1269,7 +1269,7 @@ class AnnotationsGetResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~AnnotationsGetResult]<~AnnotationsGetResult>
+        results : typing.Sequence[~AnnotationsGetResult]
         '''
         results_ = [AnnotationsGetResult.from_json(o) for o in results or []]
 
@@ -1287,7 +1287,7 @@ class AnnotationsSet(Type):
     _toPy = {'annotations': 'annotations'}
     def __init__(self, annotations=None, **unknown_fields):
         '''
-        annotations : typing.Sequence<+T_co>[~EntityAnnotations]<~EntityAnnotations>
+        annotations : typing.Sequence[~EntityAnnotations]
         '''
         annotations_ = [EntityAnnotations.from_json(o) for o in annotations or []]
 
@@ -1341,7 +1341,7 @@ class ApplicationCharmActionsResult(Type):
     _toPy = {'actions': 'actions', 'application-tag': 'application_tag', 'error': 'error'}
     def __init__(self, actions=None, application_tag=None, error=None, **unknown_fields):
         '''
-        actions : typing.Mapping<~KT, +VT_co>[str, ~ActionSpec]<~ActionSpec>
+        actions : typing.Mapping[str, ~ActionSpec]
         application_tag : str
         error : Error
         '''
@@ -1389,7 +1389,7 @@ class ApplicationCharmRelationsResults(Type):
     _toPy = {'charm-relations': 'charm_relations'}
     def __init__(self, charm_relations=None, **unknown_fields):
         '''
-        charm_relations : typing.Sequence<+T_co>[str]
+        charm_relations : typing.Sequence[str]
         '''
         charm_relations_ = charm_relations
 
@@ -1431,7 +1431,7 @@ class ApplicationCharmResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ApplicationCharmResult]<~ApplicationCharmResult>
+        results : typing.Sequence[~ApplicationCharmResult]
         '''
         results_ = [ApplicationCharmResult.from_json(o) for o in results or []]
 
@@ -1450,7 +1450,7 @@ class ApplicationConfigSet(Type):
     def __init__(self, application=None, config=None, generation=None, **unknown_fields):
         '''
         application : str
-        config : typing.Mapping<~KT, +VT_co>[str, str]
+        config : typing.Mapping[str, str]
         generation : str
         '''
         application_ = application
@@ -1479,7 +1479,7 @@ class ApplicationConfigSetArgs(Type):
     _toPy = {'Args': 'args'}
     def __init__(self, args=None, **unknown_fields):
         '''
-        args : typing.Sequence<+T_co>[~ApplicationConfigSet]<~ApplicationConfigSet>
+        args : typing.Sequence[~ApplicationConfigSet]
         '''
         args_ = [ApplicationConfigSet.from_json(o) for o in args or []]
 
@@ -1497,7 +1497,7 @@ class ApplicationConfigUnsetArgs(Type):
     _toPy = {'Args': 'args'}
     def __init__(self, args=None, **unknown_fields):
         '''
-        args : typing.Sequence<+T_co>[~ApplicationUnset]<~ApplicationUnset>
+        args : typing.Sequence[~ApplicationUnset]
         '''
         args_ = [ApplicationUnset.from_json(o) for o in args or []]
 
@@ -1542,15 +1542,15 @@ class ApplicationDeploy(Type):
         application : str
         channel : str
         charm_url : str
-        config : typing.Mapping<~KT, +VT_co>[str, str]
+        config : typing.Mapping[str, str]
         config_yaml : str
         constraints : Value
-        endpoint_bindings : typing.Mapping<~KT, +VT_co>[str, str]
+        endpoint_bindings : typing.Mapping[str, str]
         num_units : int
-        placement : typing.Sequence<+T_co>[~Placement]<~Placement>
-        resources : typing.Mapping<~KT, +VT_co>[str, str]
+        placement : typing.Sequence[~Placement]
+        resources : typing.Mapping[str, str]
         series : str
-        storage : typing.Mapping<~KT, +VT_co>[str, ~Constraints]<~Constraints>
+        storage : typing.Mapping[str, ~Constraints]
         '''
         application_ = application
         channel_ = channel
@@ -1683,7 +1683,7 @@ class ApplicationGetArgs(Type):
     _toPy = {'args': 'args'}
     def __init__(self, args=None, **unknown_fields):
         '''
-        args : typing.Sequence<+T_co>[~ApplicationGet]<~ApplicationGet>
+        args : typing.Sequence[~ApplicationGet]
         '''
         args_ = [ApplicationGet.from_json(o) for o in args or []]
 
@@ -1701,7 +1701,7 @@ class ApplicationGetConfigResults(Type):
     _toPy = {'Results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ConfigResult]<~ConfigResult>
+        results : typing.Sequence[~ConfigResult]
         '''
         results_ = [ConfigResult.from_json(o) for o in results or []]
 
@@ -1719,7 +1719,7 @@ class ApplicationGetConstraintsResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ApplicationConstraint]<~ApplicationConstraint>
+        results : typing.Sequence[~ApplicationConstraint]
         '''
         results_ = [ApplicationConstraint.from_json(o) for o in results or []]
 
@@ -1738,10 +1738,10 @@ class ApplicationGetResults(Type):
     def __init__(self, application=None, application_config=None, channel=None, charm=None, config=None, constraints=None, series=None, **unknown_fields):
         '''
         application : str
-        application_config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        application_config : typing.Mapping[str, typing.Any]
         channel : str
         charm : str
-        config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        config : typing.Mapping[str, typing.Any]
         constraints : Value
         series : str
         '''
@@ -1794,7 +1794,7 @@ class ApplicationInfo(Type):
         channel : str
         charm : str
         constraints : Value
-        endpoint_bindings : typing.Mapping<~KT, +VT_co>[str, str]
+        endpoint_bindings : typing.Mapping[str, str]
         exposed : bool
         principal : bool
         remote : bool
@@ -1881,7 +1881,7 @@ class ApplicationInfoResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ApplicationInfoResult]<~ApplicationInfoResult>
+        results : typing.Sequence[~ApplicationInfoResult]
         '''
         results_ = [ApplicationInfoResult.from_json(o) for o in results or []]
 
@@ -1900,7 +1900,7 @@ class ApplicationMetricCredential(Type):
     def __init__(self, application=None, metrics_credentials=None, **unknown_fields):
         '''
         application : str
-        metrics_credentials : typing.Sequence<+T_co>[int]
+        metrics_credentials : typing.Sequence[int]
         '''
         application_ = application
         metrics_credentials_ = metrics_credentials
@@ -1923,7 +1923,7 @@ class ApplicationMetricCredentials(Type):
     _toPy = {'creds': 'creds'}
     def __init__(self, creds=None, **unknown_fields):
         '''
-        creds : typing.Sequence<+T_co>[~ApplicationMetricCredential]<~ApplicationMetricCredential>
+        creds : typing.Sequence[~ApplicationMetricCredential]
         '''
         creds_ = [ApplicationMetricCredential.from_json(o) for o in creds or []]
 
@@ -1943,12 +1943,12 @@ class ApplicationOffer(Type):
         '''
         access : str
         application_description : str
-        bindings : typing.Mapping<~KT, +VT_co>[str, str]
-        endpoints : typing.Sequence<+T_co>[~RemoteEndpoint]<~RemoteEndpoint>
+        bindings : typing.Mapping[str, str]
+        endpoints : typing.Sequence[~RemoteEndpoint]
         offer_name : str
         offer_url : str
         source_model_tag : str
-        spaces : typing.Sequence<+T_co>[~RemoteSpace]<~RemoteSpace>
+        spaces : typing.Sequence[~RemoteSpace]
         '''
         access_ = access
         application_description_ = application_description
@@ -2004,16 +2004,16 @@ class ApplicationOfferAdminDetails(Type):
         applicationofferdetails : ApplicationOfferDetails
         application_description : str
         application_name : str
-        bindings : typing.Mapping<~KT, +VT_co>[str, str]
+        bindings : typing.Mapping[str, str]
         charm_url : str
-        connections : typing.Sequence<+T_co>[~OfferConnection]<~OfferConnection>
-        endpoints : typing.Sequence<+T_co>[~RemoteEndpoint]<~RemoteEndpoint>
+        connections : typing.Sequence[~OfferConnection]
+        endpoints : typing.Sequence[~RemoteEndpoint]
         offer_name : str
         offer_url : str
         offer_uuid : str
         source_model_tag : str
-        spaces : typing.Sequence<+T_co>[~RemoteSpace]<~RemoteSpace>
-        users : typing.Sequence<+T_co>[~OfferUserDetails]<~OfferUserDetails>
+        spaces : typing.Sequence[~RemoteSpace]
+        users : typing.Sequence[~OfferUserDetails]
         '''
         applicationofferdetails_ = ApplicationOfferDetails.from_json(applicationofferdetails) if applicationofferdetails else None
         application_description_ = application_description
@@ -2092,14 +2092,14 @@ class ApplicationOfferDetails(Type):
     def __init__(self, application_description=None, bindings=None, endpoints=None, offer_name=None, offer_url=None, offer_uuid=None, source_model_tag=None, spaces=None, users=None, **unknown_fields):
         '''
         application_description : str
-        bindings : typing.Mapping<~KT, +VT_co>[str, str]
-        endpoints : typing.Sequence<+T_co>[~RemoteEndpoint]<~RemoteEndpoint>
+        bindings : typing.Mapping[str, str]
+        endpoints : typing.Sequence[~RemoteEndpoint]
         offer_name : str
         offer_url : str
         offer_uuid : str
         source_model_tag : str
-        spaces : typing.Sequence<+T_co>[~RemoteSpace]<~RemoteSpace>
-        users : typing.Sequence<+T_co>[~OfferUserDetails]<~OfferUserDetails>
+        spaces : typing.Sequence[~RemoteSpace]
+        users : typing.Sequence[~OfferUserDetails]
         '''
         application_description_ = application_description
         bindings_ = bindings
@@ -2184,7 +2184,7 @@ class ApplicationOfferStatus(Type):
         active_connected_count : int
         application_name : str
         charm : str
-        endpoints : typing.Mapping<~KT, +VT_co>[str, ~RemoteEndpoint]<~RemoteEndpoint>
+        endpoints : typing.Mapping[str, ~RemoteEndpoint]
         err : Error
         offer_name : str
         total_connected_count : int
@@ -2235,7 +2235,7 @@ class ApplicationOffersResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ApplicationOfferResult]<~ApplicationOfferResult>
+        results : typing.Sequence[~ApplicationOfferResult]
         '''
         results_ = [ApplicationOfferResult.from_json(o) for o in results or []]
 
@@ -2253,8 +2253,8 @@ class ApplicationRelationsChange(Type):
     _toPy = {'changed': 'changed', 'removed': 'removed'}
     def __init__(self, changed=None, removed=None, **unknown_fields):
         '''
-        changed : typing.Sequence<+T_co>[~RelationChange]<~RelationChange>
-        removed : typing.Sequence<+T_co>[int]
+        changed : typing.Sequence[~RelationChange]
+        removed : typing.Sequence[int]
         '''
         changed_ = [RelationChange.from_json(o) for o in changed or []]
         removed_ = removed
@@ -2309,7 +2309,7 @@ class ApplicationSet(Type):
         '''
         application : str
         branch : str
-        options : typing.Mapping<~KT, +VT_co>[str, str]
+        options : typing.Mapping[str, str]
         '''
         application_ = application
         branch_ = branch
@@ -2340,14 +2340,14 @@ class ApplicationSetCharm(Type):
         application : str
         channel : str
         charm_url : str
-        config_settings : typing.Mapping<~KT, +VT_co>[str, str]
+        config_settings : typing.Mapping[str, str]
         config_settings_yaml : str
         force : bool
         force_series : bool
         force_units : bool
         generation : str
-        resource_ids : typing.Mapping<~KT, +VT_co>[str, str]
-        storage_constraints : typing.Mapping<~KT, +VT_co>[str, ~StorageConstraints]<~StorageConstraints>
+        resource_ids : typing.Mapping[str, str]
+        storage_constraints : typing.Mapping[str, ~StorageConstraints]
         '''
         application_ = application
         channel_ = channel
@@ -2443,19 +2443,19 @@ class ApplicationStatus(Type):
         charm : str
         charm_profile : str
         charm_verion : str
-        endpoint_bindings : typing.Mapping<~KT, +VT_co>[str, str]
+        endpoint_bindings : typing.Mapping[str, str]
         err : Error
         exposed : bool
         int_ : int
         life : str
-        meter_statuses : typing.Mapping<~KT, +VT_co>[str, ~MeterStatus]<~MeterStatus>
+        meter_statuses : typing.Mapping[str, ~MeterStatus]
         provider_id : str
         public_address : str
-        relations : typing.Sequence<+T_co>[str]
+        relations : typing.Sequence[str]
         series : str
         status : DetailedStatus
-        subordinate_to : typing.Sequence<+T_co>[str]
-        units : typing.Mapping<~KT, +VT_co>[str, ~UnitStatus]<~UnitStatus>
+        subordinate_to : typing.Sequence[str]
+        units : typing.Mapping[str, ~UnitStatus]
         workload_version : str
         '''
         can_upgrade_to_ = can_upgrade_to
@@ -2561,7 +2561,7 @@ class ApplicationStatusResult(Type):
         '''
         application : StatusResult
         error : Error
-        units : typing.Mapping<~KT, +VT_co>[str, ~StatusResult]<~StatusResult>
+        units : typing.Mapping[str, ~StatusResult]
         '''
         application_ = StatusResult.from_json(application) if application else None
         error_ = Error.from_json(error) if error else None
@@ -2589,7 +2589,7 @@ class ApplicationStatusResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ApplicationStatusResult]<~ApplicationStatusResult>
+        results : typing.Sequence[~ApplicationStatusResult]
         '''
         results_ = [ApplicationStatusResult.from_json(o) for o in results or []]
 
@@ -2625,7 +2625,7 @@ class ApplicationURLs(Type):
     _toPy = {'application-urls': 'application_urls'}
     def __init__(self, application_urls=None, **unknown_fields):
         '''
-        application_urls : typing.Sequence<+T_co>[str]
+        application_urls : typing.Sequence[str]
         '''
         application_urls_ = application_urls
 
@@ -2662,10 +2662,10 @@ class ApplicationUnitParams(Type):
     def __init__(self, address=None, data=None, filesystem_info=None, info=None, ports=None, provider_id=None, stateful=None, status=None, unit_tag=None, **unknown_fields):
         '''
         address : str
-        data : typing.Mapping<~KT, +VT_co>[str, typing.Any]
-        filesystem_info : typing.Sequence<+T_co>[~KubernetesFilesystemInfo]<~KubernetesFilesystemInfo>
+        data : typing.Mapping[str, typing.Any]
+        filesystem_info : typing.Sequence[~KubernetesFilesystemInfo]
         info : str
-        ports : typing.Sequence<+T_co>[str]
+        ports : typing.Sequence[str]
         provider_id : str
         stateful : bool
         status : str
@@ -2729,7 +2729,7 @@ class ApplicationUnset(Type):
         '''
         application : str
         branch : str
-        options : typing.Sequence<+T_co>[str]
+        options : typing.Sequence[str]
         '''
         application_ = application
         branch_ = branch
@@ -2765,7 +2765,7 @@ class ApplicationUpdate(Type):
         force_series : bool
         generation : str
         min_units : int
-        settings : typing.Mapping<~KT, +VT_co>[str, str]
+        settings : typing.Mapping[str, str]
         settings_yaml : str
         '''
         application_ = application
@@ -2829,7 +2829,7 @@ class ApplicationsCharmActionsResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ApplicationCharmActionsResult]<~ApplicationCharmActionsResult>
+        results : typing.Sequence[~ApplicationCharmActionsResult]
         '''
         results_ = [ApplicationCharmActionsResult.from_json(o) for o in results or []]
 
@@ -2847,7 +2847,7 @@ class ApplicationsDeploy(Type):
     _toPy = {'applications': 'applications'}
     def __init__(self, applications=None, **unknown_fields):
         '''
-        applications : typing.Sequence<+T_co>[~ApplicationDeploy]<~ApplicationDeploy>
+        applications : typing.Sequence[~ApplicationDeploy]
         '''
         applications_ = [ApplicationDeploy.from_json(o) for o in applications or []]
 
@@ -2924,7 +2924,7 @@ class BackupsListResult(Type):
     _toPy = {'list': 'list_'}
     def __init__(self, list_=None, **unknown_fields):
         '''
-        list_ : typing.Sequence<+T_co>[~BackupsMetadataResult]<~BackupsMetadataResult>
+        list_ : typing.Sequence[~BackupsMetadataResult]
         '''
         list__ = [BackupsMetadataResult.from_json(o) for o in list_ or []]
 
@@ -3050,7 +3050,7 @@ class BackupsRemoveArgs(Type):
     _toPy = {'ids': 'ids'}
     def __init__(self, ids=None, **unknown_fields):
         '''
-        ids : typing.Sequence<+T_co>[str]
+        ids : typing.Sequence[str]
         '''
         ids_ = ids
 
@@ -3165,7 +3165,7 @@ class BlockDevice(Type):
     def __init__(self, busaddress=None, devicelinks=None, devicename=None, filesystemtype=None, hardwareid=None, inuse=None, label=None, mountpoint=None, size=None, uuid=None, wwn=None, **unknown_fields):
         '''
         busaddress : str
-        devicelinks : typing.Sequence<+T_co>[str]
+        devicelinks : typing.Sequence[str]
         devicename : str
         filesystemtype : str
         hardwareid : str
@@ -3266,7 +3266,7 @@ class BlockDeviceResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~BlockDeviceResult]<~BlockDeviceResult>
+        results : typing.Sequence[~BlockDeviceResult]
         '''
         results_ = [BlockDeviceResult.from_json(o) for o in results or []]
 
@@ -3308,7 +3308,7 @@ class BlockResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~BlockResult]<~BlockResult>
+        results : typing.Sequence[~BlockResult]
         '''
         results_ = [BlockResult.from_json(o) for o in results or []]
 
@@ -3374,7 +3374,7 @@ class BoolResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~BoolResult]<~BoolResult>
+        results : typing.Sequence[~BoolResult]
         '''
         results_ = [BoolResult.from_json(o) for o in results or []]
 
@@ -3410,7 +3410,7 @@ class BranchInfoArgs(Type):
     _toPy = {'branches': 'branches', 'detailed': 'detailed'}
     def __init__(self, branches=None, detailed=None, **unknown_fields):
         '''
-        branches : typing.Sequence<+T_co>[str]
+        branches : typing.Sequence[str]
         detailed : bool
         '''
         branches_ = branches
@@ -3434,7 +3434,7 @@ class BranchStatus(Type):
     _toPy = {'assigned-units': 'assigned_units', 'created': 'created'}
     def __init__(self, assigned_units=None, created=None, **unknown_fields):
         '''
-        assigned_units : typing.Sequence<+T_co>[str]
+        assigned_units : typing.Sequence[str]
         created : int
         '''
         assigned_units_ = assigned_units
@@ -3459,7 +3459,7 @@ class BranchTrackArg(Type):
     def __init__(self, branch=None, entities=None, **unknown_fields):
         '''
         branch : str
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
+        entities : typing.Sequence[~Entity]
         '''
         branch_ = branch
         entities_ = [Entity.from_json(o) for o in entities or []]
@@ -3482,7 +3482,7 @@ class BulkImportStorageParams(Type):
     _toPy = {'storage': 'storage'}
     def __init__(self, storage=None, **unknown_fields):
         '''
-        storage : typing.Sequence<+T_co>[~ImportStorageParams]<~ImportStorageParams>
+        storage : typing.Sequence[~ImportStorageParams]
         '''
         storage_ = [ImportStorageParams.from_json(o) for o in storage or []]
 
@@ -3500,10 +3500,10 @@ class BundleChange(Type):
     _toPy = {'args': 'args', 'id': 'id_', 'method': 'method', 'requires': 'requires'}
     def __init__(self, args=None, id_=None, method=None, requires=None, **unknown_fields):
         '''
-        args : typing.Sequence<+T_co>[typing.Any]
+        args : typing.Sequence[typing.Any]
         id_ : str
         method : str
-        requires : typing.Sequence<+T_co>[str]
+        requires : typing.Sequence[str]
         '''
         args_ = args
         id__ = id_
@@ -3536,10 +3536,10 @@ class BundleChangesMapArgs(Type):
     _toPy = {'args': 'args', 'id': 'id_', 'method': 'method', 'requires': 'requires'}
     def __init__(self, args=None, id_=None, method=None, requires=None, **unknown_fields):
         '''
-        args : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        args : typing.Mapping[str, typing.Any]
         id_ : str
         method : str
-        requires : typing.Sequence<+T_co>[str]
+        requires : typing.Sequence[str]
         '''
         args_ = args
         id__ = id_
@@ -3572,8 +3572,8 @@ class BundleChangesMapArgsResults(Type):
     _toPy = {'changes': 'changes', 'errors': 'errors'}
     def __init__(self, changes=None, errors=None, **unknown_fields):
         '''
-        changes : typing.Sequence<+T_co>[~BundleChangesMapArgs]<~BundleChangesMapArgs>
-        errors : typing.Sequence<+T_co>[str]
+        changes : typing.Sequence[~BundleChangesMapArgs]
+        errors : typing.Sequence[str]
         '''
         changes_ = [BundleChangesMapArgs.from_json(o) for o in changes or []]
         errors_ = errors
@@ -3620,8 +3620,8 @@ class BundleChangesResults(Type):
     _toPy = {'changes': 'changes', 'errors': 'errors'}
     def __init__(self, changes=None, errors=None, **unknown_fields):
         '''
-        changes : typing.Sequence<+T_co>[~BundleChange]<~BundleChange>
-        errors : typing.Sequence<+T_co>[str]
+        changes : typing.Sequence[~BundleChange]
+        errors : typing.Sequence[str]
         '''
         changes_ = [BundleChange.from_json(o) for o in changes or []]
         errors_ = errors
@@ -3644,7 +3644,7 @@ class BytesResult(Type):
     _toPy = {'result': 'result'}
     def __init__(self, result=None, **unknown_fields):
         '''
-        result : typing.Sequence<+T_co>[int]
+        result : typing.Sequence[int]
         '''
         result_ = result
 
@@ -3686,7 +3686,7 @@ class ChangeModelCredentialsParams(Type):
     _toPy = {'model-credentials': 'model_credentials'}
     def __init__(self, model_credentials=None, **unknown_fields):
         '''
-        model_credentials : typing.Sequence<+T_co>[~ChangeModelCredentialParams]<~ChangeModelCredentialParams>
+        model_credentials : typing.Sequence[~ChangeModelCredentialParams]
         '''
         model_credentials_ = [ChangeModelCredentialParams.from_json(o) for o in model_credentials or []]
 
@@ -3705,7 +3705,7 @@ class CharmActionSpec(Type):
     def __init__(self, description=None, params=None, **unknown_fields):
         '''
         description : str
-        params : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        params : typing.Mapping[str, typing.Any]
         '''
         description_ = description
         params_ = params
@@ -3728,7 +3728,7 @@ class CharmActions(Type):
     _toPy = {'specs': 'specs'}
     def __init__(self, specs=None, **unknown_fields):
         '''
-        specs : typing.Mapping<~KT, +VT_co>[str, ~CharmActionSpec]<~CharmActionSpec>
+        specs : typing.Mapping[str, ~CharmActionSpec]
         '''
         specs_ = specs
 
@@ -3789,7 +3789,7 @@ class CharmInfo(Type):
     def __init__(self, actions=None, config=None, lxd_profile=None, meta=None, metrics=None, revision=None, url=None, **unknown_fields):
         '''
         actions : CharmActions
-        config : typing.Mapping<~KT, +VT_co>[str, ~CharmOption]<~CharmOption>
+        config : typing.Mapping[str, ~CharmOption]
         lxd_profile : CharmLXDProfile
         meta : CharmMeta
         metrics : CharmMetrics
@@ -3842,9 +3842,9 @@ class CharmLXDProfile(Type):
     _toPy = {'config': 'config', 'description': 'description', 'devices': 'devices'}
     def __init__(self, config=None, description=None, devices=None, **unknown_fields):
         '''
-        config : typing.Mapping<~KT, +VT_co>[str, str]
+        config : typing.Mapping[str, str]
         description : str
-        devices : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        devices : typing.Mapping[str, typing.Any]
         '''
         config_ = config
         description_ = description
@@ -3872,23 +3872,23 @@ class CharmMeta(Type):
     _toPy = {'categories': 'categories', 'description': 'description', 'devices': 'devices', 'extra-bindings': 'extra_bindings', 'min-juju-version': 'min_juju_version', 'name': 'name', 'payload-classes': 'payload_classes', 'peers': 'peers', 'provides': 'provides', 'requires': 'requires', 'resources': 'resources', 'series': 'series', 'storage': 'storage', 'subordinate': 'subordinate', 'summary': 'summary', 'tags': 'tags', 'terms': 'terms'}
     def __init__(self, categories=None, description=None, devices=None, extra_bindings=None, min_juju_version=None, name=None, payload_classes=None, peers=None, provides=None, requires=None, resources=None, series=None, storage=None, subordinate=None, summary=None, tags=None, terms=None, **unknown_fields):
         '''
-        categories : typing.Sequence<+T_co>[str]
+        categories : typing.Sequence[str]
         description : str
-        devices : typing.Mapping<~KT, +VT_co>[str, ~CharmDevice]<~CharmDevice>
-        extra_bindings : typing.Mapping<~KT, +VT_co>[str, str]
+        devices : typing.Mapping[str, ~CharmDevice]
+        extra_bindings : typing.Mapping[str, str]
         min_juju_version : str
         name : str
-        payload_classes : typing.Mapping<~KT, +VT_co>[str, ~CharmPayloadClass]<~CharmPayloadClass>
-        peers : typing.Mapping<~KT, +VT_co>[str, ~CharmRelation]<~CharmRelation>
-        provides : typing.Mapping<~KT, +VT_co>[str, ~CharmRelation]<~CharmRelation>
-        requires : typing.Mapping<~KT, +VT_co>[str, ~CharmRelation]<~CharmRelation>
-        resources : typing.Mapping<~KT, +VT_co>[str, ~CharmResourceMeta]<~CharmResourceMeta>
-        series : typing.Sequence<+T_co>[str]
-        storage : typing.Mapping<~KT, +VT_co>[str, ~CharmStorage]<~CharmStorage>
+        payload_classes : typing.Mapping[str, ~CharmPayloadClass]
+        peers : typing.Mapping[str, ~CharmRelation]
+        provides : typing.Mapping[str, ~CharmRelation]
+        requires : typing.Mapping[str, ~CharmRelation]
+        resources : typing.Mapping[str, ~CharmResourceMeta]
+        series : typing.Sequence[str]
+        storage : typing.Mapping[str, ~CharmStorage]
         subordinate : bool
         summary : str
-        tags : typing.Sequence<+T_co>[str]
-        terms : typing.Sequence<+T_co>[str]
+        tags : typing.Sequence[str]
+        terms : typing.Sequence[str]
         '''
         categories_ = categories
         description_ = description
@@ -4010,7 +4010,7 @@ class CharmMetrics(Type):
     _toPy = {'metrics': 'metrics', 'plan': 'plan'}
     def __init__(self, metrics=None, plan=None, **unknown_fields):
         '''
-        metrics : typing.Mapping<~KT, +VT_co>[str, ~CharmMetric]<~CharmMetric>
+        metrics : typing.Mapping[str, ~CharmMetric]
         plan : CharmPlan
         '''
         metrics_ = metrics
@@ -4103,11 +4103,11 @@ class CharmProfilingInfoResult(Type):
     _toPy = {'current-profiles': 'current_profiles', 'error': 'error', 'instance-id': 'instance_id', 'model-name': 'model_name', 'profile-changes': 'profile_changes'}
     def __init__(self, current_profiles=None, error=None, instance_id=None, model_name=None, profile_changes=None, **unknown_fields):
         '''
-        current_profiles : typing.Sequence<+T_co>[str]
+        current_profiles : typing.Sequence[str]
         error : Error
         instance_id : str
         model_name : str
-        profile_changes : typing.Sequence<+T_co>[~ProfileInfoResult]<~ProfileInfoResult>
+        profile_changes : typing.Sequence[~ProfileInfoResult]
         '''
         current_profiles_ = current_profiles
         error_ = Error.from_json(error) if error else None
@@ -4194,7 +4194,7 @@ class CharmResource(Type):
     def __init__(self, description=None, fingerprint=None, name=None, origin=None, path=None, revision=None, size=None, type_=None, **unknown_fields):
         '''
         description : str
-        fingerprint : typing.Sequence<+T_co>[int]
+        fingerprint : typing.Sequence[int]
         name : str
         origin : str
         path : str
@@ -4295,7 +4295,7 @@ class CharmStorage(Type):
         location : str
         minimum_size : int
         name : str
-        properties : typing.Sequence<+T_co>[str]
+        properties : typing.Sequence[str]
         read_only : bool
         shared : bool
         type_ : str
@@ -4379,7 +4379,7 @@ class CharmURLs(Type):
     _toPy = {'urls': 'urls'}
     def __init__(self, urls=None, **unknown_fields):
         '''
-        urls : typing.Sequence<+T_co>[~CharmURL]<~CharmURL>
+        urls : typing.Sequence[~CharmURL]
         '''
         urls_ = [CharmURL.from_json(o) for o in urls or []]
 
@@ -4397,7 +4397,7 @@ class CharmsList(Type):
     _toPy = {'names': 'names'}
     def __init__(self, names=None, **unknown_fields):
         '''
-        names : typing.Sequence<+T_co>[str]
+        names : typing.Sequence[str]
         '''
         names_ = names
 
@@ -4415,7 +4415,7 @@ class CharmsListResult(Type):
     _toPy = {'charm-urls': 'charm_urls'}
     def __init__(self, charm_urls=None, **unknown_fields):
         '''
-        charm_urls : typing.Sequence<+T_co>[str]
+        charm_urls : typing.Sequence[str]
         '''
         charm_urls_ = charm_urls
 
@@ -4433,7 +4433,7 @@ class ClaimLeadershipBulkParams(Type):
     _toPy = {'params': 'params'}
     def __init__(self, params=None, **unknown_fields):
         '''
-        params : typing.Sequence<+T_co>[~ClaimLeadershipParams]<~ClaimLeadershipParams>
+        params : typing.Sequence[~ClaimLeadershipParams]
         '''
         params_ = [ClaimLeadershipParams.from_json(o) for o in params or []]
 
@@ -4451,7 +4451,7 @@ class ClaimLeadershipBulkResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        results : typing.Sequence[~ErrorResult]
         '''
         results_ = [ErrorResult.from_json(o) for o in results or []]
 
@@ -4499,14 +4499,14 @@ class Cloud(Type):
     _toPy = {'auth-types': 'auth_types', 'ca-certificates': 'ca_certificates', 'config': 'config', 'endpoint': 'endpoint', 'host-cloud-region': 'host_cloud_region', 'identity-endpoint': 'identity_endpoint', 'region-config': 'region_config', 'regions': 'regions', 'storage-endpoint': 'storage_endpoint', 'type': 'type_'}
     def __init__(self, auth_types=None, ca_certificates=None, config=None, endpoint=None, host_cloud_region=None, identity_endpoint=None, region_config=None, regions=None, storage_endpoint=None, type_=None, **unknown_fields):
         '''
-        auth_types : typing.Sequence<+T_co>[str]
-        ca_certificates : typing.Sequence<+T_co>[str]
-        config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        auth_types : typing.Sequence[str]
+        ca_certificates : typing.Sequence[str]
+        config : typing.Mapping[str, typing.Any]
         endpoint : str
         host_cloud_region : str
         identity_endpoint : str
-        region_config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
-        regions : typing.Sequence<+T_co>[~CloudRegion]<~CloudRegion>
+        region_config : typing.Mapping[str, typing.Any]
+        regions : typing.Sequence[~CloudRegion]
         storage_endpoint : str
         type_ : str
         '''
@@ -4571,9 +4571,9 @@ class CloudCredential(Type):
     _toPy = {'attrs': 'attrs', 'auth-type': 'auth_type', 'redacted': 'redacted'}
     def __init__(self, attrs=None, auth_type=None, redacted=None, **unknown_fields):
         '''
-        attrs : typing.Mapping<~KT, +VT_co>[str, str]
+        attrs : typing.Mapping[str, str]
         auth_type : str
-        redacted : typing.Sequence<+T_co>[str]
+        redacted : typing.Sequence[str]
         '''
         attrs_ = attrs
         auth_type_ = auth_type
@@ -4625,7 +4625,7 @@ class CloudCredentialArgs(Type):
     _toPy = {'credentials': 'credentials', 'include-secrets': 'include_secrets'}
     def __init__(self, credentials=None, include_secrets=None, **unknown_fields):
         '''
-        credentials : typing.Sequence<+T_co>[~CloudCredentialArg]<~CloudCredentialArg>
+        credentials : typing.Sequence[~CloudCredentialArg]
         include_secrets : bool
         '''
         credentials_ = [CloudCredentialArg.from_json(o) for o in credentials or []]
@@ -4673,7 +4673,7 @@ class CloudCredentialResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~CloudCredentialResult]<~CloudCredentialResult>
+        results : typing.Sequence[~CloudCredentialResult]
         '''
         results_ = [CloudCredentialResult.from_json(o) for o in results or []]
 
@@ -4691,10 +4691,10 @@ class CloudDetails(Type):
     _toPy = {'auth-types': 'auth_types', 'endpoint': 'endpoint', 'identity-endpoint': 'identity_endpoint', 'regions': 'regions', 'storage-endpoint': 'storage_endpoint', 'type': 'type_'}
     def __init__(self, auth_types=None, endpoint=None, identity_endpoint=None, regions=None, storage_endpoint=None, type_=None, **unknown_fields):
         '''
-        auth_types : typing.Sequence<+T_co>[str]
+        auth_types : typing.Sequence[str]
         endpoint : str
         identity_endpoint : str
-        regions : typing.Sequence<+T_co>[~CloudRegion]<~CloudRegion>
+        regions : typing.Sequence[~CloudRegion]
         storage_endpoint : str
         type_ : str
         '''
@@ -4817,7 +4817,7 @@ class CloudImageMetadataList(Type):
     _toPy = {'metadata': 'metadata'}
     def __init__(self, metadata=None, **unknown_fields):
         '''
-        metadata : typing.Sequence<+T_co>[~CloudImageMetadata]<~CloudImageMetadata>
+        metadata : typing.Sequence[~CloudImageMetadata]
         '''
         metadata_ = [CloudImageMetadata.from_json(o) for o in metadata or []]
 
@@ -4836,7 +4836,7 @@ class CloudInfo(Type):
     def __init__(self, clouddetails=None, users=None, **unknown_fields):
         '''
         clouddetails : CloudDetails
-        users : typing.Sequence<+T_co>[~CloudUserInfo]<~CloudUserInfo>
+        users : typing.Sequence[~CloudUserInfo]
         '''
         clouddetails_ = CloudDetails.from_json(clouddetails) if clouddetails else None
         users_ = [CloudUserInfo.from_json(o) for o in users or []]
@@ -4883,7 +4883,7 @@ class CloudInfoResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~CloudInfoResult]<~CloudInfoResult>
+        results : typing.Sequence[~CloudInfoResult]
         '''
         results_ = [CloudInfoResult.from_json(o) for o in results or []]
 
@@ -4931,7 +4931,7 @@ class CloudInstanceTypesConstraints(Type):
     _toPy = {'constraints': 'constraints'}
     def __init__(self, constraints=None, **unknown_fields):
         '''
-        constraints : typing.Sequence<+T_co>[~CloudInstanceTypesConstraint]<~CloudInstanceTypesConstraint>
+        constraints : typing.Sequence[~CloudInstanceTypesConstraint]
         '''
         constraints_ = [CloudInstanceTypesConstraint.from_json(o) for o in constraints or []]
 
@@ -5009,7 +5009,7 @@ class CloudResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~CloudResult]<~CloudResult>
+        results : typing.Sequence[~CloudResult]
         '''
         results_ = [CloudResult.from_json(o) for o in results or []]
 
@@ -5027,7 +5027,7 @@ class CloudSpec(Type):
     _toPy = {'cacertificates': 'cacertificates', 'credential': 'credential', 'endpoint': 'endpoint', 'identity-endpoint': 'identity_endpoint', 'name': 'name', 'region': 'region', 'storage-endpoint': 'storage_endpoint', 'type': 'type_'}
     def __init__(self, cacertificates=None, credential=None, endpoint=None, identity_endpoint=None, name=None, region=None, storage_endpoint=None, type_=None, **unknown_fields):
         '''
-        cacertificates : typing.Sequence<+T_co>[str]
+        cacertificates : typing.Sequence[str]
         credential : CloudCredential
         endpoint : str
         identity_endpoint : str
@@ -5111,7 +5111,7 @@ class CloudSpecResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~CloudSpecResult]<~CloudSpecResult>
+        results : typing.Sequence[~CloudSpecResult]
         '''
         results_ = [CloudSpecResult.from_json(o) for o in results or []]
 
@@ -5159,7 +5159,7 @@ class CloudsResult(Type):
     _toPy = {'clouds': 'clouds'}
     def __init__(self, clouds=None, **unknown_fields):
         '''
-        clouds : typing.Mapping<~KT, +VT_co>[str, ~Cloud]<~Cloud>
+        clouds : typing.Mapping[str, ~Cloud]
         '''
         clouds_ = clouds
 
@@ -5177,7 +5177,7 @@ class ConfigResult(Type):
     _toPy = {'config': 'config', 'error': 'error'}
     def __init__(self, config=None, error=None, **unknown_fields):
         '''
-        config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        config : typing.Mapping[str, typing.Any]
         error : Error
         '''
         config_ = config
@@ -5202,7 +5202,7 @@ class ConfigSettingsResult(Type):
     def __init__(self, error=None, settings=None, **unknown_fields):
         '''
         error : Error
-        settings : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        settings : typing.Mapping[str, typing.Any]
         '''
         error_ = Error.from_json(error) if error else None
         settings_ = settings
@@ -5225,7 +5225,7 @@ class ConfigSettingsResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ConfigSettingsResult]<~ConfigSettingsResult>
+        results : typing.Sequence[~ConfigSettingsResult]
         '''
         results_ = [ConfigSettingsResult.from_json(o) for o in results or []]
 
@@ -5318,7 +5318,7 @@ class ConstraintsResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ConstraintsResult]<~ConstraintsResult>
+        results : typing.Sequence[~ConstraintsResult]
         '''
         results_ = [ConstraintsResult.from_json(o) for o in results or []]
 
@@ -5339,16 +5339,16 @@ class ConsumeApplicationArg(Type):
         applicationofferdetails : ApplicationOfferDetails
         application_alias : str
         application_description : str
-        bindings : typing.Mapping<~KT, +VT_co>[str, str]
-        endpoints : typing.Sequence<+T_co>[~RemoteEndpoint]<~RemoteEndpoint>
+        bindings : typing.Mapping[str, str]
+        endpoints : typing.Sequence[~RemoteEndpoint]
         external_controller : ExternalControllerInfo
         macaroon : Macaroon
         offer_name : str
         offer_url : str
         offer_uuid : str
         source_model_tag : str
-        spaces : typing.Sequence<+T_co>[~RemoteSpace]<~RemoteSpace>
-        users : typing.Sequence<+T_co>[~OfferUserDetails]<~OfferUserDetails>
+        spaces : typing.Sequence[~RemoteSpace]
+        users : typing.Sequence[~OfferUserDetails]
         '''
         applicationofferdetails_ = ApplicationOfferDetails.from_json(applicationofferdetails) if applicationofferdetails else None
         application_alias_ = application_alias
@@ -5426,7 +5426,7 @@ class ConsumeApplicationArgs(Type):
     _toPy = {'args': 'args'}
     def __init__(self, args=None, **unknown_fields):
         '''
-        args : typing.Sequence<+T_co>[~ConsumeApplicationArg]<~ConsumeApplicationArg>
+        args : typing.Sequence[~ConsumeApplicationArg]
         '''
         args_ = [ConsumeApplicationArg.from_json(o) for o in args or []]
 
@@ -5468,7 +5468,7 @@ class ConsumeApplicationResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ConsumeApplicationResult]<~ConsumeApplicationResult>
+        results : typing.Sequence[~ConsumeApplicationResult]
         '''
         results_ = [ConsumeApplicationResult.from_json(o) for o in results or []]
 
@@ -5558,7 +5558,7 @@ class ConsumeOfferDetailsResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ConsumeOfferDetailsResult]<~ConsumeOfferDetailsResult>
+        results : typing.Sequence[~ConsumeOfferDetailsResult]
         '''
         results_ = [ConsumeOfferDetailsResult.from_json(o) for o in results or []]
 
@@ -5580,7 +5580,7 @@ class ContainerConfig(Type):
         apt_mirror : str
         apt_proxy : Settings
         authorized_keys : str
-        cloudinit_userdata : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        cloudinit_userdata : typing.Mapping[str, typing.Any]
         container_inherit_properties : str
         juju_proxy : Settings
         legacy_proxy : Settings
@@ -5678,7 +5678,7 @@ class ContainerManagerConfig(Type):
     _toPy = {'config': 'config'}
     def __init__(self, config=None, **unknown_fields):
         '''
-        config : typing.Mapping<~KT, +VT_co>[str, str]
+        config : typing.Mapping[str, str]
         '''
         config_ = config
 
@@ -5715,7 +5715,7 @@ class ContainerProfileResult(Type):
     def __init__(self, error=None, lxd_profiles=None, **unknown_fields):
         '''
         error : Error
-        lxd_profiles : typing.Sequence<+T_co>[~ContainerLXDProfile]<~ContainerLXDProfile>
+        lxd_profiles : typing.Sequence[~ContainerLXDProfile]
         '''
         error_ = Error.from_json(error) if error else None
         lxd_profiles_ = [ContainerLXDProfile.from_json(o) for o in lxd_profiles or []]
@@ -5738,7 +5738,7 @@ class ContainerProfileResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ContainerProfileResult]<~ContainerProfileResult>
+        results : typing.Sequence[~ContainerProfileResult]
         '''
         results_ = [ContainerProfileResult.from_json(o) for o in results or []]
 
@@ -5780,7 +5780,7 @@ class ControllerAPIInfoResult(Type):
     _toPy = {'addresses': 'addresses', 'cacert': 'cacert', 'error': 'error'}
     def __init__(self, addresses=None, cacert=None, error=None, **unknown_fields):
         '''
-        addresses : typing.Sequence<+T_co>[str]
+        addresses : typing.Sequence[str]
         cacert : str
         error : Error
         '''
@@ -5810,7 +5810,7 @@ class ControllerAPIInfoResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ControllerAPIInfoResult]<~ControllerAPIInfoResult>
+        results : typing.Sequence[~ControllerAPIInfoResult]
         '''
         results_ = [ControllerAPIInfoResult.from_json(o) for o in results or []]
 
@@ -5828,7 +5828,7 @@ class ControllerConfigResult(Type):
     _toPy = {'config': 'config'}
     def __init__(self, config=None, **unknown_fields):
         '''
-        config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        config : typing.Mapping[str, typing.Any]
         '''
         config_ = config
 
@@ -5846,7 +5846,7 @@ class ControllerConfigSet(Type):
     _toPy = {'config': 'config'}
     def __init__(self, config=None, **unknown_fields):
         '''
-        config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        config : typing.Mapping[str, typing.Any]
         '''
         config_ = config
 
@@ -5865,7 +5865,7 @@ class ControllerCredentialInfo(Type):
     def __init__(self, content=None, models=None, **unknown_fields):
         '''
         content : CredentialContent
-        models : typing.Sequence<+T_co>[~ModelAccess]<~ModelAccess>
+        models : typing.Sequence[~ModelAccess]
         '''
         content_ = CredentialContent.from_json(content) if content else None
         models_ = [ModelAccess.from_json(o) for o in models or []]
@@ -5936,7 +5936,7 @@ class ControllersChangeResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ControllersChangeResult]<~ControllersChangeResult>
+        results : typing.Sequence[~ControllersChangeResult]
         '''
         results_ = [ControllersChangeResult.from_json(o) for o in results or []]
 
@@ -5954,10 +5954,10 @@ class ControllersChanges(Type):
     _toPy = {'added': 'added', 'converted': 'converted', 'maintained': 'maintained', 'removed': 'removed'}
     def __init__(self, added=None, converted=None, maintained=None, removed=None, **unknown_fields):
         '''
-        added : typing.Sequence<+T_co>[str]
-        converted : typing.Sequence<+T_co>[str]
-        maintained : typing.Sequence<+T_co>[str]
-        removed : typing.Sequence<+T_co>[str]
+        added : typing.Sequence[str]
+        converted : typing.Sequence[str]
+        maintained : typing.Sequence[str]
+        removed : typing.Sequence[str]
         '''
         added_ = added
         converted_ = converted
@@ -5992,7 +5992,7 @@ class ControllersSpec(Type):
         '''
         constraints : Value
         num_controllers : int
-        placement : typing.Sequence<+T_co>[str]
+        placement : typing.Sequence[str]
         series : str
         '''
         constraints_ = Value.from_json(constraints) if constraints else None
@@ -6026,7 +6026,7 @@ class ControllersSpecs(Type):
     _toPy = {'specs': 'specs'}
     def __init__(self, specs=None, **unknown_fields):
         '''
-        specs : typing.Sequence<+T_co>[~ControllersSpec]<~ControllersSpec>
+        specs : typing.Sequence[~ControllersSpec]
         '''
         specs_ = [ControllersSpec.from_json(o) for o in specs or []]
 
@@ -6044,7 +6044,7 @@ class CreateSpaceParams(Type):
     _toPy = {'cidrs': 'cidrs', 'provider-id': 'provider_id', 'public': 'public', 'space-tag': 'space_tag'}
     def __init__(self, cidrs=None, provider_id=None, public=None, space_tag=None, **unknown_fields):
         '''
-        cidrs : typing.Sequence<+T_co>[str]
+        cidrs : typing.Sequence[str]
         provider_id : str
         public : bool
         space_tag : str
@@ -6080,7 +6080,7 @@ class CreateSpacesParams(Type):
     _toPy = {'spaces': 'spaces'}
     def __init__(self, spaces=None, **unknown_fields):
         '''
-        spaces : typing.Sequence<+T_co>[~CreateSpaceParams]<~CreateSpaceParams>
+        spaces : typing.Sequence[~CreateSpaceParams]
         '''
         spaces_ = [CreateSpaceParams.from_json(o) for o in spaces or []]
 
@@ -6098,7 +6098,7 @@ class CredentialContent(Type):
     _toPy = {'attrs': 'attrs', 'auth-type': 'auth_type', 'cloud': 'cloud', 'name': 'name', 'valid': 'valid'}
     def __init__(self, attrs=None, auth_type=None, cloud=None, name=None, valid=None, **unknown_fields):
         '''
-        attrs : typing.Mapping<~KT, +VT_co>[str, str]
+        attrs : typing.Mapping[str, str]
         auth_type : str
         cloud : str
         name : str
@@ -6164,7 +6164,7 @@ class CredentialContentResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~CredentialContentResult]<~CredentialContentResult>
+        results : typing.Sequence[~CredentialContentResult]
         '''
         results_ = [CredentialContentResult.from_json(o) for o in results or []]
 
@@ -6203,7 +6203,7 @@ class DeployerConnectionValues(Type):
     _toPy = {'api-addresses': 'api_addresses'}
     def __init__(self, api_addresses=None, **unknown_fields):
         '''
-        api_addresses : typing.Sequence<+T_co>[str]
+        api_addresses : typing.Sequence[str]
         '''
         api_addresses_ = api_addresses
 
@@ -6221,9 +6221,9 @@ class DestroyApplicationInfo(Type):
     _toPy = {'destroyed-storage': 'destroyed_storage', 'destroyed-units': 'destroyed_units', 'detached-storage': 'detached_storage'}
     def __init__(self, destroyed_storage=None, destroyed_units=None, detached_storage=None, **unknown_fields):
         '''
-        destroyed_storage : typing.Sequence<+T_co>[~Entity]<~Entity>
-        destroyed_units : typing.Sequence<+T_co>[~Entity]<~Entity>
-        detached_storage : typing.Sequence<+T_co>[~Entity]<~Entity>
+        destroyed_storage : typing.Sequence[~Entity]
+        destroyed_units : typing.Sequence[~Entity]
+        detached_storage : typing.Sequence[~Entity]
         '''
         destroyed_storage_ = [Entity.from_json(o) for o in destroyed_storage or []]
         destroyed_units_ = [Entity.from_json(o) for o in destroyed_units or []]
@@ -6252,7 +6252,7 @@ class DestroyApplicationOffers(Type):
     def __init__(self, force=None, offer_urls=None, **unknown_fields):
         '''
         force : bool
-        offer_urls : typing.Sequence<+T_co>[str]
+        offer_urls : typing.Sequence[str]
         '''
         force_ = force
         offer_urls_ = offer_urls
@@ -6335,7 +6335,7 @@ class DestroyApplicationResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~DestroyApplicationResult]<~DestroyApplicationResult>
+        results : typing.Sequence[~DestroyApplicationResult]
         '''
         results_ = [DestroyApplicationResult.from_json(o) for o in results or []]
 
@@ -6353,7 +6353,7 @@ class DestroyApplicationUnits(Type):
     _toPy = {'unit-names': 'unit_names'}
     def __init__(self, unit_names=None, **unknown_fields):
         '''
-        unit_names : typing.Sequence<+T_co>[str]
+        unit_names : typing.Sequence[str]
         '''
         unit_names_ = unit_names
 
@@ -6371,7 +6371,7 @@ class DestroyApplicationsParams(Type):
     _toPy = {'applications': 'applications'}
     def __init__(self, applications=None, **unknown_fields):
         '''
-        applications : typing.Sequence<+T_co>[~DestroyApplicationParams]<~DestroyApplicationParams>
+        applications : typing.Sequence[~DestroyApplicationParams]
         '''
         applications_ = [DestroyApplicationParams.from_json(o) for o in applications or []]
 
@@ -6419,7 +6419,7 @@ class DestroyConsumedApplicationsParams(Type):
     _toPy = {'applications': 'applications'}
     def __init__(self, applications=None, **unknown_fields):
         '''
-        applications : typing.Sequence<+T_co>[~DestroyConsumedApplicationParams]<~DestroyConsumedApplicationParams>
+        applications : typing.Sequence[~DestroyConsumedApplicationParams]
         '''
         applications_ = [DestroyConsumedApplicationParams.from_json(o) for o in applications or []]
 
@@ -6461,9 +6461,9 @@ class DestroyMachineInfo(Type):
     _toPy = {'destroyed-storage': 'destroyed_storage', 'destroyed-units': 'destroyed_units', 'detached-storage': 'detached_storage'}
     def __init__(self, destroyed_storage=None, destroyed_units=None, detached_storage=None, **unknown_fields):
         '''
-        destroyed_storage : typing.Sequence<+T_co>[~Entity]<~Entity>
-        destroyed_units : typing.Sequence<+T_co>[~Entity]<~Entity>
-        detached_storage : typing.Sequence<+T_co>[~Entity]<~Entity>
+        destroyed_storage : typing.Sequence[~Entity]
+        destroyed_units : typing.Sequence[~Entity]
+        detached_storage : typing.Sequence[~Entity]
         '''
         destroyed_storage_ = [Entity.from_json(o) for o in destroyed_storage or []]
         destroyed_units_ = [Entity.from_json(o) for o in destroyed_units or []]
@@ -6515,7 +6515,7 @@ class DestroyMachineResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~DestroyMachineResult]<~DestroyMachineResult>
+        results : typing.Sequence[~DestroyMachineResult]
         '''
         results_ = [DestroyMachineResult.from_json(o) for o in results or []]
 
@@ -6534,7 +6534,7 @@ class DestroyMachines(Type):
     def __init__(self, force=None, machine_names=None, **unknown_fields):
         '''
         force : bool
-        machine_names : typing.Sequence<+T_co>[str]
+        machine_names : typing.Sequence[str]
         '''
         force_ = force
         machine_names_ = machine_names
@@ -6559,7 +6559,7 @@ class DestroyMachinesParams(Type):
         '''
         force : bool
         keep : bool
-        machine_tags : typing.Sequence<+T_co>[str]
+        machine_tags : typing.Sequence[str]
         max_wait : int
         '''
         force_ = force
@@ -6629,7 +6629,7 @@ class DestroyModelsParams(Type):
     _toPy = {'models': 'models'}
     def __init__(self, models=None, **unknown_fields):
         '''
-        models : typing.Sequence<+T_co>[~DestroyModelParams]<~DestroyModelParams>
+        models : typing.Sequence[~DestroyModelParams]
         '''
         models_ = [DestroyModelParams.from_json(o) for o in models or []]
 
@@ -6647,7 +6647,7 @@ class DestroyRelation(Type):
     _toPy = {'endpoints': 'endpoints', 'force': 'force', 'max-wait': 'max_wait', 'relation-id': 'relation_id'}
     def __init__(self, endpoints=None, force=None, max_wait=None, relation_id=None, **unknown_fields):
         '''
-        endpoints : typing.Sequence<+T_co>[str]
+        endpoints : typing.Sequence[str]
         force : bool
         max_wait : int
         relation_id : int
@@ -6683,8 +6683,8 @@ class DestroyUnitInfo(Type):
     _toPy = {'destroyed-storage': 'destroyed_storage', 'detached-storage': 'detached_storage'}
     def __init__(self, destroyed_storage=None, detached_storage=None, **unknown_fields):
         '''
-        destroyed_storage : typing.Sequence<+T_co>[~Entity]<~Entity>
-        detached_storage : typing.Sequence<+T_co>[~Entity]<~Entity>
+        destroyed_storage : typing.Sequence[~Entity]
+        detached_storage : typing.Sequence[~Entity]
         '''
         destroyed_storage_ = [Entity.from_json(o) for o in destroyed_storage or []]
         detached_storage_ = [Entity.from_json(o) for o in detached_storage or []]
@@ -6767,7 +6767,7 @@ class DestroyUnitResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~DestroyUnitResult]<~DestroyUnitResult>
+        results : typing.Sequence[~DestroyUnitResult]
         '''
         results_ = [DestroyUnitResult.from_json(o) for o in results or []]
 
@@ -6785,7 +6785,7 @@ class DestroyUnitsParams(Type):
     _toPy = {'units': 'units'}
     def __init__(self, units=None, **unknown_fields):
         '''
-        units : typing.Sequence<+T_co>[~DestroyUnitParams]<~DestroyUnitParams>
+        units : typing.Sequence[~DestroyUnitParams]
         '''
         units_ = [DestroyUnitParams.from_json(o) for o in units or []]
 
@@ -6803,7 +6803,7 @@ class DetailedStatus(Type):
     _toPy = {'data': 'data', 'err': 'err', 'info': 'info', 'kind': 'kind', 'life': 'life', 'since': 'since', 'status': 'status', 'version': 'version'}
     def __init__(self, data=None, err=None, info=None, kind=None, life=None, since=None, status=None, version=None, **unknown_fields):
         '''
-        data : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        data : typing.Mapping[str, typing.Any]
         err : Error
         info : str
         kind : str
@@ -6893,7 +6893,7 @@ class DiscoverSpacesResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ProviderSpace]<~ProviderSpace>
+        results : typing.Sequence[~ProviderSpace]
         '''
         results_ = [ProviderSpace.from_json(o) for o in results or []]
 
@@ -6912,7 +6912,7 @@ class DistributionGroupResult(Type):
     def __init__(self, error=None, result=None, **unknown_fields):
         '''
         error : Error
-        result : typing.Sequence<+T_co>[str]
+        result : typing.Sequence[str]
         '''
         error_ = Error.from_json(error) if error else None
         result_ = result
@@ -6935,7 +6935,7 @@ class DistributionGroupResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~DistributionGroupResult]<~DistributionGroupResult>
+        results : typing.Sequence[~DistributionGroupResult]
         '''
         results_ = [DistributionGroupResult.from_json(o) for o in results or []]
 
@@ -6953,7 +6953,7 @@ class DumpModelRequest(Type):
     _toPy = {'entities': 'entities', 'simplified': 'simplified'}
     def __init__(self, entities=None, simplified=None, **unknown_fields):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
+        entities : typing.Sequence[~Entity]
         simplified : bool
         '''
         entities_ = [Entity.from_json(o) for o in entities or []]
@@ -7067,7 +7067,7 @@ class Entities(Type):
     _toPy = {'entities': 'entities'}
     def __init__(self, entities=None, **unknown_fields):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
+        entities : typing.Sequence[~Entity]
         '''
         entities_ = [Entity.from_json(o) for o in entities or []]
 
@@ -7085,7 +7085,7 @@ class EntitiesCharmURL(Type):
     _toPy = {'entities': 'entities'}
     def __init__(self, entities=None, **unknown_fields):
         '''
-        entities : typing.Sequence<+T_co>[~EntityCharmURL]<~EntityCharmURL>
+        entities : typing.Sequence[~EntityCharmURL]
         '''
         entities_ = [EntityCharmURL.from_json(o) for o in entities or []]
 
@@ -7103,7 +7103,7 @@ class EntitiesPortRanges(Type):
     _toPy = {'entities': 'entities'}
     def __init__(self, entities=None, **unknown_fields):
         '''
-        entities : typing.Sequence<+T_co>[~EntityPortRange]<~EntityPortRange>
+        entities : typing.Sequence[~EntityPortRange]
         '''
         entities_ = [EntityPortRange.from_json(o) for o in entities or []]
 
@@ -7121,7 +7121,7 @@ class EntitiesResult(Type):
     _toPy = {'entities': 'entities', 'error': 'error'}
     def __init__(self, entities=None, error=None, **unknown_fields):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
+        entities : typing.Sequence[~Entity]
         error : Error
         '''
         entities_ = [Entity.from_json(o) for o in entities or []]
@@ -7145,7 +7145,7 @@ class EntitiesResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~EntitiesResult]<~EntitiesResult>
+        results : typing.Sequence[~EntitiesResult]
         '''
         results_ = [EntitiesResult.from_json(o) for o in results or []]
 
@@ -7163,7 +7163,7 @@ class EntitiesVersion(Type):
     _toPy = {'agent-tools': 'agent_tools'}
     def __init__(self, agent_tools=None, **unknown_fields):
         '''
-        agent_tools : typing.Sequence<+T_co>[~EntityVersion]<~EntityVersion>
+        agent_tools : typing.Sequence[~EntityVersion]
         '''
         agent_tools_ = [EntityVersion.from_json(o) for o in agent_tools or []]
 
@@ -7181,7 +7181,7 @@ class EntitiesWatchResult(Type):
     _toPy = {'changes': 'changes', 'error': 'error', 'watcher-id': 'watcher_id'}
     def __init__(self, changes=None, error=None, watcher_id=None, **unknown_fields):
         '''
-        changes : typing.Sequence<+T_co>[str]
+        changes : typing.Sequence[str]
         error : Error
         watcher_id : str
         '''
@@ -7229,7 +7229,7 @@ class EntityAnnotations(Type):
     _toPy = {'annotations': 'annotations', 'entity': 'entity'}
     def __init__(self, annotations=None, entity=None, **unknown_fields):
         '''
-        annotations : typing.Mapping<~KT, +VT_co>[str, str]
+        annotations : typing.Mapping[str, str]
         entity : str
         '''
         annotations_ = annotations
@@ -7301,7 +7301,7 @@ class EntityMacaroonArgs(Type):
     _toPy = {'Args': 'args'}
     def __init__(self, args=None, **unknown_fields):
         '''
-        args : typing.Sequence<+T_co>[~EntityMacaroonArg]<~EntityMacaroonArg>
+        args : typing.Sequence[~EntityMacaroonArg]
         '''
         args_ = [EntityMacaroonArg.from_json(o) for o in args or []]
 
@@ -7320,7 +7320,7 @@ class EntityMetrics(Type):
     def __init__(self, error=None, metrics=None, **unknown_fields):
         '''
         error : Error
-        metrics : typing.Sequence<+T_co>[~MetricResult]<~MetricResult>
+        metrics : typing.Sequence[~MetricResult]
         '''
         error_ = Error.from_json(error) if error else None
         metrics_ = [MetricResult.from_json(o) for o in metrics or []]
@@ -7367,7 +7367,7 @@ class EntityPasswords(Type):
     _toPy = {'changes': 'changes'}
     def __init__(self, changes=None, **unknown_fields):
         '''
-        changes : typing.Sequence<+T_co>[~EntityPassword]<~EntityPassword>
+        changes : typing.Sequence[~EntityPassword]
         '''
         changes_ = [EntityPassword.from_json(o) for o in changes or []]
 
@@ -7421,7 +7421,7 @@ class EntityStatus(Type):
     _toPy = {'data': 'data', 'info': 'info', 'since': 'since', 'status': 'status'}
     def __init__(self, data=None, info=None, since=None, status=None, **unknown_fields):
         '''
-        data : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        data : typing.Mapping[str, typing.Any]
         info : str
         since : str
         status : str
@@ -7457,7 +7457,7 @@ class EntityStatusArgs(Type):
     _toPy = {'data': 'data', 'info': 'info', 'status': 'status', 'tag': 'tag'}
     def __init__(self, data=None, info=None, status=None, tag=None, **unknown_fields):
         '''
-        data : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        data : typing.Mapping[str, typing.Any]
         info : str
         status : str
         tag : str
@@ -7565,7 +7565,7 @@ class EntityWorkloadVersions(Type):
     _toPy = {'entities': 'entities'}
     def __init__(self, entities=None, **unknown_fields):
         '''
-        entities : typing.Sequence<+T_co>[~EntityWorkloadVersion]<~EntityWorkloadVersion>
+        entities : typing.Sequence[~EntityWorkloadVersion]
         '''
         entities_ = [EntityWorkloadVersion.from_json(o) for o in entities or []]
 
@@ -7583,7 +7583,7 @@ class EnvListArgs(Type):
     _toPy = {'patterns': 'patterns'}
     def __init__(self, patterns=None, **unknown_fields):
         '''
-        patterns : typing.Sequence<+T_co>[str]
+        patterns : typing.Sequence[str]
         '''
         patterns_ = patterns
 
@@ -7601,7 +7601,7 @@ class EnvListResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~Payload]<~Payload>
+        results : typing.Sequence[~Payload]
         '''
         results_ = [Payload.from_json(o) for o in results or []]
 
@@ -7620,7 +7620,7 @@ class Error(Type):
     def __init__(self, code=None, info=None, message=None, **unknown_fields):
         '''
         code : str
-        info : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        info : typing.Mapping[str, typing.Any]
         message : str
         '''
         code_ = code
@@ -7691,7 +7691,7 @@ class ErrorResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        results : typing.Sequence[~ErrorResult]
         '''
         results_ = [ErrorResult.from_json(o) for o in results or []]
 
@@ -7709,7 +7709,7 @@ class ExternalControllerInfo(Type):
     _toPy = {'addrs': 'addrs', 'ca-cert': 'ca_cert', 'controller-alias': 'controller_alias', 'controller-tag': 'controller_tag'}
     def __init__(self, addrs=None, ca_cert=None, controller_alias=None, controller_tag=None, **unknown_fields):
         '''
-        addrs : typing.Sequence<+T_co>[str]
+        addrs : typing.Sequence[str]
         ca_cert : str
         controller_alias : str
         controller_tag : str
@@ -7769,7 +7769,7 @@ class ExternalControllerInfoResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ExternalControllerInfoResult]<~ExternalControllerInfoResult>
+        results : typing.Sequence[~ExternalControllerInfoResult]
         '''
         results_ = [ExternalControllerInfoResult.from_json(o) for o in results or []]
 
@@ -7811,7 +7811,7 @@ class FanConfigResult(Type):
     _toPy = {'fans': 'fans'}
     def __init__(self, fans=None, **unknown_fields):
         '''
-        fans : typing.Sequence<+T_co>[~FanConfigEntry]<~FanConfigEntry>
+        fans : typing.Sequence[~FanConfigEntry]
         '''
         fans_ = [FanConfigEntry.from_json(o) for o in fans or []]
 
@@ -8027,7 +8027,7 @@ class FilesystemAttachmentParamsResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~FilesystemAttachmentParamsResult]<~FilesystemAttachmentParamsResult>
+        results : typing.Sequence[~FilesystemAttachmentParamsResult]
         '''
         results_ = [FilesystemAttachmentParamsResult.from_json(o) for o in results or []]
 
@@ -8069,7 +8069,7 @@ class FilesystemAttachmentResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~FilesystemAttachmentResult]<~FilesystemAttachmentResult>
+        results : typing.Sequence[~FilesystemAttachmentResult]
         '''
         results_ = [FilesystemAttachmentResult.from_json(o) for o in results or []]
 
@@ -8087,7 +8087,7 @@ class FilesystemAttachments(Type):
     _toPy = {'filesystem-attachments': 'filesystem_attachments'}
     def __init__(self, filesystem_attachments=None, **unknown_fields):
         '''
-        filesystem_attachments : typing.Sequence<+T_co>[~FilesystemAttachment]<~FilesystemAttachment>
+        filesystem_attachments : typing.Sequence[~FilesystemAttachment]
         '''
         filesystem_attachments_ = [FilesystemAttachment.from_json(o) for o in filesystem_attachments or []]
 
@@ -8108,10 +8108,10 @@ class FilesystemDetails(Type):
         filesystem_tag : str
         info : FilesystemInfo
         life : str
-        machine_attachments : typing.Mapping<~KT, +VT_co>[str, ~FilesystemAttachmentDetails]<~FilesystemAttachmentDetails>
+        machine_attachments : typing.Mapping[str, ~FilesystemAttachmentDetails]
         status : EntityStatus
         storage : StorageDetails
-        unit_attachments : typing.Mapping<~KT, +VT_co>[str, ~FilesystemAttachmentDetails]<~FilesystemAttachmentDetails>
+        unit_attachments : typing.Mapping[str, ~FilesystemAttachmentDetails]
         volume_tag : str
         '''
         filesystem_tag_ = filesystem_tag
@@ -8166,7 +8166,7 @@ class FilesystemDetailsListResult(Type):
     def __init__(self, error=None, result=None, **unknown_fields):
         '''
         error : Error
-        result : typing.Sequence<+T_co>[~FilesystemDetails]<~FilesystemDetails>
+        result : typing.Sequence[~FilesystemDetails]
         '''
         error_ = Error.from_json(error) if error else None
         result_ = [FilesystemDetails.from_json(o) for o in result or []]
@@ -8189,7 +8189,7 @@ class FilesystemDetailsListResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~FilesystemDetailsListResult]<~FilesystemDetailsListResult>
+        results : typing.Sequence[~FilesystemDetailsListResult]
         '''
         results_ = [FilesystemDetailsListResult.from_json(o) for o in results or []]
 
@@ -8207,7 +8207,7 @@ class FilesystemFilter(Type):
     _toPy = {'machines': 'machines'}
     def __init__(self, machines=None, **unknown_fields):
         '''
-        machines : typing.Sequence<+T_co>[str]
+        machines : typing.Sequence[str]
         '''
         machines_ = machines
 
@@ -8225,7 +8225,7 @@ class FilesystemFilters(Type):
     _toPy = {'filters': 'filters'}
     def __init__(self, filters=None, **unknown_fields):
         '''
-        filters : typing.Sequence<+T_co>[~FilesystemFilter]<~FilesystemFilter>
+        filters : typing.Sequence[~FilesystemFilter]
         '''
         filters_ = [FilesystemFilter.from_json(o) for o in filters or []]
 
@@ -8274,11 +8274,11 @@ class FilesystemParams(Type):
     def __init__(self, attachment=None, attributes=None, filesystem_tag=None, provider=None, size=None, tags=None, volume_tag=None, **unknown_fields):
         '''
         attachment : FilesystemAttachmentParams
-        attributes : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        attributes : typing.Mapping[str, typing.Any]
         filesystem_tag : str
         provider : str
         size : int
-        tags : typing.Mapping<~KT, +VT_co>[str, str]
+        tags : typing.Mapping[str, str]
         volume_tag : str
         '''
         attachment_ = FilesystemAttachmentParams.from_json(attachment) if attachment else None
@@ -8351,7 +8351,7 @@ class FilesystemParamsResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~FilesystemParamsResult]<~FilesystemParamsResult>
+        results : typing.Sequence[~FilesystemParamsResult]
         '''
         results_ = [FilesystemParamsResult.from_json(o) for o in results or []]
 
@@ -8393,7 +8393,7 @@ class FilesystemResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~FilesystemResult]<~FilesystemResult>
+        results : typing.Sequence[~FilesystemResult]
         '''
         results_ = [FilesystemResult.from_json(o) for o in results or []]
 
@@ -8411,7 +8411,7 @@ class Filesystems(Type):
     _toPy = {'filesystems': 'filesystems'}
     def __init__(self, filesystems=None, **unknown_fields):
         '''
-        filesystems : typing.Sequence<+T_co>[~Filesystem]<~Filesystem>
+        filesystems : typing.Sequence[~Filesystem]
         '''
         filesystems_ = [Filesystem.from_json(o) for o in filesystems or []]
 
@@ -8429,7 +8429,7 @@ class FindActionsByNames(Type):
     _toPy = {'names': 'names'}
     def __init__(self, names=None, **unknown_fields):
         '''
-        names : typing.Sequence<+T_co>[str]
+        names : typing.Sequence[str]
         '''
         names_ = names
 
@@ -8447,7 +8447,7 @@ class FindTags(Type):
     _toPy = {'prefixes': 'prefixes'}
     def __init__(self, prefixes=None, **unknown_fields):
         '''
-        prefixes : typing.Sequence<+T_co>[str]
+        prefixes : typing.Sequence[str]
         '''
         prefixes_ = prefixes
 
@@ -8465,7 +8465,7 @@ class FindTagsResults(Type):
     _toPy = {'matches': 'matches'}
     def __init__(self, matches=None, **unknown_fields):
         '''
-        matches : typing.Sequence<+T_co>[~Entity]<~Entity>
+        matches : typing.Sequence[~Entity]
         '''
         matches_ = [Entity.from_json(o) for o in matches or []]
 
@@ -8532,7 +8532,7 @@ class FindToolsResult(Type):
     def __init__(self, error=None, list_=None, **unknown_fields):
         '''
         error : Error
-        list_ : typing.Sequence<+T_co>[~Tools]<~Tools>
+        list_ : typing.Sequence[~Tools]
         '''
         error_ = Error.from_json(error) if error else None
         list__ = [Tools.from_json(o) for o in list_ or []]
@@ -8556,7 +8556,7 @@ class FirewallRule(Type):
     def __init__(self, known_service=None, whitelist_cidrs=None, **unknown_fields):
         '''
         known_service : str
-        whitelist_cidrs : typing.Sequence<+T_co>[str]
+        whitelist_cidrs : typing.Sequence[str]
         '''
         known_service_ = known_service
         whitelist_cidrs_ = whitelist_cidrs
@@ -8579,7 +8579,7 @@ class FirewallRuleArgs(Type):
     _toPy = {'args': 'args'}
     def __init__(self, args=None, **unknown_fields):
         '''
-        args : typing.Sequence<+T_co>[~FirewallRule]<~FirewallRule>
+        args : typing.Sequence[~FirewallRule]
         '''
         args_ = [FirewallRule.from_json(o) for o in args or []]
 
@@ -8597,14 +8597,14 @@ class FullStatus(Type):
     _toPy = {'applications': 'applications', 'branches': 'branches', 'controller-timestamp': 'controller_timestamp', 'machines': 'machines', 'model': 'model', 'offers': 'offers', 'relations': 'relations', 'remote-applications': 'remote_applications'}
     def __init__(self, applications=None, branches=None, controller_timestamp=None, machines=None, model=None, offers=None, relations=None, remote_applications=None, **unknown_fields):
         '''
-        applications : typing.Mapping<~KT, +VT_co>[str, ~ApplicationStatus]<~ApplicationStatus>
-        branches : typing.Mapping<~KT, +VT_co>[str, ~BranchStatus]<~BranchStatus>
+        applications : typing.Mapping[str, ~ApplicationStatus]
+        branches : typing.Mapping[str, ~BranchStatus]
         controller_timestamp : str
-        machines : typing.Mapping<~KT, +VT_co>[str, ~MachineStatus]<~MachineStatus>
+        machines : typing.Mapping[str, ~MachineStatus]
         model : ModelStatusInfo
-        offers : typing.Mapping<~KT, +VT_co>[str, ~ApplicationOfferStatus]<~ApplicationOfferStatus>
-        relations : typing.Sequence<+T_co>[~RelationStatus]<~RelationStatus>
-        remote_applications : typing.Mapping<~KT, +VT_co>[str, ~RemoteApplicationStatus]<~RemoteApplicationStatus>
+        offers : typing.Mapping[str, ~ApplicationOfferStatus]
+        relations : typing.Sequence[~RelationStatus]
+        remote_applications : typing.Mapping[str, ~RemoteApplicationStatus]
         '''
         applications_ = applications
         branches_ = branches
@@ -8657,7 +8657,7 @@ class Generation(Type):
     _toPy = {'applications': 'applications', 'branch': 'branch', 'created': 'created', 'created-by': 'created_by'}
     def __init__(self, applications=None, branch=None, created=None, created_by=None, **unknown_fields):
         '''
-        applications : typing.Sequence<+T_co>[~GenerationApplication]<~GenerationApplication>
+        applications : typing.Sequence[~GenerationApplication]
         branch : str
         created : int
         created_by : str
@@ -8694,10 +8694,10 @@ class GenerationApplication(Type):
     def __init__(self, application=None, config=None, pending=None, progress=None, tracking=None, **unknown_fields):
         '''
         application : str
-        config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
-        pending : typing.Sequence<+T_co>[str]
+        config : typing.Mapping[str, typing.Any]
+        pending : typing.Sequence[str]
         progress : str
-        tracking : typing.Sequence<+T_co>[str]
+        tracking : typing.Sequence[str]
         '''
         application_ = application
         config_ = config
@@ -8736,7 +8736,7 @@ class GenerationResults(Type):
     def __init__(self, error=None, generations=None, **unknown_fields):
         '''
         error : Error
-        generations : typing.Sequence<+T_co>[~Generation]<~Generation>
+        generations : typing.Sequence[~Generation]
         '''
         error_ = Error.from_json(error) if error else None
         generations_ = [Generation.from_json(o) for o in generations or []]
@@ -8795,7 +8795,7 @@ class GetLeadershipSettingsBulkResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~GetLeadershipSettingsResult]<~GetLeadershipSettingsResult>
+        results : typing.Sequence[~GetLeadershipSettingsResult]
         '''
         results_ = [GetLeadershipSettingsResult.from_json(o) for o in results or []]
 
@@ -8814,7 +8814,7 @@ class GetLeadershipSettingsResult(Type):
     def __init__(self, error=None, settings=None, **unknown_fields):
         '''
         error : Error
-        settings : typing.Mapping<~KT, +VT_co>[str, str]
+        settings : typing.Mapping[str, str]
         '''
         error_ = Error.from_json(error) if error else None
         settings_ = settings
@@ -8855,7 +8855,7 @@ class GetTokenArgs(Type):
     _toPy = {'Args': 'args'}
     def __init__(self, args=None, **unknown_fields):
         '''
-        args : typing.Sequence<+T_co>[~GetTokenArg]<~GetTokenArg>
+        args : typing.Sequence[~GetTokenArg]
         '''
         args_ = [GetTokenArg.from_json(o) for o in args or []]
 
@@ -8873,8 +8873,8 @@ class GoalState(Type):
     _toPy = {'relations': 'relations', 'units': 'units'}
     def __init__(self, relations=None, units=None, **unknown_fields):
         '''
-        relations : typing.Mapping<~KT, +VT_co>[str, typing.Any]
-        units : typing.Mapping<~KT, +VT_co>[str, ~GoalStateStatus]<~GoalStateStatus>
+        relations : typing.Mapping[str, typing.Any]
+        units : typing.Mapping[str, ~GoalStateStatus]
         '''
         relations_ = relations
         units_ = units
@@ -8921,7 +8921,7 @@ class GoalStateResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~GoalStateResult]<~GoalStateResult>
+        results : typing.Sequence[~GoalStateResult]
         '''
         results_ = [GoalStateResult.from_json(o) for o in results or []]
 
@@ -9000,7 +9000,7 @@ class HardwareCharacteristics(Type):
         mem : int
         root_disk : int
         root_disk_source : str
-        tags : typing.Sequence<+T_co>[str]
+        tags : typing.Sequence[str]
         '''
         arch_ = arch
         availability_zone_ = availability_zone
@@ -9054,7 +9054,7 @@ class History(Type):
     def __init__(self, error=None, statuses=None, **unknown_fields):
         '''
         error : Error
-        statuses : typing.Sequence<+T_co>[~DetailedStatus]<~DetailedStatus>
+        statuses : typing.Sequence[~DetailedStatus]
         '''
         error_ = Error.from_json(error) if error else None
         statuses_ = [DetailedStatus.from_json(o) for o in statuses or []]
@@ -9078,7 +9078,7 @@ class HostNetworkChange(Type):
     def __init__(self, error=None, new_bridges=None, reconfigure_delay=None, **unknown_fields):
         '''
         error : Error
-        new_bridges : typing.Sequence<+T_co>[~DeviceBridgeInfo]<~DeviceBridgeInfo>
+        new_bridges : typing.Sequence[~DeviceBridgeInfo]
         reconfigure_delay : int
         '''
         error_ = Error.from_json(error) if error else None
@@ -9107,7 +9107,7 @@ class HostNetworkChangeResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~HostNetworkChange]<~HostNetworkChange>
+        results : typing.Sequence[~HostNetworkChange]
         '''
         results_ = [HostNetworkChange.from_json(o) for o in results or []]
 
@@ -9180,7 +9180,7 @@ class HostedModelConfig(Type):
     def __init__(self, cloud_spec=None, config=None, error=None, name=None, owner=None, **unknown_fields):
         '''
         cloud_spec : CloudSpec
-        config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        config : typing.Mapping[str, typing.Any]
         error : Error
         name : str
         owner : str
@@ -9221,7 +9221,7 @@ class HostedModelConfigsResults(Type):
     _toPy = {'models': 'models'}
     def __init__(self, models=None, **unknown_fields):
         '''
-        models : typing.Sequence<+T_co>[~HostedModelConfig]<~HostedModelConfig>
+        models : typing.Sequence[~HostedModelConfig]
         '''
         models_ = [HostedModelConfig.from_json(o) for o in models or []]
 
@@ -9239,7 +9239,7 @@ class ImageFilterParams(Type):
     _toPy = {'images': 'images'}
     def __init__(self, images=None, **unknown_fields):
         '''
-        images : typing.Sequence<+T_co>[~ImageSpec]<~ImageSpec>
+        images : typing.Sequence[~ImageSpec]
         '''
         images_ = [ImageSpec.from_json(o) for o in images or []]
 
@@ -9299,10 +9299,10 @@ class ImageMetadataFilter(Type):
     _toPy = {'arches': 'arches', 'region': 'region', 'root-storage-type': 'root_storage_type', 'series': 'series', 'stream': 'stream', 'virt-type': 'virt_type'}
     def __init__(self, arches=None, region=None, root_storage_type=None, series=None, stream=None, virt_type=None, **unknown_fields):
         '''
-        arches : typing.Sequence<+T_co>[str]
+        arches : typing.Sequence[str]
         region : str
         root_storage_type : str
-        series : typing.Sequence<+T_co>[str]
+        series : typing.Sequence[str]
         stream : str
         virt_type : str
         '''
@@ -9455,7 +9455,7 @@ class ImportStorageResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ImportStorageResult]<~ImportStorageResult>
+        results : typing.Sequence[~ImportStorageResult]
         '''
         results_ = [ImportStorageResult.from_json(o) for o in results or []]
 
@@ -9475,8 +9475,8 @@ class IngressNetworksChangeEvent(Type):
         '''
         application_token : str
         ingress_required : bool
-        macaroons : typing.Sequence<+T_co>[~Macaroon]<~Macaroon>
-        networks : typing.Sequence<+T_co>[str]
+        macaroons : typing.Sequence[~Macaroon]
+        networks : typing.Sequence[str]
         relation_token : str
         '''
         application_token_ = application_token
@@ -9515,7 +9515,7 @@ class IngressNetworksChanges(Type):
     _toPy = {'changes': 'changes'}
     def __init__(self, changes=None, **unknown_fields):
         '''
-        changes : typing.Sequence<+T_co>[~IngressNetworksChangeEvent]<~IngressNetworksChangeEvent>
+        changes : typing.Sequence[~IngressNetworksChangeEvent]
         '''
         changes_ = [IngressNetworksChangeEvent.from_json(o) for o in changes or []]
 
@@ -9533,7 +9533,7 @@ class InitiateMigrationArgs(Type):
     _toPy = {'specs': 'specs'}
     def __init__(self, specs=None, **unknown_fields):
         '''
-        specs : typing.Sequence<+T_co>[~MigrationSpec]<~MigrationSpec>
+        specs : typing.Sequence[~MigrationSpec]
         '''
         specs_ = [MigrationSpec.from_json(o) for o in specs or []]
 
@@ -9581,7 +9581,7 @@ class InitiateMigrationResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~InitiateMigrationResult]<~InitiateMigrationResult>
+        results : typing.Sequence[~InitiateMigrationResult]
         '''
         results_ = [InitiateMigrationResult.from_json(o) for o in results or []]
 
@@ -9600,14 +9600,14 @@ class InstanceInfo(Type):
     def __init__(self, characteristics=None, charm_profiles=None, display_name=None, instance_id=None, network_config=None, nonce=None, tag=None, volume_attachments=None, volumes=None, **unknown_fields):
         '''
         characteristics : HardwareCharacteristics
-        charm_profiles : typing.Sequence<+T_co>[str]
+        charm_profiles : typing.Sequence[str]
         display_name : str
         instance_id : str
-        network_config : typing.Sequence<+T_co>[~NetworkConfig]<~NetworkConfig>
+        network_config : typing.Sequence[~NetworkConfig]
         nonce : str
         tag : str
-        volume_attachments : typing.Mapping<~KT, +VT_co>[str, ~VolumeAttachmentInfo]<~VolumeAttachmentInfo>
-        volumes : typing.Sequence<+T_co>[~Volume]<~Volume>
+        volume_attachments : typing.Mapping[str, ~VolumeAttachmentInfo]
+        volumes : typing.Sequence[~Volume]
         '''
         characteristics_ = HardwareCharacteristics.from_json(characteristics) if characteristics else None
         charm_profiles_ = charm_profiles
@@ -9665,7 +9665,7 @@ class InstanceType(Type):
     _toPy = {'arches': 'arches', 'cost': 'cost', 'cpu-cores': 'cpu_cores', 'deprecated': 'deprecated', 'memory': 'memory', 'name': 'name', 'root-disk': 'root_disk', 'virt-type': 'virt_type'}
     def __init__(self, arches=None, cost=None, cpu_cores=None, deprecated=None, memory=None, name=None, root_disk=None, virt_type=None, **unknown_fields):
         '''
-        arches : typing.Sequence<+T_co>[str]
+        arches : typing.Sequence[str]
         cost : int
         cpu_cores : int
         deprecated : bool
@@ -9729,7 +9729,7 @@ class InstanceTypesResult(Type):
         cost_divisor : int
         cost_unit : str
         error : Error
-        instance_types : typing.Sequence<+T_co>[~InstanceType]<~InstanceType>
+        instance_types : typing.Sequence[~InstanceType]
         '''
         cost_currency_ = cost_currency
         cost_divisor_ = cost_divisor
@@ -9767,7 +9767,7 @@ class InstanceTypesResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~InstanceTypesResult]<~InstanceTypesResult>
+        results : typing.Sequence[~InstanceTypesResult]
         '''
         results_ = [InstanceTypesResult.from_json(o) for o in results or []]
 
@@ -9785,7 +9785,7 @@ class InstancesInfo(Type):
     _toPy = {'machines': 'machines'}
     def __init__(self, machines=None, **unknown_fields):
         '''
-        machines : typing.Sequence<+T_co>[~InstanceInfo]<~InstanceInfo>
+        machines : typing.Sequence[~InstanceInfo]
         '''
         machines_ = [InstanceInfo.from_json(o) for o in machines or []]
 
@@ -9827,7 +9827,7 @@ class IntResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~IntResult]<~IntResult>
+        results : typing.Sequence[~IntResult]
         '''
         results_ = [IntResult.from_json(o) for o in results or []]
 
@@ -9930,7 +9930,7 @@ class JobsResult(Type):
     def __init__(self, error=None, jobs=None, **unknown_fields):
         '''
         error : Error
-        jobs : typing.Sequence<+T_co>[str]
+        jobs : typing.Sequence[str]
         '''
         error_ = Error.from_json(error) if error else None
         jobs_ = jobs
@@ -9953,7 +9953,7 @@ class JobsResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~JobsResult]<~JobsResult>
+        results : typing.Sequence[~JobsResult]
         '''
         results_ = [JobsResult.from_json(o) for o in results or []]
 
@@ -9971,7 +9971,7 @@ class KnownServiceArgs(Type):
     _toPy = {'known-services': 'known_services'}
     def __init__(self, known_services=None, **unknown_fields):
         '''
-        known_services : typing.Sequence<+T_co>[str]
+        known_services : typing.Sequence[str]
         '''
         known_services_ = known_services
 
@@ -10013,7 +10013,7 @@ class KubernetesDeviceParams(Type):
     _toPy = {'Attributes': 'attributes', 'Count': 'count', 'Type': 'type_'}
     def __init__(self, attributes=None, count=None, type_=None, **unknown_fields):
         '''
-        attributes : typing.Mapping<~KT, +VT_co>[str, str]
+        attributes : typing.Mapping[str, str]
         count : int
         type_ : str
         '''
@@ -10073,7 +10073,7 @@ class KubernetesFilesystemInfo(Type):
     _toPy = {'data': 'data', 'filesystem-id': 'filesystem_id', 'info': 'info', 'mount-point': 'mount_point', 'pool': 'pool', 'read-only': 'read_only', 'size': 'size', 'status': 'status', 'storagename': 'storagename', 'volume': 'volume'}
     def __init__(self, data=None, filesystem_id=None, info=None, mount_point=None, pool=None, read_only=None, size=None, status=None, storagename=None, volume=None, **unknown_fields):
         '''
-        data : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        data : typing.Mapping[str, typing.Any]
         filesystem_id : str
         info : str
         mount_point : str
@@ -10146,11 +10146,11 @@ class KubernetesFilesystemParams(Type):
     def __init__(self, attachment=None, attributes=None, provider=None, size=None, storagename=None, tags=None, **unknown_fields):
         '''
         attachment : KubernetesFilesystemAttachmentParams
-        attributes : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        attributes : typing.Mapping[str, typing.Any]
         provider : str
         size : int
         storagename : str
-        tags : typing.Mapping<~KT, +VT_co>[str, str]
+        tags : typing.Mapping[str, str]
         '''
         attachment_ = KubernetesFilesystemAttachmentParams.from_json(attachment) if attachment else None
         attributes_ = attributes
@@ -10195,11 +10195,11 @@ class KubernetesProvisioningInfo(Type):
         '''
         constraints : Value
         deployment_info : KubernetesDeploymentInfo
-        devices : typing.Sequence<+T_co>[~KubernetesDeviceParams]<~KubernetesDeviceParams>
-        filesystems : typing.Sequence<+T_co>[~KubernetesFilesystemParams]<~KubernetesFilesystemParams>
+        devices : typing.Sequence[~KubernetesDeviceParams]
+        filesystems : typing.Sequence[~KubernetesFilesystemParams]
         pod_spec : str
-        tags : typing.Mapping<~KT, +VT_co>[str, str]
-        volumes : typing.Sequence<+T_co>[~KubernetesVolumeParams]<~KubernetesVolumeParams>
+        tags : typing.Mapping[str, str]
+        volumes : typing.Sequence[~KubernetesVolumeParams]
         '''
         constraints_ = Value.from_json(constraints) if constraints else None
         deployment_info_ = KubernetesDeploymentInfo.from_json(deployment_info) if deployment_info else None
@@ -10271,7 +10271,7 @@ class KubernetesProvisioningInfoResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~KubernetesProvisioningInfoResult]<~KubernetesProvisioningInfoResult>
+        results : typing.Sequence[~KubernetesProvisioningInfoResult]
         '''
         results_ = [KubernetesProvisioningInfoResult.from_json(o) for o in results or []]
 
@@ -10337,7 +10337,7 @@ class KubernetesVolumeInfo(Type):
     _toPy = {'data': 'data', 'info': 'info', 'persistent': 'persistent', 'pool': 'pool', 'size': 'size', 'status': 'status', 'volume-id': 'volume_id'}
     def __init__(self, data=None, info=None, persistent=None, pool=None, size=None, status=None, volume_id=None, **unknown_fields):
         '''
-        data : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        data : typing.Mapping[str, typing.Any]
         info : str
         persistent : bool
         pool : str
@@ -10392,11 +10392,11 @@ class KubernetesVolumeParams(Type):
     def __init__(self, attachment=None, attributes=None, provider=None, size=None, storagename=None, tags=None, **unknown_fields):
         '''
         attachment : KubernetesVolumeAttachmentParams
-        attributes : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        attributes : typing.Mapping[str, typing.Any]
         provider : str
         size : int
         storagename : str
-        tags : typing.Mapping<~KT, +VT_co>[str, str]
+        tags : typing.Mapping[str, str]
         '''
         attachment_ = KubernetesVolumeAttachmentParams.from_json(attachment) if attachment else None
         attributes_ = attributes
@@ -10439,9 +10439,9 @@ class LXDProfile(Type):
     _toPy = {'config': 'config', 'description': 'description', 'devices': 'devices'}
     def __init__(self, config=None, description=None, devices=None, **unknown_fields):
         '''
-        config : typing.Mapping<~KT, +VT_co>[str, str]
+        config : typing.Mapping[str, str]
         description : str
-        devices : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        devices : typing.Mapping[str, typing.Any]
         '''
         config_ = config
         description_ = description
@@ -10523,7 +10523,7 @@ class LXDProfileUpgradeMessagesResults(Type):
     _toPy = {'args': 'args'}
     def __init__(self, args=None, **unknown_fields):
         '''
-        args : typing.Sequence<+T_co>[~LXDProfileUpgradeMessagesResult]<~LXDProfileUpgradeMessagesResult>
+        args : typing.Sequence[~LXDProfileUpgradeMessagesResult]
         '''
         args_ = [LXDProfileUpgradeMessagesResult.from_json(o) for o in args or []]
 
@@ -10565,7 +10565,7 @@ class LifeResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~LifeResult]<~LifeResult>
+        results : typing.Sequence[~LifeResult]
         '''
         results_ = [LifeResult.from_json(o) for o in results or []]
 
@@ -10583,7 +10583,7 @@ class ListCloudImageMetadataResult(Type):
     _toPy = {'result': 'result'}
     def __init__(self, result=None, **unknown_fields):
         '''
-        result : typing.Sequence<+T_co>[~CloudImageMetadata]<~CloudImageMetadata>
+        result : typing.Sequence[~CloudImageMetadata]
         '''
         result_ = [CloudImageMetadata.from_json(o) for o in result or []]
 
@@ -10649,7 +10649,7 @@ class ListCloudInfoResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ListCloudInfoResult]<~ListCloudInfoResult>
+        results : typing.Sequence[~ListCloudInfoResult]
         '''
         results_ = [ListCloudInfoResult.from_json(o) for o in results or []]
 
@@ -10691,7 +10691,7 @@ class ListFirewallRulesResults(Type):
     _toPy = {'Rules': 'rules'}
     def __init__(self, rules=None, **unknown_fields):
         '''
-        rules : typing.Sequence<+T_co>[~FirewallRule]<~FirewallRule>
+        rules : typing.Sequence[~FirewallRule]
         '''
         rules_ = [FirewallRule.from_json(o) for o in rules or []]
 
@@ -10709,7 +10709,7 @@ class ListImageResult(Type):
     _toPy = {'result': 'result'}
     def __init__(self, result=None, **unknown_fields):
         '''
-        result : typing.Sequence<+T_co>[~ImageMetadata]<~ImageMetadata>
+        result : typing.Sequence[~ImageMetadata]
         '''
         result_ = [ImageMetadata.from_json(o) for o in result or []]
 
@@ -10727,7 +10727,7 @@ class ListResourcesArgs(Type):
     _toPy = {'entities': 'entities'}
     def __init__(self, entities=None, **unknown_fields):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
+        entities : typing.Sequence[~Entity]
         '''
         entities_ = [Entity.from_json(o) for o in entities or []]
 
@@ -10769,7 +10769,7 @@ class ListSpacesResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~Space]<~Space>
+        results : typing.Sequence[~Space]
         '''
         results_ = [Space.from_json(o) for o in results or []]
 
@@ -10787,7 +10787,7 @@ class ListSubnetsResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~Subnet]<~Subnet>
+        results : typing.Sequence[~Subnet]
         '''
         results_ = [Subnet.from_json(o) for o in results or []]
 
@@ -10805,7 +10805,7 @@ class ListUnitResourcesArgs(Type):
     _toPy = {'resource-names': 'resource_names'}
     def __init__(self, resource_names=None, **unknown_fields):
         '''
-        resource_names : typing.Sequence<+T_co>[str]
+        resource_names : typing.Sequence[str]
         '''
         resource_names_ = resource_names
 
@@ -10823,7 +10823,7 @@ class LogForwardingGetLastSentParams(Type):
     _toPy = {'ids': 'ids'}
     def __init__(self, ids=None, **unknown_fields):
         '''
-        ids : typing.Sequence<+T_co>[~LogForwardingID]<~LogForwardingID>
+        ids : typing.Sequence[~LogForwardingID]
         '''
         ids_ = [LogForwardingID.from_json(o) for o in ids or []]
 
@@ -10871,7 +10871,7 @@ class LogForwardingGetLastSentResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~LogForwardingGetLastSentResult]<~LogForwardingGetLastSentResult>
+        results : typing.Sequence[~LogForwardingGetLastSentResult]
         '''
         results_ = [LogForwardingGetLastSentResult.from_json(o) for o in results or []]
 
@@ -10955,7 +10955,7 @@ class LogForwardingSetLastSentParams(Type):
     _toPy = {'params': 'params'}
     def __init__(self, params=None, **unknown_fields):
         '''
-        params : typing.Sequence<+T_co>[~LogForwardingSetLastSentParam]<~LogForwardingSetLastSentParam>
+        params : typing.Sequence[~LogForwardingSetLastSentParam]
         '''
         params_ = [LogForwardingSetLastSentParam.from_json(o) for o in params or []]
 
@@ -10997,7 +10997,7 @@ class LookUpArgs(Type):
     _toPy = {'args': 'args'}
     def __init__(self, args=None, **unknown_fields):
         '''
-        args : typing.Sequence<+T_co>[~LookUpArg]<~LookUpArg>
+        args : typing.Sequence[~LookUpArg]
         '''
         args_ = [LookUpArg.from_json(o) for o in args or []]
 
@@ -11039,7 +11039,7 @@ class LookUpPayloadArgs(Type):
     _toPy = {'args': 'args'}
     def __init__(self, args=None, **unknown_fields):
         '''
-        args : typing.Sequence<+T_co>[~LookUpPayloadArg]<~LookUpPayloadArg>
+        args : typing.Sequence[~LookUpPayloadArg]
         '''
         args_ = [LookUpPayloadArg.from_json(o) for o in args or []]
 
@@ -11092,7 +11092,7 @@ class MacaroonResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~MacaroonResult]<~MacaroonResult>
+        results : typing.Sequence[~MacaroonResult]
         '''
         results_ = [MacaroonResult.from_json(o) for o in results or []]
 
@@ -11110,7 +11110,7 @@ class MachineAddresses(Type):
     _toPy = {'addresses': 'addresses', 'tag': 'tag'}
     def __init__(self, addresses=None, tag=None, **unknown_fields):
         '''
-        addresses : typing.Sequence<+T_co>[~Address]<~Address>
+        addresses : typing.Sequence[~Address]
         tag : str
         '''
         addresses_ = [Address.from_json(o) for o in addresses or []]
@@ -11134,7 +11134,7 @@ class MachineAddressesResult(Type):
     _toPy = {'addresses': 'addresses', 'error': 'error'}
     def __init__(self, addresses=None, error=None, **unknown_fields):
         '''
-        addresses : typing.Sequence<+T_co>[~Address]<~Address>
+        addresses : typing.Sequence[~Address]
         error : Error
         '''
         addresses_ = [Address.from_json(o) for o in addresses or []]
@@ -11158,7 +11158,7 @@ class MachineAddressesResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~MachineAddressesResult]<~MachineAddressesResult>
+        results : typing.Sequence[~MachineAddressesResult]
         '''
         results_ = [MachineAddressesResult.from_json(o) for o in results or []]
 
@@ -11176,7 +11176,7 @@ class MachineBlockDevices(Type):
     _toPy = {'block-devices': 'block_devices', 'machine': 'machine'}
     def __init__(self, block_devices=None, machine=None, **unknown_fields):
         '''
-        block_devices : typing.Sequence<+T_co>[~BlockDevice]<~BlockDevice>
+        block_devices : typing.Sequence[~BlockDevice]
         machine : str
         '''
         block_devices_ = [BlockDevice.from_json(o) for o in block_devices or []]
@@ -11200,7 +11200,7 @@ class MachineContainerResult(Type):
     _toPy = {'container-types': 'container_types', 'determined': 'determined', 'error': 'error'}
     def __init__(self, container_types=None, determined=None, error=None, **unknown_fields):
         '''
-        container_types : typing.Sequence<+T_co>[str]
+        container_types : typing.Sequence[str]
         determined : bool
         error : Error
         '''
@@ -11230,7 +11230,7 @@ class MachineContainerResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~MachineContainerResult]<~MachineContainerResult>
+        results : typing.Sequence[~MachineContainerResult]
         '''
         results_ = [MachineContainerResult.from_json(o) for o in results or []]
 
@@ -11248,7 +11248,7 @@ class MachineContainers(Type):
     _toPy = {'container-types': 'container_types', 'machine-tag': 'machine_tag'}
     def __init__(self, container_types=None, machine_tag=None, **unknown_fields):
         '''
-        container_types : typing.Sequence<+T_co>[str]
+        container_types : typing.Sequence[str]
         machine_tag : str
         '''
         container_types_ = container_types
@@ -11272,7 +11272,7 @@ class MachineContainersParams(Type):
     _toPy = {'params': 'params'}
     def __init__(self, params=None, **unknown_fields):
         '''
-        params : typing.Sequence<+T_co>[~MachineContainers]<~MachineContainers>
+        params : typing.Sequence[~MachineContainers]
         '''
         params_ = [MachineContainers.from_json(o) for o in params or []]
 
@@ -11296,7 +11296,7 @@ class MachineHardware(Type):
         cpu_power : int
         mem : int
         root_disk : int
-        tags : typing.Sequence<+T_co>[str]
+        tags : typing.Sequence[str]
         '''
         arch_ = arch
         availability_zone_ = availability_zone
@@ -11345,7 +11345,7 @@ class MachineNetworkConfigResult(Type):
     def __init__(self, error=None, info=None, **unknown_fields):
         '''
         error : Error
-        info : typing.Sequence<+T_co>[~NetworkConfig]<~NetworkConfig>
+        info : typing.Sequence[~NetworkConfig]
         '''
         error_ = Error.from_json(error) if error else None
         info_ = [NetworkConfig.from_json(o) for o in info or []]
@@ -11368,7 +11368,7 @@ class MachineNetworkConfigResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~MachineNetworkConfigResult]<~MachineNetworkConfigResult>
+        results : typing.Sequence[~MachineNetworkConfigResult]
         '''
         results_ = [MachineNetworkConfigResult.from_json(o) for o in results or []]
 
@@ -11440,7 +11440,7 @@ class MachinePortsParams(Type):
     _toPy = {'params': 'params'}
     def __init__(self, params=None, **unknown_fields):
         '''
-        params : typing.Sequence<+T_co>[~MachinePorts]<~MachinePorts>
+        params : typing.Sequence[~MachinePorts]
         '''
         params_ = [MachinePorts.from_json(o) for o in params or []]
 
@@ -11459,7 +11459,7 @@ class MachinePortsResult(Type):
     def __init__(self, error=None, ports=None, **unknown_fields):
         '''
         error : Error
-        ports : typing.Sequence<+T_co>[~MachinePortRange]<~MachinePortRange>
+        ports : typing.Sequence[~MachinePortRange]
         '''
         error_ = Error.from_json(error) if error else None
         ports_ = [MachinePortRange.from_json(o) for o in ports or []]
@@ -11482,7 +11482,7 @@ class MachinePortsResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~MachinePortsResult]<~MachinePortsResult>
+        results : typing.Sequence[~MachinePortsResult]
         '''
         results_ = [MachinePortsResult.from_json(o) for o in results or []]
 
@@ -11502,7 +11502,7 @@ class MachineStatus(Type):
         '''
         agent_status : DetailedStatus
         constraints : str
-        containers : typing.Mapping<~KT, +VT_co>[str, ~MachineStatus]<~MachineStatus>
+        containers : typing.Mapping[str, ~MachineStatus]
         display_name : str
         dns_name : str
         hardware : str
@@ -11510,11 +11510,11 @@ class MachineStatus(Type):
         id_ : str
         instance_id : str
         instance_status : DetailedStatus
-        ip_addresses : typing.Sequence<+T_co>[str]
-        jobs : typing.Sequence<+T_co>[str]
-        lxd_profiles : typing.Mapping<~KT, +VT_co>[str, ~LXDProfile]<~LXDProfile>
+        ip_addresses : typing.Sequence[str]
+        jobs : typing.Sequence[str]
+        lxd_profiles : typing.Mapping[str, ~LXDProfile]
         modification_status : DetailedStatus
-        network_interfaces : typing.Mapping<~KT, +VT_co>[str, ~NetworkInterface]<~NetworkInterface>
+        network_interfaces : typing.Mapping[str, ~NetworkInterface]
         series : str
         wants_vote : bool
         '''
@@ -11638,7 +11638,7 @@ class MachineStorageIds(Type):
     _toPy = {'ids': 'ids'}
     def __init__(self, ids=None, **unknown_fields):
         '''
-        ids : typing.Sequence<+T_co>[~MachineStorageId]<~MachineStorageId>
+        ids : typing.Sequence[~MachineStorageId]
         '''
         ids_ = [MachineStorageId.from_json(o) for o in ids or []]
 
@@ -11656,7 +11656,7 @@ class MachineStorageIdsWatchResult(Type):
     _toPy = {'changes': 'changes', 'error': 'error', 'watcher-id': 'watcher_id'}
     def __init__(self, changes=None, error=None, watcher_id=None, **unknown_fields):
         '''
-        changes : typing.Sequence<+T_co>[~MachineStorageId]<~MachineStorageId>
+        changes : typing.Sequence[~MachineStorageId]
         error : Error
         watcher_id : str
         '''
@@ -11686,7 +11686,7 @@ class MachineStorageIdsWatchResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~MachineStorageIdsWatchResult]<~MachineStorageIdsWatchResult>
+        results : typing.Sequence[~MachineStorageIdsWatchResult]
         '''
         results_ = [MachineStorageIdsWatchResult.from_json(o) for o in results or []]
 
@@ -11705,7 +11705,7 @@ class MapResult(Type):
     def __init__(self, error=None, result=None, **unknown_fields):
         '''
         error : Error
-        result : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        result : typing.Mapping[str, typing.Any]
         '''
         error_ = Error.from_json(error) if error else None
         result_ = result
@@ -11728,7 +11728,7 @@ class MapResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~MapResult]<~MapResult>
+        results : typing.Sequence[~MapResult]
         '''
         results_ = [MapResult.from_json(o) for o in results or []]
 
@@ -11789,7 +11789,7 @@ class Member(Type):
         id_ : int
         priority : float
         slavedelay : int
-        tags : typing.Mapping<~KT, +VT_co>[str, str]
+        tags : typing.Mapping[str, str]
         votes : int
         '''
         address_ = address
@@ -11848,7 +11848,7 @@ class MergeLeadershipSettingsBulkParams(Type):
     _toPy = {'params': 'params'}
     def __init__(self, params=None, **unknown_fields):
         '''
-        params : typing.Sequence<+T_co>[~MergeLeadershipSettingsParam]<~MergeLeadershipSettingsParam>
+        params : typing.Sequence[~MergeLeadershipSettingsParam]
         '''
         params_ = [MergeLeadershipSettingsParam.from_json(o) for o in params or []]
 
@@ -11867,7 +11867,7 @@ class MergeLeadershipSettingsParam(Type):
     def __init__(self, application_tag=None, settings=None, unit_tag=None, **unknown_fields):
         '''
         application_tag : str
-        settings : typing.Mapping<~KT, +VT_co>[str, str]
+        settings : typing.Mapping[str, str]
         unit_tag : str
         '''
         application_tag_ = application_tag
@@ -11896,7 +11896,7 @@ class MetadataImageIds(Type):
     _toPy = {'image-ids': 'image_ids'}
     def __init__(self, image_ids=None, **unknown_fields):
         '''
-        image_ids : typing.Sequence<+T_co>[str]
+        image_ids : typing.Sequence[str]
         '''
         image_ids_ = image_ids
 
@@ -11914,7 +11914,7 @@ class MetadataSaveParams(Type):
     _toPy = {'metadata': 'metadata'}
     def __init__(self, metadata=None, **unknown_fields):
         '''
-        metadata : typing.Sequence<+T_co>[~CloudImageMetadataList]<~CloudImageMetadataList>
+        metadata : typing.Sequence[~CloudImageMetadataList]
         '''
         metadata_ = [CloudImageMetadataList.from_json(o) for o in metadata or []]
 
@@ -11986,7 +11986,7 @@ class MeterStatusParams(Type):
     _toPy = {'statues': 'statues'}
     def __init__(self, statues=None, **unknown_fields):
         '''
-        statues : typing.Sequence<+T_co>[~MeterStatusParam]<~MeterStatusParam>
+        statues : typing.Sequence[~MeterStatusParam]
         '''
         statues_ = [MeterStatusParam.from_json(o) for o in statues or []]
 
@@ -12034,7 +12034,7 @@ class MeterStatusResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~MeterStatusResult]<~MeterStatusResult>
+        results : typing.Sequence[~MeterStatusResult]
         '''
         results_ = [MeterStatusResult.from_json(o) for o in results or []]
 
@@ -12053,7 +12053,7 @@ class Metric(Type):
     def __init__(self, key=None, labels=None, time=None, value=None, **unknown_fields):
         '''
         key : str
-        labels : typing.Mapping<~KT, +VT_co>[str, str]
+        labels : typing.Mapping[str, str]
         time : str
         value : str
         '''
@@ -12090,7 +12090,7 @@ class MetricBatch(Type):
         '''
         charm_url : str
         created : str
-        metrics : typing.Sequence<+T_co>[~Metric]<~Metric>
+        metrics : typing.Sequence[~Metric]
         uuid : str
         '''
         charm_url_ = charm_url
@@ -12148,7 +12148,7 @@ class MetricBatchParams(Type):
     _toPy = {'batches': 'batches'}
     def __init__(self, batches=None, **unknown_fields):
         '''
-        batches : typing.Sequence<+T_co>[~MetricBatchParam]<~MetricBatchParam>
+        batches : typing.Sequence[~MetricBatchParam]
         '''
         batches_ = [MetricBatchParam.from_json(o) for o in batches or []]
 
@@ -12167,7 +12167,7 @@ class MetricResult(Type):
     def __init__(self, key=None, labels=None, time=None, unit=None, value=None, **unknown_fields):
         '''
         key : str
-        labels : typing.Mapping<~KT, +VT_co>[str, str]
+        labels : typing.Mapping[str, str]
         time : str
         unit : str
         value : str
@@ -12208,7 +12208,7 @@ class MetricResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~EntityMetrics]<~EntityMetrics>
+        results : typing.Sequence[~EntityMetrics]
         '''
         results_ = [EntityMetrics.from_json(o) for o in results or []]
 
@@ -12295,9 +12295,9 @@ class MigrationStatus(Type):
         attempt : int
         migration_id : str
         phase : str
-        source_api_addrs : typing.Sequence<+T_co>[str]
+        source_api_addrs : typing.Sequence[str]
         source_ca_cert : str
-        target_api_addrs : typing.Sequence<+T_co>[str]
+        target_api_addrs : typing.Sequence[str]
         target_ca_cert : str
         '''
         attempt_ = attempt
@@ -12346,7 +12346,7 @@ class MigrationTargetInfo(Type):
     _toPy = {'addrs': 'addrs', 'auth-tag': 'auth_tag', 'ca-cert': 'ca_cert', 'controller-alias': 'controller_alias', 'controller-tag': 'controller_tag', 'macaroons': 'macaroons', 'password': 'password'}
     def __init__(self, addrs=None, auth_tag=None, ca_cert=None, controller_alias=None, controller_tag=None, macaroons=None, password=None, **unknown_fields):
         '''
-        addrs : typing.Sequence<+T_co>[str]
+        addrs : typing.Sequence[str]
         auth_tag : str
         ca_cert : str
         controller_alias : str
@@ -12430,12 +12430,12 @@ class MinionReports(Type):
     _toPy = {'failed': 'failed', 'migration-id': 'migration_id', 'phase': 'phase', 'success-count': 'success_count', 'unknown-count': 'unknown_count', 'unknown-sample': 'unknown_sample'}
     def __init__(self, failed=None, migration_id=None, phase=None, success_count=None, unknown_count=None, unknown_sample=None, **unknown_fields):
         '''
-        failed : typing.Sequence<+T_co>[str]
+        failed : typing.Sequence[str]
         migration_id : str
         phase : str
         success_count : int
         unknown_count : int
-        unknown_sample : typing.Sequence<+T_co>[str]
+        unknown_sample : typing.Sequence[str]
         '''
         failed_ = failed
         migration_id_ = migration_id
@@ -12556,7 +12556,7 @@ class ModelBlockInfo(Type):
     _toPy = {'blocks': 'blocks', 'model-uuid': 'model_uuid', 'name': 'name', 'owner-tag': 'owner_tag'}
     def __init__(self, blocks=None, model_uuid=None, name=None, owner_tag=None, **unknown_fields):
         '''
-        blocks : typing.Sequence<+T_co>[str]
+        blocks : typing.Sequence[str]
         model_uuid : str
         name : str
         owner_tag : str
@@ -12592,7 +12592,7 @@ class ModelBlockInfoList(Type):
     _toPy = {'models': 'models'}
     def __init__(self, models=None, **unknown_fields):
         '''
-        models : typing.Sequence<+T_co>[~ModelBlockInfo]<~ModelBlockInfo>
+        models : typing.Sequence[~ModelBlockInfo]
         '''
         models_ = [ModelBlockInfo.from_json(o) for o in models or []]
 
@@ -12610,7 +12610,7 @@ class ModelConfigResult(Type):
     _toPy = {'config': 'config'}
     def __init__(self, config=None, **unknown_fields):
         '''
-        config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        config : typing.Mapping[str, typing.Any]
         '''
         config_ = config
 
@@ -12628,7 +12628,7 @@ class ModelConfigResults(Type):
     _toPy = {'config': 'config'}
     def __init__(self, config=None, **unknown_fields):
         '''
-        config : typing.Mapping<~KT, +VT_co>[str, ~ConfigValue]<~ConfigValue>
+        config : typing.Mapping[str, ~ConfigValue]
         '''
         config_ = config
 
@@ -12647,7 +12647,7 @@ class ModelCreateArgs(Type):
     def __init__(self, cloud_tag=None, config=None, credential=None, name=None, owner_tag=None, region=None, **unknown_fields):
         '''
         cloud_tag : str
-        config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        config : typing.Mapping[str, typing.Any]
         credential : str
         name : str
         owner_tag : str
@@ -12732,7 +12732,7 @@ class ModelDefaultValues(Type):
         '''
         cloud_region : str
         cloud_tag : str
-        config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        config : typing.Mapping[str, typing.Any]
         '''
         cloud_region_ = cloud_region
         cloud_tag_ = cloud_tag
@@ -12762,7 +12762,7 @@ class ModelDefaults(Type):
         '''
         controller : Any
         default : Any
-        regions : typing.Sequence<+T_co>[~RegionDefaults]<~RegionDefaults>
+        regions : typing.Sequence[~RegionDefaults]
         '''
         controller_ = controller
         default_ = default
@@ -12784,7 +12784,7 @@ class ModelDefaultsResult(Type):
     _toPy = {'config': 'config', 'error': 'error'}
     def __init__(self, config=None, error=None, **unknown_fields):
         '''
-        config : typing.Mapping<~KT, +VT_co>[str, ~ModelDefaults]<~ModelDefaults>
+        config : typing.Mapping[str, ~ModelDefaults]
         error : Error
         '''
         config_ = config
@@ -12808,7 +12808,7 @@ class ModelDefaultsResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ModelDefaultsResult]<~ModelDefaultsResult>
+        results : typing.Sequence[~ModelDefaultsResult]
         '''
         results_ = [ModelDefaultsResult.from_json(o) for o in results or []]
 
@@ -12901,7 +12901,7 @@ class ModelInfo(Type):
         default_series : str
         is_controller : bool
         life : str
-        machines : typing.Sequence<+T_co>[~ModelMachineInfo]<~ModelMachineInfo>
+        machines : typing.Sequence[~ModelMachineInfo]
         migration : ModelMigrationStatus
         name : str
         owner_tag : str
@@ -12909,7 +12909,7 @@ class ModelInfo(Type):
         sla : ModelSLAInfo
         status : EntityStatus
         type_ : str
-        users : typing.Sequence<+T_co>[~ModelUserInfo]<~ModelUserInfo>
+        users : typing.Sequence[~ModelUserInfo]
         uuid : str
         '''
         agent_version_ = Number.from_json(agent_version) if agent_version else None
@@ -13042,7 +13042,7 @@ class ModelInfoResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ModelInfoResult]<~ModelInfoResult>
+        results : typing.Sequence[~ModelInfoResult]
         '''
         results_ = [ModelInfoResult.from_json(o) for o in results or []]
 
@@ -13078,7 +13078,7 @@ class ModelInstanceTypesConstraints(Type):
     _toPy = {'constraints': 'constraints'}
     def __init__(self, constraints=None, **unknown_fields):
         '''
-        constraints : typing.Sequence<+T_co>[~ModelInstanceTypesConstraint]<~ModelInstanceTypesConstraint>
+        constraints : typing.Sequence[~ModelInstanceTypesConstraint]
         '''
         constraints_ = [ModelInstanceTypesConstraint.from_json(o) for o in constraints or []]
 
@@ -13223,7 +13223,7 @@ class ModelSLA(Type):
     def __init__(self, modelslainfo=None, creds=None, level=None, owner=None, **unknown_fields):
         '''
         modelslainfo : ModelSLAInfo
-        creds : typing.Sequence<+T_co>[int]
+        creds : typing.Sequence[int]
         level : str
         owner : str
         '''
@@ -13282,7 +13282,7 @@ class ModelSequencesResult(Type):
     _toPy = {'sequences': 'sequences'}
     def __init__(self, sequences=None, **unknown_fields):
         '''
-        sequences : typing.Mapping<~KT, +VT_co>[str, int]
+        sequences : typing.Mapping[str, int]
         '''
         sequences_ = sequences
 
@@ -13300,7 +13300,7 @@ class ModelSet(Type):
     _toPy = {'config': 'config'}
     def __init__(self, config=None, **unknown_fields):
         '''
-        config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        config : typing.Mapping[str, typing.Any]
         '''
         config_ = config
 
@@ -13320,15 +13320,15 @@ class ModelStatus(Type):
         '''
         application_count : int
         error : Error
-        filesystems : typing.Sequence<+T_co>[~ModelFilesystemInfo]<~ModelFilesystemInfo>
+        filesystems : typing.Sequence[~ModelFilesystemInfo]
         hosted_machine_count : int
         life : str
-        machines : typing.Sequence<+T_co>[~ModelMachineInfo]<~ModelMachineInfo>
+        machines : typing.Sequence[~ModelMachineInfo]
         model_tag : str
         owner_tag : str
         type_ : str
         unit_count : int
-        volumes : typing.Sequence<+T_co>[~ModelVolumeInfo]<~ModelVolumeInfo>
+        volumes : typing.Sequence[~ModelVolumeInfo]
         '''
         application_count_ = application_count
         error_ = Error.from_json(error) if error else None
@@ -13444,7 +13444,7 @@ class ModelStatusResults(Type):
     _toPy = {'models': 'models'}
     def __init__(self, models=None, **unknown_fields):
         '''
-        models : typing.Sequence<+T_co>[~ModelStatus]<~ModelStatus>
+        models : typing.Sequence[~ModelStatus]
         '''
         models_ = [ModelStatus.from_json(o) for o in models or []]
 
@@ -13491,7 +13491,7 @@ class ModelSummary(Type):
         cloud_region : str
         cloud_tag : str
         controller_uuid : str
-        counts : typing.Sequence<+T_co>[~ModelEntityCount]<~ModelEntityCount>
+        counts : typing.Sequence[~ModelEntityCount]
         default_series : str
         is_controller : bool
         last_connection : str
@@ -13636,7 +13636,7 @@ class ModelSummaryResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ModelSummaryResult]<~ModelSummaryResult>
+        results : typing.Sequence[~ModelSummaryResult]
         '''
         results_ = [ModelSummaryResult.from_json(o) for o in results or []]
 
@@ -13665,7 +13665,7 @@ class ModelUnset(Type):
     _toPy = {'keys': 'keys'}
     def __init__(self, keys=None, **unknown_fields):
         '''
-        keys : typing.Sequence<+T_co>[str]
+        keys : typing.Sequence[str]
         '''
         keys_ = keys
 
@@ -13685,7 +13685,7 @@ class ModelUnsetKeys(Type):
         '''
         cloud_region : str
         cloud_tag : str
-        keys : typing.Sequence<+T_co>[str]
+        keys : typing.Sequence[str]
         '''
         cloud_region_ = cloud_region
         cloud_tag_ = cloud_tag
@@ -13773,7 +13773,7 @@ class ModelUserInfoResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ModelUserInfoResult]<~ModelUserInfoResult>
+        results : typing.Sequence[~ModelUserInfoResult]
         '''
         results_ = [ModelUserInfoResult.from_json(o) for o in results or []]
 
@@ -13869,7 +13869,7 @@ class ModifyCloudAccessRequest(Type):
     _toPy = {'changes': 'changes'}
     def __init__(self, changes=None, **unknown_fields):
         '''
-        changes : typing.Sequence<+T_co>[~ModifyCloudAccess]<~ModifyCloudAccess>
+        changes : typing.Sequence[~ModifyCloudAccess]
         '''
         changes_ = [ModifyCloudAccess.from_json(o) for o in changes or []]
 
@@ -13917,7 +13917,7 @@ class ModifyControllerAccessRequest(Type):
     _toPy = {'changes': 'changes'}
     def __init__(self, changes=None, **unknown_fields):
         '''
-        changes : typing.Sequence<+T_co>[~ModifyControllerAccess]<~ModifyControllerAccess>
+        changes : typing.Sequence[~ModifyControllerAccess]
         '''
         changes_ = [ModifyControllerAccess.from_json(o) for o in changes or []]
 
@@ -13971,7 +13971,7 @@ class ModifyModelAccessRequest(Type):
     _toPy = {'changes': 'changes'}
     def __init__(self, changes=None, **unknown_fields):
         '''
-        changes : typing.Sequence<+T_co>[~ModifyModelAccess]<~ModifyModelAccess>
+        changes : typing.Sequence[~ModifyModelAccess]
         '''
         changes_ = [ModifyModelAccess.from_json(o) for o in changes or []]
 
@@ -14025,7 +14025,7 @@ class ModifyOfferAccessRequest(Type):
     _toPy = {'changes': 'changes'}
     def __init__(self, changes=None, **unknown_fields):
         '''
-        changes : typing.Sequence<+T_co>[~ModifyOfferAccess]<~ModifyOfferAccess>
+        changes : typing.Sequence[~ModifyOfferAccess]
         '''
         changes_ = [ModifyOfferAccess.from_json(o) for o in changes or []]
 
@@ -14043,7 +14043,7 @@ class ModifyUserSSHKeys(Type):
     _toPy = {'ssh-keys': 'ssh_keys', 'user': 'user'}
     def __init__(self, ssh_keys=None, user=None, **unknown_fields):
         '''
-        ssh_keys : typing.Sequence<+T_co>[str]
+        ssh_keys : typing.Sequence[str]
         user : str
         '''
         ssh_keys_ = ssh_keys
@@ -14067,9 +14067,9 @@ class MongoUpgradeResults(Type):
     _toPy = {'ha-members': 'ha_members', 'master': 'master', 'rs-members': 'rs_members'}
     def __init__(self, ha_members=None, master=None, rs_members=None, **unknown_fields):
         '''
-        ha_members : typing.Sequence<+T_co>[~HAMember]<~HAMember>
+        ha_members : typing.Sequence[~HAMember]
         master : HAMember
-        rs_members : typing.Sequence<+T_co>[~Member]<~Member>
+        rs_members : typing.Sequence[~Member]
         '''
         ha_members_ = [HAMember.from_json(o) for o in ha_members or []]
         master_ = HAMember.from_json(master) if master else None
@@ -14138,8 +14138,8 @@ class NetworkConfig(Type):
         config_type : str
         device_index : int
         disabled : bool
-        dns_search_domains : typing.Sequence<+T_co>[str]
-        dns_servers : typing.Sequence<+T_co>[str]
+        dns_search_domains : typing.Sequence[str]
+        dns_servers : typing.Sequence[str]
         gateway_address : str
         interface_name : str
         interface_type : str
@@ -14153,7 +14153,7 @@ class NetworkConfig(Type):
         provider_space_id : str
         provider_subnet_id : str
         provider_vlan_id : str
-        routes : typing.Sequence<+T_co>[~NetworkRoute]<~NetworkRoute>
+        routes : typing.Sequence[~NetworkRoute]
         vlan_tag : int
         '''
         address_ = address
@@ -14277,7 +14277,7 @@ class NetworkInfo(Type):
     _toPy = {'addresses': 'addresses', 'interface-name': 'interface_name', 'mac-address': 'mac_address'}
     def __init__(self, addresses=None, interface_name=None, mac_address=None, **unknown_fields):
         '''
-        addresses : typing.Sequence<+T_co>[~InterfaceAddress]<~InterfaceAddress>
+        addresses : typing.Sequence[~InterfaceAddress]
         interface_name : str
         mac_address : str
         '''
@@ -14307,7 +14307,7 @@ class NetworkInfoParams(Type):
     _toPy = {'bindings': 'bindings', 'relation-id': 'relation_id', 'unit': 'unit'}
     def __init__(self, bindings=None, relation_id=None, unit=None, **unknown_fields):
         '''
-        bindings : typing.Sequence<+T_co>[str]
+        bindings : typing.Sequence[str]
         relation_id : int
         unit : str
         '''
@@ -14337,10 +14337,10 @@ class NetworkInfoResult(Type):
     _toPy = {'bind-addresses': 'bind_addresses', 'egress-subnets': 'egress_subnets', 'error': 'error', 'ingress-addresses': 'ingress_addresses'}
     def __init__(self, bind_addresses=None, egress_subnets=None, error=None, ingress_addresses=None, **unknown_fields):
         '''
-        bind_addresses : typing.Sequence<+T_co>[~NetworkInfo]<~NetworkInfo>
-        egress_subnets : typing.Sequence<+T_co>[str]
+        bind_addresses : typing.Sequence[~NetworkInfo]
+        egress_subnets : typing.Sequence[str]
         error : Error
-        ingress_addresses : typing.Sequence<+T_co>[str]
+        ingress_addresses : typing.Sequence[str]
         '''
         bind_addresses_ = [NetworkInfo.from_json(o) for o in bind_addresses or []]
         egress_subnets_ = egress_subnets
@@ -14373,7 +14373,7 @@ class NetworkInfoResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Mapping<~KT, +VT_co>[str, ~NetworkInfoResult]<~NetworkInfoResult>
+        results : typing.Mapping[str, ~NetworkInfoResult]
         '''
         results_ = results
 
@@ -14391,9 +14391,9 @@ class NetworkInterface(Type):
     _toPy = {'dns-nameservers': 'dns_nameservers', 'gateway': 'gateway', 'ip-addresses': 'ip_addresses', 'is-up': 'is_up', 'mac-address': 'mac_address', 'space': 'space'}
     def __init__(self, dns_nameservers=None, gateway=None, ip_addresses=None, is_up=None, mac_address=None, space=None, **unknown_fields):
         '''
-        dns_nameservers : typing.Sequence<+T_co>[str]
+        dns_nameservers : typing.Sequence[str]
         gateway : str
-        ip_addresses : typing.Sequence<+T_co>[str]
+        ip_addresses : typing.Sequence[str]
         is_up : bool
         mac_address : str
         space : str
@@ -14493,7 +14493,7 @@ class NotifyWatchResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~NotifyWatchResult]<~NotifyWatchResult>
+        results : typing.Sequence[~NotifyWatchResult]
         '''
         results_ = [NotifyWatchResult.from_json(o) for o in results or []]
 
@@ -14553,7 +14553,7 @@ class OfferArg(Type):
     _toPy = {'macaroons': 'macaroons', 'offer-uuid': 'offer_uuid'}
     def __init__(self, macaroons=None, offer_uuid=None, **unknown_fields):
         '''
-        macaroons : typing.Sequence<+T_co>[~Macaroon]<~Macaroon>
+        macaroons : typing.Sequence[~Macaroon]
         offer_uuid : str
         '''
         macaroons_ = [Macaroon.from_json(o) for o in macaroons or []]
@@ -14577,7 +14577,7 @@ class OfferArgs(Type):
     _toPy = {'args': 'args'}
     def __init__(self, args=None, **unknown_fields):
         '''
-        args : typing.Sequence<+T_co>[~OfferArg]<~OfferArg>
+        args : typing.Sequence[~OfferArg]
         '''
         args_ = [OfferArg.from_json(o) for o in args or []]
 
@@ -14596,7 +14596,7 @@ class OfferConnection(Type):
     def __init__(self, endpoint=None, ingress_subnets=None, relation_id=None, source_model_tag=None, status=None, username=None, **unknown_fields):
         '''
         endpoint : str
-        ingress_subnets : typing.Sequence<+T_co>[str]
+        ingress_subnets : typing.Sequence[str]
         relation_id : int
         source_model_tag : str
         status : EntityStatus
@@ -14643,12 +14643,12 @@ class OfferFilter(Type):
     _toPy = {'allowed-users': 'allowed_users', 'application-description': 'application_description', 'application-name': 'application_name', 'application-user': 'application_user', 'connected-users': 'connected_users', 'endpoints': 'endpoints', 'model-name': 'model_name', 'offer-name': 'offer_name', 'owner-name': 'owner_name'}
     def __init__(self, allowed_users=None, application_description=None, application_name=None, application_user=None, connected_users=None, endpoints=None, model_name=None, offer_name=None, owner_name=None, **unknown_fields):
         '''
-        allowed_users : typing.Sequence<+T_co>[str]
+        allowed_users : typing.Sequence[str]
         application_description : str
         application_name : str
         application_user : str
-        connected_users : typing.Sequence<+T_co>[str]
-        endpoints : typing.Sequence<+T_co>[~EndpointFilterAttributes]<~EndpointFilterAttributes>
+        connected_users : typing.Sequence[str]
+        endpoints : typing.Sequence[~EndpointFilterAttributes]
         model_name : str
         offer_name : str
         owner_name : str
@@ -14709,7 +14709,7 @@ class OfferFilters(Type):
     _toPy = {'Filters': 'filters'}
     def __init__(self, filters=None, **unknown_fields):
         '''
-        filters : typing.Sequence<+T_co>[~OfferFilter]<~OfferFilter>
+        filters : typing.Sequence[~OfferFilter]
         '''
         filters_ = [OfferFilter.from_json(o) for o in filters or []]
 
@@ -14751,7 +14751,7 @@ class OfferStatusWatchResult(Type):
     _toPy = {'changes': 'changes', 'error': 'error', 'watcher-id': 'watcher_id'}
     def __init__(self, changes=None, error=None, watcher_id=None, **unknown_fields):
         '''
-        changes : typing.Sequence<+T_co>[~OfferStatusChange]<~OfferStatusChange>
+        changes : typing.Sequence[~OfferStatusChange]
         error : Error
         watcher_id : str
         '''
@@ -14781,7 +14781,7 @@ class OfferStatusWatchResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~OfferStatusWatchResult]<~OfferStatusWatchResult>
+        results : typing.Sequence[~OfferStatusWatchResult]
         '''
         results_ = [OfferStatusWatchResult.from_json(o) for o in results or []]
 
@@ -14799,7 +14799,7 @@ class OfferURLs(Type):
     _toPy = {'offer-urls': 'offer_urls'}
     def __init__(self, offer_urls=None, **unknown_fields):
         '''
-        offer_urls : typing.Sequence<+T_co>[str]
+        offer_urls : typing.Sequence[str]
         '''
         offer_urls_ = offer_urls
 
@@ -14847,10 +14847,10 @@ class OperatorProvisioningInfo(Type):
     _toPy = {'api-addresses': 'api_addresses', 'charm-storage': 'charm_storage', 'image-path': 'image_path', 'tags': 'tags', 'version': 'version'}
     def __init__(self, api_addresses=None, charm_storage=None, image_path=None, tags=None, version=None, **unknown_fields):
         '''
-        api_addresses : typing.Sequence<+T_co>[str]
+        api_addresses : typing.Sequence[str]
         charm_storage : KubernetesFilesystemParams
         image_path : str
-        tags : typing.Mapping<~KT, +VT_co>[str, str]
+        tags : typing.Mapping[str, str]
         version : Number
         '''
         api_addresses_ = api_addresses
@@ -14891,7 +14891,7 @@ class Payload(Type):
         '''
         class_ : str
         id_ : str
-        labels : typing.Sequence<+T_co>[str]
+        labels : typing.Sequence[str]
         machine : str
         status : str
         type_ : str
@@ -14943,7 +14943,7 @@ class PayloadListArgs(Type):
     _toPy = {'patterns': 'patterns'}
     def __init__(self, patterns=None, **unknown_fields):
         '''
-        patterns : typing.Sequence<+T_co>[str]
+        patterns : typing.Sequence[str]
         '''
         patterns_ = patterns
 
@@ -14961,7 +14961,7 @@ class PayloadListResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~Payload]<~Payload>
+        results : typing.Sequence[~Payload]
         '''
         results_ = [Payload.from_json(o) for o in results or []]
 
@@ -15021,7 +15021,7 @@ class PayloadResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~PayloadResult]<~PayloadResult>
+        results : typing.Sequence[~PayloadResult]
         '''
         results_ = [PayloadResult.from_json(o) for o in results or []]
 
@@ -15063,7 +15063,7 @@ class PhaseResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~PhaseResult]<~PhaseResult>
+        results : typing.Sequence[~PhaseResult]
         '''
         results_ = [PhaseResult.from_json(o) for o in results or []]
 
@@ -15105,7 +15105,7 @@ class PinApplicationsResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~PinApplicationResult]<~PinApplicationResult>
+        results : typing.Sequence[~PinApplicationResult]
         '''
         results_ = [PinApplicationResult.from_json(o) for o in results or []]
 
@@ -15123,7 +15123,7 @@ class PinnedLeadershipResult(Type):
     _toPy = {'result': 'result'}
     def __init__(self, result=None, **unknown_fields):
         '''
-        result : typing.Sequence<+T_co>[str]
+        result : typing.Sequence[str]
         '''
         result_ = result
 
@@ -15273,7 +15273,7 @@ class ProfileChangeResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ProfileChangeResult]<~ProfileChangeResult>
+        results : typing.Sequence[~ProfileChangeResult]
         '''
         results_ = [ProfileChangeResult.from_json(o) for o in results or []]
 
@@ -15358,7 +15358,7 @@ class ProviderInterfaceInfoResult(Type):
     def __init__(self, error=None, interfaces=None, machine_tag=None, **unknown_fields):
         '''
         error : Error
-        interfaces : typing.Sequence<+T_co>[~ProviderInterfaceInfo]<~ProviderInterfaceInfo>
+        interfaces : typing.Sequence[~ProviderInterfaceInfo]
         machine_tag : str
         '''
         error_ = Error.from_json(error) if error else None
@@ -15387,7 +15387,7 @@ class ProviderInterfaceInfoResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ProviderInterfaceInfoResult]<~ProviderInterfaceInfoResult>
+        results : typing.Sequence[~ProviderInterfaceInfoResult]
         '''
         results_ = [ProviderInterfaceInfoResult.from_json(o) for o in results or []]
 
@@ -15408,7 +15408,7 @@ class ProviderSpace(Type):
         error : Error
         name : str
         provider_id : str
-        subnets : typing.Sequence<+T_co>[~Subnet]<~Subnet>
+        subnets : typing.Sequence[~Subnet]
         '''
         error_ = Error.from_json(error) if error else None
         name_ = name
@@ -15441,19 +15441,19 @@ class ProvisioningInfo(Type):
     _toPy = {'charm-lxd-profiles': 'charm_lxd_profiles', 'cloudinit-userdata': 'cloudinit_userdata', 'constraints': 'constraints', 'controller-config': 'controller_config', 'endpoint-bindings': 'endpoint_bindings', 'image-metadata': 'image_metadata', 'jobs': 'jobs', 'placement': 'placement', 'series': 'series', 'subnets-to-zones': 'subnets_to_zones', 'tags': 'tags', 'volume-attachments': 'volume_attachments', 'volumes': 'volumes'}
     def __init__(self, charm_lxd_profiles=None, cloudinit_userdata=None, constraints=None, controller_config=None, endpoint_bindings=None, image_metadata=None, jobs=None, placement=None, series=None, subnets_to_zones=None, tags=None, volume_attachments=None, volumes=None, **unknown_fields):
         '''
-        charm_lxd_profiles : typing.Sequence<+T_co>[str]
-        cloudinit_userdata : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        charm_lxd_profiles : typing.Sequence[str]
+        cloudinit_userdata : typing.Mapping[str, typing.Any]
         constraints : Value
-        controller_config : typing.Mapping<~KT, +VT_co>[str, typing.Any]
-        endpoint_bindings : typing.Mapping<~KT, +VT_co>[str, str]
-        image_metadata : typing.Sequence<+T_co>[~CloudImageMetadata]<~CloudImageMetadata>
-        jobs : typing.Sequence<+T_co>[str]
+        controller_config : typing.Mapping[str, typing.Any]
+        endpoint_bindings : typing.Mapping[str, str]
+        image_metadata : typing.Sequence[~CloudImageMetadata]
+        jobs : typing.Sequence[str]
         placement : str
         series : str
-        subnets_to_zones : typing.Sequence<+T_co>[str]
-        tags : typing.Mapping<~KT, +VT_co>[str, str]
-        volume_attachments : typing.Sequence<+T_co>[~VolumeAttachmentParams]<~VolumeAttachmentParams>
-        volumes : typing.Sequence<+T_co>[~VolumeParams]<~VolumeParams>
+        subnets_to_zones : typing.Sequence[str]
+        tags : typing.Mapping[str, str]
+        volume_attachments : typing.Sequence[~VolumeAttachmentParams]
+        volumes : typing.Sequence[~VolumeParams]
         '''
         charm_lxd_profiles_ = charm_lxd_profiles
         cloudinit_userdata_ = cloudinit_userdata
@@ -15555,7 +15555,7 @@ class ProvisioningInfoResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ProvisioningInfoResult]<~ProvisioningInfoResult>
+        results : typing.Sequence[~ProvisioningInfoResult]
         '''
         results_ = [ProvisioningInfoResult.from_json(o) for o in results or []]
 
@@ -15717,7 +15717,7 @@ class ProxyConfigResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ProxyConfigResult]<~ProxyConfigResult>
+        results : typing.Sequence[~ProxyConfigResult]
         '''
         results_ = [ProxyConfigResult.from_json(o) for o in results or []]
 
@@ -15771,7 +15771,7 @@ class QueryApplicationOffersResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ApplicationOfferAdminDetails]<~ApplicationOfferAdminDetails>
+        results : typing.Sequence[~ApplicationOfferAdminDetails]
         '''
         results_ = [ApplicationOfferAdminDetails.from_json(o) for o in results or []]
 
@@ -15813,7 +15813,7 @@ class RebootActionResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~RebootActionResult]<~RebootActionResult>
+        results : typing.Sequence[~RebootActionResult]
         '''
         results_ = [RebootActionResult.from_json(o) for o in results or []]
 
@@ -15854,7 +15854,7 @@ class RegisterRemoteRelationArg(Type):
         '''
         application_token : str
         local_endpoint_name : str
-        macaroons : typing.Sequence<+T_co>[~Macaroon]<~Macaroon>
+        macaroons : typing.Sequence[~Macaroon]
         offer_uuid : str
         relation_token : str
         remote_endpoint : RemoteEndpoint
@@ -15912,7 +15912,7 @@ class RegisterRemoteRelationArgs(Type):
     _toPy = {'relations': 'relations'}
     def __init__(self, relations=None, **unknown_fields):
         '''
-        relations : typing.Sequence<+T_co>[~RegisterRemoteRelationArg]<~RegisterRemoteRelationArg>
+        relations : typing.Sequence[~RegisterRemoteRelationArg]
         '''
         relations_ = [RegisterRemoteRelationArg.from_json(o) for o in relations or []]
 
@@ -15954,7 +15954,7 @@ class RegisterRemoteRelationResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~RegisterRemoteRelationResult]<~RegisterRemoteRelationResult>
+        results : typing.Sequence[~RegisterRemoteRelationResult]
         '''
         results_ = [RegisterRemoteRelationResult.from_json(o) for o in results or []]
 
@@ -15972,8 +15972,8 @@ class RelationChange(Type):
     _toPy = {'changedunits': 'changedunits', 'departedunits': 'departedunits', 'id': 'id_', 'life': 'life'}
     def __init__(self, changedunits=None, departedunits=None, id_=None, life=None, **unknown_fields):
         '''
-        changedunits : typing.Mapping<~KT, +VT_co>[str, ~RelationUnitChange]<~RelationUnitChange>
-        departedunits : typing.Sequence<+T_co>[str]
+        changedunits : typing.Mapping[str, ~RelationUnitChange]
+        departedunits : typing.Sequence[str]
         id_ : int
         life : str
         '''
@@ -16008,7 +16008,7 @@ class RelationIds(Type):
     _toPy = {'relation-ids': 'relation_ids'}
     def __init__(self, relation_ids=None, **unknown_fields):
         '''
-        relation_ids : typing.Sequence<+T_co>[int]
+        relation_ids : typing.Sequence[int]
         '''
         relation_ids_ = relation_ids
 
@@ -16062,7 +16062,7 @@ class RelationLifeSuspendedStatusWatchResult(Type):
     _toPy = {'changes': 'changes', 'error': 'error', 'watcher-id': 'watcher_id'}
     def __init__(self, changes=None, error=None, watcher_id=None, **unknown_fields):
         '''
-        changes : typing.Sequence<+T_co>[~RelationLifeSuspendedStatusChange]<~RelationLifeSuspendedStatusChange>
+        changes : typing.Sequence[~RelationLifeSuspendedStatusChange]
         error : Error
         watcher_id : str
         '''
@@ -16146,7 +16146,7 @@ class RelationResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~RelationResult]<~RelationResult>
+        results : typing.Sequence[~RelationResult]
         '''
         results_ = [RelationResult.from_json(o) for o in results or []]
 
@@ -16164,7 +16164,7 @@ class RelationStatus(Type):
     _toPy = {'endpoints': 'endpoints', 'id': 'id_', 'interface': 'interface', 'key': 'key', 'scope': 'scope', 'status': 'status'}
     def __init__(self, endpoints=None, id_=None, interface=None, key=None, scope=None, status=None, **unknown_fields):
         '''
-        endpoints : typing.Sequence<+T_co>[~EndpointStatus]<~EndpointStatus>
+        endpoints : typing.Sequence[~EndpointStatus]
         id_ : int
         interface : str
         key : str
@@ -16248,7 +16248,7 @@ class RelationStatusArgs(Type):
     _toPy = {'args': 'args'}
     def __init__(self, args=None, **unknown_fields):
         '''
-        args : typing.Sequence<+T_co>[~RelationStatusArg]<~RelationStatusArg>
+        args : typing.Sequence[~RelationStatusArg]
         '''
         args_ = [RelationStatusArg.from_json(o) for o in args or []]
 
@@ -16266,7 +16266,7 @@ class RelationStatusWatchResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~RelationLifeSuspendedStatusWatchResult]<~RelationLifeSuspendedStatusWatchResult>
+        results : typing.Sequence[~RelationLifeSuspendedStatusWatchResult]
         '''
         results_ = [RelationLifeSuspendedStatusWatchResult.from_json(o) for o in results or []]
 
@@ -16314,7 +16314,7 @@ class RelationSuspendedArgs(Type):
     _toPy = {'args': 'args'}
     def __init__(self, args=None, **unknown_fields):
         '''
-        args : typing.Sequence<+T_co>[~RelationSuspendedArg]<~RelationSuspendedArg>
+        args : typing.Sequence[~RelationSuspendedArg]
         '''
         args_ = [RelationSuspendedArg.from_json(o) for o in args or []]
 
@@ -16356,7 +16356,7 @@ class RelationUnitChange(Type):
     _toPy = {'settings': 'settings'}
     def __init__(self, settings=None, **unknown_fields):
         '''
-        settings : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        settings : typing.Mapping[str, typing.Any]
         '''
         settings_ = settings
 
@@ -16404,7 +16404,7 @@ class RelationUnitPairs(Type):
     _toPy = {'relation-unit-pairs': 'relation_unit_pairs'}
     def __init__(self, relation_unit_pairs=None, **unknown_fields):
         '''
-        relation_unit_pairs : typing.Sequence<+T_co>[~RelationUnitPair]<~RelationUnitPair>
+        relation_unit_pairs : typing.Sequence[~RelationUnitPair]
         '''
         relation_unit_pairs_ = [RelationUnitPair.from_json(o) for o in relation_unit_pairs or []]
 
@@ -16423,7 +16423,7 @@ class RelationUnitSettings(Type):
     def __init__(self, relation=None, settings=None, unit=None, **unknown_fields):
         '''
         relation : str
-        settings : typing.Mapping<~KT, +VT_co>[str, str]
+        settings : typing.Mapping[str, str]
         unit : str
         '''
         relation_ = relation
@@ -16483,7 +16483,7 @@ class RelationUnitStatusResult(Type):
     def __init__(self, error=None, results=None, **unknown_fields):
         '''
         error : Error
-        results : typing.Sequence<+T_co>[~RelationUnitStatus]<~RelationUnitStatus>
+        results : typing.Sequence[~RelationUnitStatus]
         '''
         error_ = Error.from_json(error) if error else None
         results_ = [RelationUnitStatus.from_json(o) for o in results or []]
@@ -16506,7 +16506,7 @@ class RelationUnitStatusResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~RelationUnitStatusResult]<~RelationUnitStatusResult>
+        results : typing.Sequence[~RelationUnitStatusResult]
         '''
         results_ = [RelationUnitStatusResult.from_json(o) for o in results or []]
 
@@ -16524,7 +16524,7 @@ class RelationUnits(Type):
     _toPy = {'relation-units': 'relation_units'}
     def __init__(self, relation_units=None, **unknown_fields):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnit]<~RelationUnit>
+        relation_units : typing.Sequence[~RelationUnit]
         '''
         relation_units_ = [RelationUnit.from_json(o) for o in relation_units or []]
 
@@ -16542,8 +16542,8 @@ class RelationUnitsChange(Type):
     _toPy = {'changed': 'changed', 'departed': 'departed'}
     def __init__(self, changed=None, departed=None, **unknown_fields):
         '''
-        changed : typing.Mapping<~KT, +VT_co>[str, ~UnitSettings]<~UnitSettings>
-        departed : typing.Sequence<+T_co>[str]
+        changed : typing.Mapping[str, ~UnitSettings]
+        departed : typing.Sequence[str]
         '''
         changed_ = changed
         departed_ = departed
@@ -16566,7 +16566,7 @@ class RelationUnitsSettings(Type):
     _toPy = {'relation-units': 'relation_units'}
     def __init__(self, relation_units=None, **unknown_fields):
         '''
-        relation_units : typing.Sequence<+T_co>[~RelationUnitSettings]<~RelationUnitSettings>
+        relation_units : typing.Sequence[~RelationUnitSettings]
         '''
         relation_units_ = [RelationUnitSettings.from_json(o) for o in relation_units or []]
 
@@ -16614,7 +16614,7 @@ class RelationUnitsWatchResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~RelationUnitsWatchResult]<~RelationUnitsWatchResult>
+        results : typing.Sequence[~RelationUnitsWatchResult]
         '''
         results_ = [RelationUnitsWatchResult.from_json(o) for o in results or []]
 
@@ -16717,7 +16717,7 @@ class RemoteApplicationInfo(Type):
     def __init__(self, description=None, endpoints=None, icon_url_path=None, model_tag=None, name=None, offer_url=None, source_model_label=None, **unknown_fields):
         '''
         description : str
-        endpoints : typing.Sequence<+T_co>[~RemoteEndpoint]<~RemoteEndpoint>
+        endpoints : typing.Sequence[~RemoteEndpoint]
         icon_url_path : str
         model_tag : str
         name : str
@@ -16794,7 +16794,7 @@ class RemoteApplicationInfoResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~RemoteApplicationInfoResult]<~RemoteApplicationInfoResult>
+        results : typing.Sequence[~RemoteApplicationInfoResult]
         '''
         results_ = [RemoteApplicationInfoResult.from_json(o) for o in results or []]
 
@@ -16836,7 +16836,7 @@ class RemoteApplicationResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~RemoteApplicationResult]<~RemoteApplicationResult>
+        results : typing.Sequence[~RemoteApplicationResult]
         '''
         results_ = [RemoteApplicationResult.from_json(o) for o in results or []]
 
@@ -16854,12 +16854,12 @@ class RemoteApplicationStatus(Type):
     _toPy = {'endpoints': 'endpoints', 'err': 'err', 'life': 'life', 'offer-name': 'offer_name', 'offer-url': 'offer_url', 'relations': 'relations', 'status': 'status'}
     def __init__(self, endpoints=None, err=None, life=None, offer_name=None, offer_url=None, relations=None, status=None, **unknown_fields):
         '''
-        endpoints : typing.Sequence<+T_co>[~RemoteEndpoint]<~RemoteEndpoint>
+        endpoints : typing.Sequence[~RemoteEndpoint]
         err : Error
         life : str
         offer_name : str
         offer_url : str
-        relations : typing.Sequence<+T_co>[str]
+        relations : typing.Sequence[str]
         status : DetailedStatus
         '''
         endpoints_ = [RemoteEndpoint.from_json(o) for o in endpoints or []]
@@ -16974,7 +16974,7 @@ class RemoteEntityArg(Type):
     _toPy = {'macaroons': 'macaroons', 'relation-token': 'relation_token'}
     def __init__(self, macaroons=None, relation_token=None, **unknown_fields):
         '''
-        macaroons : typing.Sequence<+T_co>[~Macaroon]<~Macaroon>
+        macaroons : typing.Sequence[~Macaroon]
         relation_token : str
         '''
         macaroons_ = [Macaroon.from_json(o) for o in macaroons or []]
@@ -16998,7 +16998,7 @@ class RemoteEntityArgs(Type):
     _toPy = {'args': 'args'}
     def __init__(self, args=None, **unknown_fields):
         '''
-        args : typing.Sequence<+T_co>[~RemoteEntityArg]<~RemoteEntityArg>
+        args : typing.Sequence[~RemoteEntityArg]
         '''
         args_ = [RemoteEntityArg.from_json(o) for o in args or []]
 
@@ -17064,7 +17064,7 @@ class RemoteEntityTokenArgs(Type):
     _toPy = {'Args': 'args'}
     def __init__(self, args=None, **unknown_fields):
         '''
-        args : typing.Sequence<+T_co>[~RemoteEntityTokenArg]<~RemoteEntityTokenArg>
+        args : typing.Sequence[~RemoteEntityTokenArg]
         '''
         args_ = [RemoteEntityTokenArg.from_json(o) for o in args or []]
 
@@ -17148,8 +17148,8 @@ class RemoteRelationChange(Type):
     _toPy = {'changed-units': 'changed_units', 'departed-units': 'departed_units', 'id': 'id_', 'life': 'life'}
     def __init__(self, changed_units=None, departed_units=None, id_=None, life=None, **unknown_fields):
         '''
-        changed_units : typing.Mapping<~KT, +VT_co>[str, ~RemoteRelationUnitChange]<~RemoteRelationUnitChange>
-        departed_units : typing.Sequence<+T_co>[str]
+        changed_units : typing.Mapping[str, ~RemoteRelationUnitChange]
+        departed_units : typing.Sequence[str]
         id_ : int
         life : str
         '''
@@ -17185,11 +17185,11 @@ class RemoteRelationChangeEvent(Type):
     def __init__(self, application_token=None, changed_units=None, departed_units=None, force_cleanup=None, life=None, macaroons=None, relation_token=None, suspended=None, suspended_reason=None, **unknown_fields):
         '''
         application_token : str
-        changed_units : typing.Sequence<+T_co>[~RemoteRelationUnitChange]<~RemoteRelationUnitChange>
-        departed_units : typing.Sequence<+T_co>[int]
+        changed_units : typing.Sequence[~RemoteRelationUnitChange]
+        departed_units : typing.Sequence[int]
         force_cleanup : bool
         life : str
-        macaroons : typing.Sequence<+T_co>[~Macaroon]<~Macaroon>
+        macaroons : typing.Sequence[~Macaroon]
         relation_token : str
         suspended : bool
         suspended_reason : str
@@ -17298,7 +17298,7 @@ class RemoteRelationResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~RemoteRelationResult]<~RemoteRelationResult>
+        results : typing.Sequence[~RemoteRelationResult]
         '''
         results_ = [RemoteRelationResult.from_json(o) for o in results or []]
 
@@ -17316,7 +17316,7 @@ class RemoteRelationUnit(Type):
     _toPy = {'macaroons': 'macaroons', 'relation-token': 'relation_token', 'unit': 'unit'}
     def __init__(self, macaroons=None, relation_token=None, unit=None, **unknown_fields):
         '''
-        macaroons : typing.Sequence<+T_co>[~Macaroon]<~Macaroon>
+        macaroons : typing.Sequence[~Macaroon]
         relation_token : str
         unit : str
         '''
@@ -17346,7 +17346,7 @@ class RemoteRelationUnitChange(Type):
     _toPy = {'settings': 'settings', 'unit-id': 'unit_id'}
     def __init__(self, settings=None, unit_id=None, **unknown_fields):
         '''
-        settings : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        settings : typing.Mapping[str, typing.Any]
         unit_id : int
         '''
         settings_ = settings
@@ -17370,7 +17370,7 @@ class RemoteRelationUnits(Type):
     _toPy = {'relation-units': 'relation_units'}
     def __init__(self, relation_units=None, **unknown_fields):
         '''
-        relation_units : typing.Sequence<+T_co>[~RemoteRelationUnit]<~RemoteRelationUnit>
+        relation_units : typing.Sequence[~RemoteRelationUnit]
         '''
         relation_units_ = [RemoteRelationUnit.from_json(o) for o in relation_units or []]
 
@@ -17388,9 +17388,9 @@ class RemoteRelationsChange(Type):
     _toPy = {'changed': 'changed', 'initial': 'initial', 'removed': 'removed'}
     def __init__(self, changed=None, initial=None, removed=None, **unknown_fields):
         '''
-        changed : typing.Sequence<+T_co>[~RemoteRelationChange]<~RemoteRelationChange>
+        changed : typing.Sequence[~RemoteRelationChange]
         initial : bool
-        removed : typing.Sequence<+T_co>[int]
+        removed : typing.Sequence[int]
         '''
         changed_ = [RemoteRelationChange.from_json(o) for o in changed or []]
         initial_ = initial
@@ -17418,7 +17418,7 @@ class RemoteRelationsChanges(Type):
     _toPy = {'changes': 'changes'}
     def __init__(self, changes=None, **unknown_fields):
         '''
-        changes : typing.Sequence<+T_co>[~RemoteRelationChangeEvent]<~RemoteRelationChangeEvent>
+        changes : typing.Sequence[~RemoteRelationChangeEvent]
         '''
         changes_ = [RemoteRelationChangeEvent.from_json(o) for o in changes or []]
 
@@ -17468,9 +17468,9 @@ class RemoteSpace(Type):
         '''
         cloud_type : str
         name : str
-        provider_attributes : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        provider_attributes : typing.Mapping[str, typing.Any]
         provider_id : str
-        subnets : typing.Sequence<+T_co>[~Subnet]<~Subnet>
+        subnets : typing.Sequence[~Subnet]
         '''
         cloud_type_ = cloud_type
         name_ = name
@@ -17580,7 +17580,7 @@ class RemoveFilesystemParamsResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~RemoveFilesystemParamsResult]<~RemoveFilesystemParamsResult>
+        results : typing.Sequence[~RemoveFilesystemParamsResult]
         '''
         results_ = [RemoveFilesystemParamsResult.from_json(o) for o in results or []]
 
@@ -17598,7 +17598,7 @@ class RemoveStorage(Type):
     _toPy = {'storage': 'storage'}
     def __init__(self, storage=None, **unknown_fields):
         '''
-        storage : typing.Sequence<+T_co>[~RemoveStorageInstance]<~RemoveStorageInstance>
+        storage : typing.Sequence[~RemoveStorageInstance]
         '''
         storage_ = [RemoveStorageInstance.from_json(o) for o in storage or []]
 
@@ -17712,7 +17712,7 @@ class RemoveVolumeParamsResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~RemoveVolumeParamsResult]<~RemoveVolumeParamsResult>
+        results : typing.Sequence[~RemoveVolumeParamsResult]
         '''
         results_ = [RemoveVolumeParamsResult.from_json(o) for o in results or []]
 
@@ -17754,7 +17754,7 @@ class ResolveCharmResults(Type):
     _toPy = {'urls': 'urls'}
     def __init__(self, urls=None, **unknown_fields):
         '''
-        urls : typing.Sequence<+T_co>[~ResolveCharmResult]<~ResolveCharmResult>
+        urls : typing.Sequence[~ResolveCharmResult]
         '''
         urls_ = [ResolveCharmResult.from_json(o) for o in urls or []]
 
@@ -17772,7 +17772,7 @@ class ResolveCharms(Type):
     _toPy = {'references': 'references'}
     def __init__(self, references=None, **unknown_fields):
         '''
-        references : typing.Sequence<+T_co>[str]
+        references : typing.Sequence[str]
         '''
         references_ = references
 
@@ -17838,7 +17838,7 @@ class ResolvedModeResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ResolvedModeResult]<~ResolvedModeResult>
+        results : typing.Sequence[~ResolvedModeResult]
         '''
         results_ = [ResolvedModeResult.from_json(o) for o in results or []]
 
@@ -17859,7 +17859,7 @@ class Resource(Type):
         charmresource : CharmResource
         application : str
         description : str
-        fingerprint : typing.Sequence<+T_co>[int]
+        fingerprint : typing.Sequence[int]
         id_ : str
         name : str
         origin : str
@@ -17977,10 +17977,10 @@ class ResourcesResult(Type):
     def __init__(self, errorresult=None, charm_store_resources=None, error=None, resources=None, unit_resources=None, **unknown_fields):
         '''
         errorresult : ErrorResult
-        charm_store_resources : typing.Sequence<+T_co>[~CharmResource]<~CharmResource>
+        charm_store_resources : typing.Sequence[~CharmResource]
         error : Error
-        resources : typing.Sequence<+T_co>[~Resource]<~Resource>
-        unit_resources : typing.Sequence<+T_co>[~UnitResources]<~UnitResources>
+        resources : typing.Sequence[~Resource]
+        unit_resources : typing.Sequence[~UnitResources]
         '''
         errorresult_ = ErrorResult.from_json(errorresult) if errorresult else None
         charm_store_resources_ = [CharmResource.from_json(o) for o in charm_store_resources or []]
@@ -18018,7 +18018,7 @@ class ResourcesResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ResourcesResult]<~ResourcesResult>
+        results : typing.Sequence[~ResourcesResult]
         '''
         results_ = [ResourcesResult.from_json(o) for o in results or []]
 
@@ -18054,7 +18054,7 @@ class ResumeReplicationParams(Type):
     _toPy = {'members': 'members'}
     def __init__(self, members=None, **unknown_fields):
         '''
-        members : typing.Sequence<+T_co>[~Member]<~Member>
+        members : typing.Sequence[~Member]
         '''
         members_ = [Member.from_json(o) for o in members or []]
 
@@ -18138,7 +18138,7 @@ class RetryStrategyResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~RetryStrategyResult]<~RetryStrategyResult>
+        results : typing.Sequence[~RetryStrategyResult]
         '''
         results_ = [RetryStrategyResult.from_json(o) for o in results or []]
 
@@ -18180,7 +18180,7 @@ class RevokeCredentialArgs(Type):
     _toPy = {'credentials': 'credentials'}
     def __init__(self, credentials=None, **unknown_fields):
         '''
-        credentials : typing.Sequence<+T_co>[~RevokeCredentialArg]<~RevokeCredentialArg>
+        credentials : typing.Sequence[~RevokeCredentialArg]
         '''
         credentials_ = [RevokeCredentialArg.from_json(o) for o in credentials or []]
 
@@ -18198,11 +18198,11 @@ class RunParams(Type):
     _toPy = {'applications': 'applications', 'commands': 'commands', 'machines': 'machines', 'timeout': 'timeout', 'units': 'units', 'workload-context': 'workload_context'}
     def __init__(self, applications=None, commands=None, machines=None, timeout=None, units=None, workload_context=None, **unknown_fields):
         '''
-        applications : typing.Sequence<+T_co>[str]
+        applications : typing.Sequence[str]
         commands : str
-        machines : typing.Sequence<+T_co>[str]
+        machines : typing.Sequence[str]
         timeout : int
-        units : typing.Sequence<+T_co>[str]
+        units : typing.Sequence[str]
         workload_context : bool
         '''
         applications_ = applications
@@ -18270,7 +18270,7 @@ class SSHAddressResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~SSHAddressResult]<~SSHAddressResult>
+        results : typing.Sequence[~SSHAddressResult]
         '''
         results_ = [SSHAddressResult.from_json(o) for o in results or []]
 
@@ -18288,7 +18288,7 @@ class SSHAddressesResult(Type):
     _toPy = {'addresses': 'addresses', 'error': 'error'}
     def __init__(self, addresses=None, error=None, **unknown_fields):
         '''
-        addresses : typing.Sequence<+T_co>[str]
+        addresses : typing.Sequence[str]
         error : Error
         '''
         addresses_ = addresses
@@ -18312,7 +18312,7 @@ class SSHAddressesResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~SSHAddressesResult]<~SSHAddressesResult>
+        results : typing.Sequence[~SSHAddressesResult]
         '''
         results_ = [SSHAddressesResult.from_json(o) for o in results or []]
 
@@ -18330,7 +18330,7 @@ class SSHHostKeySet(Type):
     _toPy = {'entity-keys': 'entity_keys'}
     def __init__(self, entity_keys=None, **unknown_fields):
         '''
-        entity_keys : typing.Sequence<+T_co>[~SSHHostKeys]<~SSHHostKeys>
+        entity_keys : typing.Sequence[~SSHHostKeys]
         '''
         entity_keys_ = [SSHHostKeys.from_json(o) for o in entity_keys or []]
 
@@ -18348,7 +18348,7 @@ class SSHHostKeys(Type):
     _toPy = {'public-keys': 'public_keys', 'tag': 'tag'}
     def __init__(self, public_keys=None, tag=None, **unknown_fields):
         '''
-        public_keys : typing.Sequence<+T_co>[str]
+        public_keys : typing.Sequence[str]
         tag : str
         '''
         public_keys_ = public_keys
@@ -18391,7 +18391,7 @@ class SSHPublicKeysResult(Type):
     def __init__(self, error=None, public_keys=None, **unknown_fields):
         '''
         error : Error
-        public_keys : typing.Sequence<+T_co>[str]
+        public_keys : typing.Sequence[str]
         '''
         error_ = Error.from_json(error) if error else None
         public_keys_ = public_keys
@@ -18414,7 +18414,7 @@ class SSHPublicKeysResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~SSHPublicKeysResult]<~SSHPublicKeysResult>
+        results : typing.Sequence[~SSHPublicKeysResult]
         '''
         results_ = [SSHPublicKeysResult.from_json(o) for o in results or []]
 
@@ -18510,7 +18510,7 @@ class ScaleApplicationResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ScaleApplicationResult]<~ScaleApplicationResult>
+        results : typing.Sequence[~ScaleApplicationResult]
         '''
         results_ = [ScaleApplicationResult.from_json(o) for o in results or []]
 
@@ -18528,7 +18528,7 @@ class ScaleApplicationsParams(Type):
     _toPy = {'applications': 'applications'}
     def __init__(self, applications=None, **unknown_fields):
         '''
-        applications : typing.Sequence<+T_co>[~ScaleApplicationParams]<~ScaleApplicationParams>
+        applications : typing.Sequence[~ScaleApplicationParams]
         '''
         applications_ = [ScaleApplicationParams.from_json(o) for o in applications or []]
 
@@ -18546,10 +18546,10 @@ class SerializedModel(Type):
     _toPy = {'bytes': 'bytes_', 'charms': 'charms', 'resources': 'resources', 'tools': 'tools'}
     def __init__(self, bytes_=None, charms=None, resources=None, tools=None, **unknown_fields):
         '''
-        bytes_ : typing.Sequence<+T_co>[int]
-        charms : typing.Sequence<+T_co>[str]
-        resources : typing.Sequence<+T_co>[~SerializedModelResource]<~SerializedModelResource>
-        tools : typing.Sequence<+T_co>[~SerializedModelTools]<~SerializedModelTools>
+        bytes_ : typing.Sequence[int]
+        charms : typing.Sequence[str]
+        resources : typing.Sequence[~SerializedModelResource]
+        tools : typing.Sequence[~SerializedModelTools]
         '''
         bytes__ = bytes_
         charms_ = charms
@@ -18586,7 +18586,7 @@ class SerializedModelResource(Type):
         application_revision : SerializedModelResourceRevision
         charmstore_revision : SerializedModelResourceRevision
         name : str
-        unit_revisions : typing.Mapping<~KT, +VT_co>[str, ~SerializedModelResourceRevision]<~SerializedModelResourceRevision>
+        unit_revisions : typing.Mapping[str, ~SerializedModelResourceRevision]
         '''
         application_ = application
         application_revision_ = SerializedModelResourceRevision.from_json(application_revision) if application_revision else None
@@ -18756,7 +18756,7 @@ class SetExternalControllersInfoParams(Type):
     _toPy = {'controllers': 'controllers'}
     def __init__(self, controllers=None, **unknown_fields):
         '''
-        controllers : typing.Sequence<+T_co>[~SetExternalControllerInfoParams]<~SetExternalControllerInfoParams>
+        controllers : typing.Sequence[~SetExternalControllerInfoParams]
         '''
         controllers_ = [SetExternalControllerInfoParams.from_json(o) for o in controllers or []]
 
@@ -18774,7 +18774,7 @@ class SetMachineBlockDevices(Type):
     _toPy = {'machine-block-devices': 'machine_block_devices'}
     def __init__(self, machine_block_devices=None, **unknown_fields):
         '''
-        machine_block_devices : typing.Sequence<+T_co>[~MachineBlockDevices]<~MachineBlockDevices>
+        machine_block_devices : typing.Sequence[~MachineBlockDevices]
         '''
         machine_block_devices_ = [MachineBlockDevices.from_json(o) for o in machine_block_devices or []]
 
@@ -18792,7 +18792,7 @@ class SetMachineNetworkConfig(Type):
     _toPy = {'config': 'config', 'tag': 'tag'}
     def __init__(self, config=None, tag=None, **unknown_fields):
         '''
-        config : typing.Sequence<+T_co>[~NetworkConfig]<~NetworkConfig>
+        config : typing.Sequence[~NetworkConfig]
         tag : str
         '''
         config_ = [NetworkConfig.from_json(o) for o in config or []]
@@ -18816,7 +18816,7 @@ class SetMachinesAddresses(Type):
     _toPy = {'machine-addresses': 'machine_addresses'}
     def __init__(self, machine_addresses=None, **unknown_fields):
         '''
-        machine_addresses : typing.Sequence<+T_co>[~MachineAddresses]<~MachineAddresses>
+        machine_addresses : typing.Sequence[~MachineAddresses]
         '''
         machine_addresses_ = [MachineAddresses.from_json(o) for o in machine_addresses or []]
 
@@ -18894,7 +18894,7 @@ class SetModelDefaults(Type):
     _toPy = {'config': 'config'}
     def __init__(self, config=None, **unknown_fields):
         '''
-        config : typing.Sequence<+T_co>[~ModelDefaultValues]<~ModelDefaultValues>
+        config : typing.Sequence[~ModelDefaultValues]
         '''
         config_ = [ModelDefaultValues.from_json(o) for o in config or []]
 
@@ -18936,7 +18936,7 @@ class SetModelEnvironVersions(Type):
     _toPy = {'models': 'models'}
     def __init__(self, models=None, **unknown_fields):
         '''
-        models : typing.Sequence<+T_co>[~SetModelEnvironVersion]<~SetModelEnvironVersion>
+        models : typing.Sequence[~SetModelEnvironVersion]
         '''
         models_ = [SetModelEnvironVersion.from_json(o) for o in models or []]
 
@@ -18984,7 +18984,7 @@ class SetPayloadStatusArgs(Type):
     _toPy = {'args': 'args'}
     def __init__(self, args=None, **unknown_fields):
         '''
-        args : typing.Sequence<+T_co>[~SetPayloadStatusArg]<~SetPayloadStatusArg>
+        args : typing.Sequence[~SetPayloadStatusArg]
         '''
         args_ = [SetPayloadStatusArg.from_json(o) for o in args or []]
 
@@ -19002,7 +19002,7 @@ class SetPodSpecParams(Type):
     _toPy = {'specs': 'specs'}
     def __init__(self, specs=None, **unknown_fields):
         '''
-        specs : typing.Sequence<+T_co>[~EntityString]<~EntityString>
+        specs : typing.Sequence[~EntityString]
         '''
         specs_ = [EntityString.from_json(o) for o in specs or []]
 
@@ -19021,7 +19021,7 @@ class SetProfileArg(Type):
     def __init__(self, entity=None, profiles=None, **unknown_fields):
         '''
         entity : Entity
-        profiles : typing.Sequence<+T_co>[str]
+        profiles : typing.Sequence[str]
         '''
         entity_ = Entity.from_json(entity) if entity else None
         profiles_ = profiles
@@ -19044,7 +19044,7 @@ class SetProfileArgs(Type):
     _toPy = {'args': 'args'}
     def __init__(self, args=None, **unknown_fields):
         '''
-        args : typing.Sequence<+T_co>[~SetProfileArg]<~SetProfileArg>
+        args : typing.Sequence[~SetProfileArg]
         '''
         args_ = [SetProfileArg.from_json(o) for o in args or []]
 
@@ -19086,7 +19086,7 @@ class SetProfileUpgradeCompleteArgs(Type):
     _toPy = {'args': 'args'}
     def __init__(self, args=None, **unknown_fields):
         '''
-        args : typing.Sequence<+T_co>[~SetProfileUpgradeCompleteArg]<~SetProfileUpgradeCompleteArg>
+        args : typing.Sequence[~SetProfileUpgradeCompleteArg]
         '''
         args_ = [SetProfileUpgradeCompleteArg.from_json(o) for o in args or []]
 
@@ -19104,7 +19104,7 @@ class SetStatus(Type):
     _toPy = {'entities': 'entities'}
     def __init__(self, entities=None, **unknown_fields):
         '''
-        entities : typing.Sequence<+T_co>[~EntityStatusArgs]<~EntityStatusArgs>
+        entities : typing.Sequence[~EntityStatusArgs]
         '''
         entities_ = [EntityStatusArgs.from_json(o) for o in entities or []]
 
@@ -19146,7 +19146,7 @@ class SetStatusArgs(Type):
     _toPy = {'args': 'args'}
     def __init__(self, args=None, **unknown_fields):
         '''
-        args : typing.Sequence<+T_co>[~SetStatusArg]<~SetStatusArg>
+        args : typing.Sequence[~SetStatusArg]
         '''
         args_ = [SetStatusArg.from_json(o) for o in args or []]
 
@@ -19207,7 +19207,7 @@ class SettingsResult(Type):
     def __init__(self, error=None, settings=None, **unknown_fields):
         '''
         error : Error
-        settings : typing.Mapping<~KT, +VT_co>[str, str]
+        settings : typing.Mapping[str, str]
         '''
         error_ = Error.from_json(error) if error else None
         settings_ = settings
@@ -19230,7 +19230,7 @@ class SettingsResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~SettingsResult]<~SettingsResult>
+        results : typing.Sequence[~SettingsResult]
         '''
         results_ = [SettingsResult.from_json(o) for o in results or []]
 
@@ -19278,7 +19278,7 @@ class SingularClaims(Type):
     _toPy = {'claims': 'claims'}
     def __init__(self, claims=None, **unknown_fields):
         '''
-        claims : typing.Sequence<+T_co>[~SingularClaim]<~SingularClaim>
+        claims : typing.Sequence[~SingularClaim]
         '''
         claims_ = [SingularClaim.from_json(o) for o in claims or []]
 
@@ -19299,7 +19299,7 @@ class Space(Type):
         error : Error
         id_ : str
         name : str
-        subnets : typing.Sequence<+T_co>[~Subnet]<~Subnet>
+        subnets : typing.Sequence[~Subnet]
         '''
         error_ = Error.from_json(error) if error else None
         id__ = id_
@@ -19356,7 +19356,7 @@ class SpaceResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~SpaceResult]<~SpaceResult>
+        results : typing.Sequence[~SpaceResult]
         '''
         results_ = [SpaceResult.from_json(o) for o in results or []]
 
@@ -19436,7 +19436,7 @@ class StatusHistoryFilter(Type):
         '''
         date : str
         delta : int
-        exclude : typing.Sequence<+T_co>[str]
+        exclude : typing.Sequence[str]
         size : int
         '''
         date_ = date
@@ -19530,7 +19530,7 @@ class StatusHistoryRequests(Type):
     _toPy = {'requests': 'requests'}
     def __init__(self, requests=None, **unknown_fields):
         '''
-        requests : typing.Sequence<+T_co>[~StatusHistoryRequest]<~StatusHistoryRequest>
+        requests : typing.Sequence[~StatusHistoryRequest]
         '''
         requests_ = [StatusHistoryRequest.from_json(o) for o in requests or []]
 
@@ -19572,7 +19572,7 @@ class StatusHistoryResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~StatusHistoryResult]<~StatusHistoryResult>
+        results : typing.Sequence[~StatusHistoryResult]
         '''
         results_ = [StatusHistoryResult.from_json(o) for o in results or []]
 
@@ -19590,7 +19590,7 @@ class StatusParams(Type):
     _toPy = {'patterns': 'patterns'}
     def __init__(self, patterns=None, **unknown_fields):
         '''
-        patterns : typing.Sequence<+T_co>[str]
+        patterns : typing.Sequence[str]
         '''
         patterns_ = patterns
 
@@ -19608,7 +19608,7 @@ class StatusResult(Type):
     _toPy = {'data': 'data', 'error': 'error', 'id': 'id_', 'info': 'info', 'life': 'life', 'since': 'since', 'status': 'status'}
     def __init__(self, data=None, error=None, id_=None, info=None, life=None, since=None, status=None, **unknown_fields):
         '''
-        data : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        data : typing.Mapping[str, typing.Any]
         error : Error
         id_ : str
         info : str
@@ -19662,7 +19662,7 @@ class StatusResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~StatusResult]<~StatusResult>
+        results : typing.Sequence[~StatusResult]
         '''
         results_ = [StatusResult.from_json(o) for o in results or []]
 
@@ -19824,7 +19824,7 @@ class StorageAttachmentIds(Type):
     _toPy = {'ids': 'ids'}
     def __init__(self, ids=None, **unknown_fields):
         '''
-        ids : typing.Sequence<+T_co>[~StorageAttachmentId]<~StorageAttachmentId>
+        ids : typing.Sequence[~StorageAttachmentId]
         '''
         ids_ = [StorageAttachmentId.from_json(o) for o in ids or []]
 
@@ -19866,7 +19866,7 @@ class StorageAttachmentIdsResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~StorageAttachmentIdsResult]<~StorageAttachmentIdsResult>
+        results : typing.Sequence[~StorageAttachmentIdsResult]
         '''
         results_ = [StorageAttachmentIdsResult.from_json(o) for o in results or []]
 
@@ -19908,7 +19908,7 @@ class StorageAttachmentResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~StorageAttachmentResult]<~StorageAttachmentResult>
+        results : typing.Sequence[~StorageAttachmentResult]
         '''
         results_ = [StorageAttachmentResult.from_json(o) for o in results or []]
 
@@ -19986,7 +19986,7 @@ class StorageDetails(Type):
     _toPy = {'attachments': 'attachments', 'kind': 'kind', 'life': 'life', 'owner-tag': 'owner_tag', 'persistent': 'persistent', 'status': 'status', 'storage-tag': 'storage_tag'}
     def __init__(self, attachments=None, kind=None, life=None, owner_tag=None, persistent=None, status=None, storage_tag=None, **unknown_fields):
         '''
-        attachments : typing.Mapping<~KT, +VT_co>[str, ~StorageAttachmentDetails]<~StorageAttachmentDetails>
+        attachments : typing.Mapping[str, ~StorageAttachmentDetails]
         kind : int
         life : str
         owner_tag : str
@@ -20041,7 +20041,7 @@ class StorageDetailsListResult(Type):
     def __init__(self, error=None, result=None, **unknown_fields):
         '''
         error : Error
-        result : typing.Sequence<+T_co>[~StorageDetails]<~StorageDetails>
+        result : typing.Sequence[~StorageDetails]
         '''
         error_ = Error.from_json(error) if error else None
         result_ = [StorageDetails.from_json(o) for o in result or []]
@@ -20064,7 +20064,7 @@ class StorageDetailsListResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~StorageDetailsListResult]<~StorageDetailsListResult>
+        results : typing.Sequence[~StorageDetailsListResult]
         '''
         results_ = [StorageDetailsListResult.from_json(o) for o in results or []]
 
@@ -20106,7 +20106,7 @@ class StorageDetailsResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~StorageDetailsResult]<~StorageDetailsResult>
+        results : typing.Sequence[~StorageDetailsResult]
         '''
         results_ = [StorageDetailsResult.from_json(o) for o in results or []]
 
@@ -20135,7 +20135,7 @@ class StorageFilters(Type):
     _toPy = {'filters': 'filters'}
     def __init__(self, filters=None, **unknown_fields):
         '''
-        filters : typing.Sequence<+T_co>[~StorageFilter]<~StorageFilter>
+        filters : typing.Sequence[~StorageFilter]
         '''
         filters_ = [StorageFilter.from_json(o) for o in filters or []]
 
@@ -20153,7 +20153,7 @@ class StoragePool(Type):
     _toPy = {'attrs': 'attrs', 'name': 'name', 'provider': 'provider'}
     def __init__(self, attrs=None, name=None, provider=None, **unknown_fields):
         '''
-        attrs : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        attrs : typing.Mapping[str, typing.Any]
         name : str
         provider : str
         '''
@@ -20183,7 +20183,7 @@ class StoragePoolArgs(Type):
     _toPy = {'pools': 'pools'}
     def __init__(self, pools=None, **unknown_fields):
         '''
-        pools : typing.Sequence<+T_co>[~StoragePool]<~StoragePool>
+        pools : typing.Sequence[~StoragePool]
         '''
         pools_ = [StoragePool.from_json(o) for o in pools or []]
 
@@ -20219,7 +20219,7 @@ class StoragePoolDeleteArgs(Type):
     _toPy = {'pools': 'pools'}
     def __init__(self, pools=None, **unknown_fields):
         '''
-        pools : typing.Sequence<+T_co>[~StoragePoolDeleteArg]<~StoragePoolDeleteArg>
+        pools : typing.Sequence[~StoragePoolDeleteArg]
         '''
         pools_ = [StoragePoolDeleteArg.from_json(o) for o in pools or []]
 
@@ -20237,8 +20237,8 @@ class StoragePoolFilter(Type):
     _toPy = {'names': 'names', 'providers': 'providers'}
     def __init__(self, names=None, providers=None, **unknown_fields):
         '''
-        names : typing.Sequence<+T_co>[str]
-        providers : typing.Sequence<+T_co>[str]
+        names : typing.Sequence[str]
+        providers : typing.Sequence[str]
         '''
         names_ = names
         providers_ = providers
@@ -20261,7 +20261,7 @@ class StoragePoolFilters(Type):
     _toPy = {'filters': 'filters'}
     def __init__(self, filters=None, **unknown_fields):
         '''
-        filters : typing.Sequence<+T_co>[~StoragePoolFilter]<~StoragePoolFilter>
+        filters : typing.Sequence[~StoragePoolFilter]
         '''
         filters_ = [StoragePoolFilter.from_json(o) for o in filters or []]
 
@@ -20280,7 +20280,7 @@ class StoragePoolsResult(Type):
     def __init__(self, error=None, storage_pools=None, **unknown_fields):
         '''
         error : Error
-        storage_pools : typing.Sequence<+T_co>[~StoragePool]<~StoragePool>
+        storage_pools : typing.Sequence[~StoragePool]
         '''
         error_ = Error.from_json(error) if error else None
         storage_pools_ = [StoragePool.from_json(o) for o in storage_pools or []]
@@ -20303,7 +20303,7 @@ class StoragePoolsResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~StoragePoolsResult]<~StoragePoolsResult>
+        results : typing.Sequence[~StoragePoolsResult]
         '''
         results_ = [StoragePoolsResult.from_json(o) for o in results or []]
 
@@ -20321,7 +20321,7 @@ class StoragesAddParams(Type):
     _toPy = {'storages': 'storages'}
     def __init__(self, storages=None, **unknown_fields):
         '''
-        storages : typing.Sequence<+T_co>[~StorageAddParams]<~StorageAddParams>
+        storages : typing.Sequence[~StorageAddParams]
         '''
         storages_ = [StorageAddParams.from_json(o) for o in storages or []]
 
@@ -20369,7 +20369,7 @@ class StringBoolResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~StringBoolResult]<~StringBoolResult>
+        results : typing.Sequence[~StringBoolResult]
         '''
         results_ = [StringBoolResult.from_json(o) for o in results or []]
 
@@ -20411,7 +20411,7 @@ class StringResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~StringResult]<~StringResult>
+        results : typing.Sequence[~StringResult]
         '''
         results_ = [StringResult.from_json(o) for o in results or []]
 
@@ -20430,7 +20430,7 @@ class StringsResult(Type):
     def __init__(self, error=None, result=None, **unknown_fields):
         '''
         error : Error
-        result : typing.Sequence<+T_co>[str]
+        result : typing.Sequence[str]
         '''
         error_ = Error.from_json(error) if error else None
         result_ = result
@@ -20453,7 +20453,7 @@ class StringsResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~StringsResult]<~StringsResult>
+        results : typing.Sequence[~StringsResult]
         '''
         results_ = [StringsResult.from_json(o) for o in results or []]
 
@@ -20471,7 +20471,7 @@ class StringsWatchResult(Type):
     _toPy = {'changes': 'changes', 'error': 'error', 'watcher-id': 'watcher_id'}
     def __init__(self, changes=None, error=None, watcher_id=None, **unknown_fields):
         '''
-        changes : typing.Sequence<+T_co>[str]
+        changes : typing.Sequence[str]
         error : Error
         watcher_id : str
         '''
@@ -20501,7 +20501,7 @@ class StringsWatchResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~StringsWatchResult]<~StringsWatchResult>
+        results : typing.Sequence[~StringsWatchResult]
         '''
         results_ = [StringsWatchResult.from_json(o) for o in results or []]
 
@@ -20527,7 +20527,7 @@ class Subnet(Type):
         space_tag : str
         status : str
         vlan_tag : int
-        zones : typing.Sequence<+T_co>[str]
+        zones : typing.Sequence[str]
         '''
         cidr_ = cidr
         life_ = life
@@ -20633,7 +20633,7 @@ class TaggedCredentials(Type):
     _toPy = {'credentials': 'credentials'}
     def __init__(self, credentials=None, **unknown_fields):
         '''
-        credentials : typing.Sequence<+T_co>[~TaggedCredential]<~TaggedCredential>
+        credentials : typing.Sequence[~TaggedCredential]
         '''
         credentials_ = [TaggedCredential.from_json(o) for o in credentials or []]
 
@@ -20675,7 +20675,7 @@ class TokenResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~TokenResult]<~TokenResult>
+        results : typing.Sequence[~TokenResult]
         '''
         results_ = [TokenResult.from_json(o) for o in results or []]
 
@@ -20731,7 +20731,7 @@ class ToolsResult(Type):
         '''
         disable_ssl_hostname_verification : bool
         error : Error
-        tools : typing.Sequence<+T_co>[~Tools]<~Tools>
+        tools : typing.Sequence[~Tools]
         '''
         disable_ssl_hostname_verification_ = disable_ssl_hostname_verification
         error_ = Error.from_json(error) if error else None
@@ -20759,7 +20759,7 @@ class ToolsResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ToolsResult]<~ToolsResult>
+        results : typing.Sequence[~ToolsResult]
         '''
         results_ = [ToolsResult.from_json(o) for o in results or []]
 
@@ -20777,7 +20777,7 @@ class TrackArgs(Type):
     _toPy = {'payloads': 'payloads'}
     def __init__(self, payloads=None, **unknown_fields):
         '''
-        payloads : typing.Sequence<+T_co>[~Payload]<~Payload>
+        payloads : typing.Sequence[~Payload]
         '''
         payloads_ = [Payload.from_json(o) for o in payloads or []]
 
@@ -20795,7 +20795,7 @@ class TrackPayloadArgs(Type):
     _toPy = {'payloads': 'payloads'}
     def __init__(self, payloads=None, **unknown_fields):
         '''
-        payloads : typing.Sequence<+T_co>[~Payload]<~Payload>
+        payloads : typing.Sequence[~Payload]
         '''
         payloads_ = [Payload.from_json(o) for o in payloads or []]
 
@@ -20910,7 +20910,7 @@ class UnitNetworkConfigResult(Type):
     def __init__(self, error=None, info=None, **unknown_fields):
         '''
         error : Error
-        info : typing.Sequence<+T_co>[~NetworkConfig]<~NetworkConfig>
+        info : typing.Sequence[~NetworkConfig]
         '''
         error_ = Error.from_json(error) if error else None
         info_ = [NetworkConfig.from_json(o) for o in info or []]
@@ -20933,7 +20933,7 @@ class UnitNetworkConfigResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~UnitNetworkConfigResult]<~UnitNetworkConfigResult>
+        results : typing.Sequence[~UnitNetworkConfigResult]
         '''
         results_ = [UnitNetworkConfigResult.from_json(o) for o in results or []]
 
@@ -20987,7 +20987,7 @@ class UnitRefreshResults(Type):
     _toPy = {'Results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~UnitRefreshResult]<~UnitRefreshResult>
+        results : typing.Sequence[~UnitRefreshResult]
         '''
         results_ = [UnitRefreshResult.from_json(o) for o in results or []]
 
@@ -21036,8 +21036,8 @@ class UnitResources(Type):
     def __init__(self, entity=None, download_progress=None, resources=None, tag=None, **unknown_fields):
         '''
         entity : Entity
-        download_progress : typing.Mapping<~KT, +VT_co>[str, int]
-        resources : typing.Sequence<+T_co>[~Resource]<~Resource>
+        download_progress : typing.Mapping[str, int]
+        resources : typing.Sequence[~Resource]
         tag : str
         '''
         entity_ = Entity.from_json(entity) if entity else None
@@ -21073,7 +21073,7 @@ class UnitResourcesResult(Type):
         '''
         errorresult : ErrorResult
         error : Error
-        resources : typing.Sequence<+T_co>[~UnitResourceResult]<~UnitResourceResult>
+        resources : typing.Sequence[~UnitResourceResult]
         '''
         errorresult_ = ErrorResult.from_json(errorresult) if errorresult else None
         error_ = Error.from_json(error) if error else None
@@ -21124,10 +21124,10 @@ class UnitStatus(Type):
         charm : str
         leader : bool
         machine : str
-        opened_ports : typing.Sequence<+T_co>[str]
+        opened_ports : typing.Sequence[str]
         provider_id : str
         public_address : str
-        subordinates : typing.Mapping<~KT, +VT_co>[str, ~UnitStatus]<~UnitStatus>
+        subordinates : typing.Mapping[str, ~UnitStatus]
         workload_status : DetailedStatus
         workload_version : str
         '''
@@ -21197,7 +21197,7 @@ class UnitsNetworkConfig(Type):
     _toPy = {'args': 'args'}
     def __init__(self, args=None, **unknown_fields):
         '''
-        args : typing.Sequence<+T_co>[~UnitNetworkConfig]<~UnitNetworkConfig>
+        args : typing.Sequence[~UnitNetworkConfig]
         '''
         args_ = [UnitNetworkConfig.from_json(o) for o in args or []]
 
@@ -21245,7 +21245,7 @@ class UnsetModelDefaults(Type):
     _toPy = {'keys': 'keys'}
     def __init__(self, keys=None, **unknown_fields):
         '''
-        keys : typing.Sequence<+T_co>[~ModelUnsetKeys]<~ModelUnsetKeys>
+        keys : typing.Sequence[~ModelUnsetKeys]
         '''
         keys_ = [ModelUnsetKeys.from_json(o) for o in keys or []]
 
@@ -21263,7 +21263,7 @@ class UpdateApplicationServiceArg(Type):
     _toPy = {'addresses': 'addresses', 'application-tag': 'application_tag', 'generation': 'generation', 'provider-id': 'provider_id', 'scale': 'scale'}
     def __init__(self, addresses=None, application_tag=None, generation=None, provider_id=None, scale=None, **unknown_fields):
         '''
-        addresses : typing.Sequence<+T_co>[~Address]<~Address>
+        addresses : typing.Sequence[~Address]
         application_tag : str
         generation : int
         provider_id : str
@@ -21305,7 +21305,7 @@ class UpdateApplicationServiceArgs(Type):
     _toPy = {'args': 'args'}
     def __init__(self, args=None, **unknown_fields):
         '''
-        args : typing.Sequence<+T_co>[~UpdateApplicationServiceArg]<~UpdateApplicationServiceArg>
+        args : typing.Sequence[~UpdateApplicationServiceArg]
         '''
         args_ = [UpdateApplicationServiceArg.from_json(o) for o in args or []]
 
@@ -21323,7 +21323,7 @@ class UpdateApplicationUnitArgs(Type):
     _toPy = {'args': 'args'}
     def __init__(self, args=None, **unknown_fields):
         '''
-        args : typing.Sequence<+T_co>[~UpdateApplicationUnits]<~UpdateApplicationUnits>
+        args : typing.Sequence[~UpdateApplicationUnits]
         '''
         args_ = [UpdateApplicationUnits.from_json(o) for o in args or []]
 
@@ -21345,7 +21345,7 @@ class UpdateApplicationUnits(Type):
         generation : int
         scale : int
         status : EntityStatus
-        units : typing.Sequence<+T_co>[~ApplicationUnitParams]<~ApplicationUnitParams>
+        units : typing.Sequence[~ApplicationUnitParams]
         '''
         application_tag_ = application_tag
         generation_ = generation
@@ -21407,7 +21407,7 @@ class UpdateCloudArgs(Type):
     _toPy = {'clouds': 'clouds'}
     def __init__(self, clouds=None, **unknown_fields):
         '''
-        clouds : typing.Sequence<+T_co>[~AddCloudArgs]<~AddCloudArgs>
+        clouds : typing.Sequence[~AddCloudArgs]
         '''
         clouds_ = [AddCloudArgs.from_json(o) for o in clouds or []]
 
@@ -21449,7 +21449,7 @@ class UpdateCloudCredentials(Type):
     _toPy = {'credentials': 'credentials'}
     def __init__(self, credentials=None, **unknown_fields):
         '''
-        credentials : typing.Sequence<+T_co>[~UpdateCloudCredential]<~UpdateCloudCredential>
+        credentials : typing.Sequence[~UpdateCloudCredential]
         '''
         credentials_ = [UpdateCloudCredential.from_json(o) for o in credentials or []]
 
@@ -21467,7 +21467,7 @@ class UpdateCredentialArgs(Type):
     _toPy = {'credentials': 'credentials', 'force': 'force'}
     def __init__(self, credentials=None, force=None, **unknown_fields):
         '''
-        credentials : typing.Sequence<+T_co>[~TaggedCredential]<~TaggedCredential>
+        credentials : typing.Sequence[~TaggedCredential]
         force : bool
         '''
         credentials_ = [TaggedCredential.from_json(o) for o in credentials or []]
@@ -21491,7 +21491,7 @@ class UpdateCredentialModelResult(Type):
     _toPy = {'errors': 'errors', 'name': 'name', 'uuid': 'uuid'}
     def __init__(self, errors=None, name=None, uuid=None, **unknown_fields):
         '''
-        errors : typing.Sequence<+T_co>[~ErrorResult]<~ErrorResult>
+        errors : typing.Sequence[~ErrorResult]
         name : str
         uuid : str
         '''
@@ -21522,7 +21522,7 @@ class UpdateCredentialResult(Type):
     def __init__(self, error=None, models=None, tag=None, **unknown_fields):
         '''
         error : Error
-        models : typing.Sequence<+T_co>[~UpdateCredentialModelResult]<~UpdateCredentialModelResult>
+        models : typing.Sequence[~UpdateCredentialModelResult]
         tag : str
         '''
         error_ = Error.from_json(error) if error else None
@@ -21551,7 +21551,7 @@ class UpdateCredentialResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~UpdateCredentialResult]<~UpdateCredentialResult>
+        results : typing.Sequence[~UpdateCredentialResult]
         '''
         results_ = [UpdateCredentialResult.from_json(o) for o in results or []]
 
@@ -21599,7 +21599,7 @@ class UpdateSeriesArgs(Type):
     _toPy = {'args': 'args'}
     def __init__(self, args=None, **unknown_fields):
         '''
-        args : typing.Sequence<+T_co>[~UpdateSeriesArg]<~UpdateSeriesArg>
+        args : typing.Sequence[~UpdateSeriesArg]
         '''
         args_ = [UpdateSeriesArg.from_json(o) for o in args or []]
 
@@ -21659,7 +21659,7 @@ class UpgradeSeriesNotificationParams(Type):
     _toPy = {'params': 'params'}
     def __init__(self, params=None, **unknown_fields):
         '''
-        params : typing.Sequence<+T_co>[~UpgradeSeriesNotificationParam]<~UpgradeSeriesNotificationParam>
+        params : typing.Sequence[~UpgradeSeriesNotificationParam]
         '''
         params_ = [UpgradeSeriesNotificationParam.from_json(o) for o in params or []]
 
@@ -21677,7 +21677,7 @@ class UpgradeSeriesStartUnitCompletionParam(Type):
     _toPy = {'entities': 'entities', 'message': 'message'}
     def __init__(self, entities=None, message=None, **unknown_fields):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
+        entities : typing.Sequence[~Entity]
         message : str
         '''
         entities_ = [Entity.from_json(o) for o in entities or []]
@@ -21731,7 +21731,7 @@ class UpgradeSeriesStatusParams(Type):
     _toPy = {'params': 'params'}
     def __init__(self, params=None, **unknown_fields):
         '''
-        params : typing.Sequence<+T_co>[~UpgradeSeriesStatusParam]<~UpgradeSeriesStatusParam>
+        params : typing.Sequence[~UpgradeSeriesStatusParam]
         '''
         params_ = [UpgradeSeriesStatusParam.from_json(o) for o in params or []]
 
@@ -21773,7 +21773,7 @@ class UpgradeSeriesStatusResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~UpgradeSeriesStatusResult]<~UpgradeSeriesStatusResult>
+        results : typing.Sequence[~UpgradeSeriesStatusResult]
         '''
         results_ = [UpgradeSeriesStatusResult.from_json(o) for o in results or []]
 
@@ -21792,7 +21792,7 @@ class UpgradeSeriesUnitsResult(Type):
     def __init__(self, error=None, unit_names=None, **unknown_fields):
         '''
         error : Error
-        unit_names : typing.Sequence<+T_co>[str]
+        unit_names : typing.Sequence[str]
         '''
         error_ = Error.from_json(error) if error else None
         unit_names_ = unit_names
@@ -21815,7 +21815,7 @@ class UpgradeSeriesUnitsResults(Type):
     _toPy = {'Results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~UpgradeSeriesUnitsResult]<~UpgradeSeriesUnitsResult>
+        results : typing.Sequence[~UpgradeSeriesUnitsResult]
         '''
         results_ = [UpgradeSeriesUnitsResult.from_json(o) for o in results or []]
 
@@ -21881,7 +21881,7 @@ class UserAccessResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~UserAccessResult]<~UserAccessResult>
+        results : typing.Sequence[~UserAccessResult]
         '''
         results_ = [UserAccessResult.from_json(o) for o in results or []]
 
@@ -21923,7 +21923,7 @@ class UserClouds(Type):
     _toPy = {'user-clouds': 'user_clouds'}
     def __init__(self, user_clouds=None, **unknown_fields):
         '''
-        user_clouds : typing.Sequence<+T_co>[~UserCloud]<~UserCloud>
+        user_clouds : typing.Sequence[~UserCloud]
         '''
         user_clouds_ = [UserCloud.from_json(o) for o in user_clouds or []]
 
@@ -21995,7 +21995,7 @@ class UserInfoRequest(Type):
     _toPy = {'entities': 'entities', 'include-disabled': 'include_disabled'}
     def __init__(self, entities=None, include_disabled=None, **unknown_fields):
         '''
-        entities : typing.Sequence<+T_co>[~Entity]<~Entity>
+        entities : typing.Sequence[~Entity]
         include_disabled : bool
         '''
         entities_ = [Entity.from_json(o) for o in entities or []]
@@ -22043,7 +22043,7 @@ class UserInfoResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~UserInfoResult]<~UserInfoResult>
+        results : typing.Sequence[~UserInfoResult]
         '''
         results_ = [UserInfoResult.from_json(o) for o in results or []]
 
@@ -22085,7 +22085,7 @@ class UserModelList(Type):
     _toPy = {'user-models': 'user_models'}
     def __init__(self, user_models=None, **unknown_fields):
         '''
-        user_models : typing.Sequence<+T_co>[~UserModel]<~UserModel>
+        user_models : typing.Sequence[~UserModel]
         '''
         user_models_ = [UserModel.from_json(o) for o in user_models or []]
 
@@ -22111,10 +22111,10 @@ class Value(Type):
         mem : int
         root_disk : int
         root_disk_source : str
-        spaces : typing.Sequence<+T_co>[str]
-        tags : typing.Sequence<+T_co>[str]
+        spaces : typing.Sequence[str]
+        tags : typing.Sequence[str]
         virt_type : str
-        zones : typing.Sequence<+T_co>[str]
+        zones : typing.Sequence[str]
         '''
         arch_ = arch
         container_ = container
@@ -22229,7 +22229,7 @@ class VersionResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~VersionResult]<~VersionResult>
+        results : typing.Sequence[~VersionResult]
         '''
         results_ = [VersionResult.from_json(o) for o in results or []]
 
@@ -22469,7 +22469,7 @@ class VolumeAttachmentParamsResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~VolumeAttachmentParamsResult]<~VolumeAttachmentParamsResult>
+        results : typing.Sequence[~VolumeAttachmentParamsResult]
         '''
         results_ = [VolumeAttachmentParamsResult.from_json(o) for o in results or []]
 
@@ -22529,7 +22529,7 @@ class VolumeAttachmentPlanInfo(Type):
     _toPy = {'device-attributes': 'device_attributes', 'device-type': 'device_type'}
     def __init__(self, device_attributes=None, device_type=None, **unknown_fields):
         '''
-        device_attributes : typing.Mapping<~KT, +VT_co>[str, str]
+        device_attributes : typing.Mapping[str, str]
         device_type : str
         '''
         device_attributes_ = device_attributes
@@ -22577,7 +22577,7 @@ class VolumeAttachmentPlanResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~VolumeAttachmentPlanResult]<~VolumeAttachmentPlanResult>
+        results : typing.Sequence[~VolumeAttachmentPlanResult]
         '''
         results_ = [VolumeAttachmentPlanResult.from_json(o) for o in results or []]
 
@@ -22595,7 +22595,7 @@ class VolumeAttachmentPlans(Type):
     _toPy = {'volume-plans': 'volume_plans'}
     def __init__(self, volume_plans=None, **unknown_fields):
         '''
-        volume_plans : typing.Sequence<+T_co>[~VolumeAttachmentPlan]<~VolumeAttachmentPlan>
+        volume_plans : typing.Sequence[~VolumeAttachmentPlan]
         '''
         volume_plans_ = [VolumeAttachmentPlan.from_json(o) for o in volume_plans or []]
 
@@ -22637,7 +22637,7 @@ class VolumeAttachmentResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~VolumeAttachmentResult]<~VolumeAttachmentResult>
+        results : typing.Sequence[~VolumeAttachmentResult]
         '''
         results_ = [VolumeAttachmentResult.from_json(o) for o in results or []]
 
@@ -22655,7 +22655,7 @@ class VolumeAttachments(Type):
     _toPy = {'volume-attachments': 'volume_attachments'}
     def __init__(self, volume_attachments=None, **unknown_fields):
         '''
-        volume_attachments : typing.Sequence<+T_co>[~VolumeAttachment]<~VolumeAttachment>
+        volume_attachments : typing.Sequence[~VolumeAttachment]
         '''
         volume_attachments_ = [VolumeAttachment.from_json(o) for o in volume_attachments or []]
 
@@ -22675,10 +22675,10 @@ class VolumeDetails(Type):
         '''
         info : VolumeInfo
         life : str
-        machine_attachments : typing.Mapping<~KT, +VT_co>[str, ~VolumeAttachmentDetails]<~VolumeAttachmentDetails>
+        machine_attachments : typing.Mapping[str, ~VolumeAttachmentDetails]
         status : EntityStatus
         storage : StorageDetails
-        unit_attachments : typing.Mapping<~KT, +VT_co>[str, ~VolumeAttachmentDetails]<~VolumeAttachmentDetails>
+        unit_attachments : typing.Mapping[str, ~VolumeAttachmentDetails]
         volume_tag : str
         '''
         info_ = VolumeInfo.from_json(info) if info else None
@@ -22728,7 +22728,7 @@ class VolumeDetailsListResult(Type):
     def __init__(self, error=None, result=None, **unknown_fields):
         '''
         error : Error
-        result : typing.Sequence<+T_co>[~VolumeDetails]<~VolumeDetails>
+        result : typing.Sequence[~VolumeDetails]
         '''
         error_ = Error.from_json(error) if error else None
         result_ = [VolumeDetails.from_json(o) for o in result or []]
@@ -22751,7 +22751,7 @@ class VolumeDetailsListResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~VolumeDetailsListResult]<~VolumeDetailsListResult>
+        results : typing.Sequence[~VolumeDetailsListResult]
         '''
         results_ = [VolumeDetailsListResult.from_json(o) for o in results or []]
 
@@ -22769,7 +22769,7 @@ class VolumeFilter(Type):
     _toPy = {'machines': 'machines'}
     def __init__(self, machines=None, **unknown_fields):
         '''
-        machines : typing.Sequence<+T_co>[str]
+        machines : typing.Sequence[str]
         '''
         machines_ = machines
 
@@ -22787,7 +22787,7 @@ class VolumeFilters(Type):
     _toPy = {'filters': 'filters'}
     def __init__(self, filters=None, **unknown_fields):
         '''
-        filters : typing.Sequence<+T_co>[~VolumeFilter]<~VolumeFilter>
+        filters : typing.Sequence[~VolumeFilter]
         '''
         filters_ = [VolumeFilter.from_json(o) for o in filters or []]
 
@@ -22854,10 +22854,10 @@ class VolumeParams(Type):
     def __init__(self, attachment=None, attributes=None, provider=None, size=None, tags=None, volume_tag=None, **unknown_fields):
         '''
         attachment : VolumeAttachmentParams
-        attributes : typing.Mapping<~KT, +VT_co>[str, typing.Any]
+        attributes : typing.Mapping[str, typing.Any]
         provider : str
         size : int
-        tags : typing.Mapping<~KT, +VT_co>[str, str]
+        tags : typing.Mapping[str, str]
         volume_tag : str
         '''
         attachment_ = VolumeAttachmentParams.from_json(attachment) if attachment else None
@@ -22925,7 +22925,7 @@ class VolumeParamsResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~VolumeParamsResult]<~VolumeParamsResult>
+        results : typing.Sequence[~VolumeParamsResult]
         '''
         results_ = [VolumeParamsResult.from_json(o) for o in results or []]
 
@@ -22967,7 +22967,7 @@ class VolumeResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~VolumeResult]<~VolumeResult>
+        results : typing.Sequence[~VolumeResult]
         '''
         results_ = [VolumeResult.from_json(o) for o in results or []]
 
@@ -22985,7 +22985,7 @@ class Volumes(Type):
     _toPy = {'volumes': 'volumes'}
     def __init__(self, volumes=None, **unknown_fields):
         '''
-        volumes : typing.Sequence<+T_co>[~Volume]<~Volume>
+        volumes : typing.Sequence[~Volume]
         '''
         volumes_ = [Volume.from_json(o) for o in volumes or []]
 
@@ -23027,7 +23027,7 @@ class WatchContainers(Type):
     _toPy = {'params': 'params'}
     def __init__(self, params=None, **unknown_fields):
         '''
-        params : typing.Sequence<+T_co>[~WatchContainer]<~WatchContainer>
+        params : typing.Sequence[~WatchContainer]
         '''
         params_ = [WatchContainer.from_json(o) for o in params or []]
 
@@ -23075,7 +23075,7 @@ class ZoneResults(Type):
     _toPy = {'results': 'results'}
     def __init__(self, results=None, **unknown_fields):
         '''
-        results : typing.Sequence<+T_co>[~ZoneResult]<~ZoneResult>
+        results : typing.Sequence[~ZoneResult]
         '''
         results_ = [ZoneResult.from_json(o) for o in results or []]
 

--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -28,7 +28,7 @@ client_facades = {
     'ApplicationScaler': {'versions': [1]},
     'Backups': {'versions': [1, 2]},
     'Block': {'versions': [2]},
-    'Bundle': {'versions': [1, 2, 3]},
+    'Bundle': {'versions': [1, 2, 3, 4]},
     'CharmRevisionUpdater': {'versions': [2]},
     'Charms': {'versions': [2]},
     'Cleaner': {'versions': [2]},


### PR DESCRIPTION
The following PR updates the BundleHandler code to use `GetChangesMapArgs` from Juju when possible. Additionally also updated the schema to have the latest 2.7-dev schema.

### QA

Ensure you have the following branch checked out https://github.com/juju/juju/pull/10601, or if it's merged, use develop branch.

Deploy the branch so we can test against it:
```sh
juju bootstrap lxd test --no-gui --build-agent
```

To ensure that we're using the right method call, change the following:
```diff
diff --git a/juju/bundle.py b/juju/bundle.py
index f6fd91f..6df6635 100644
--- a/juju/bundle.py
+++ b/juju/bundle.py
@@ -140,7 +140,7 @@ class BundleHandler:
                 bundleurl=entity_id,
                 yaml=yaml.dump(self.bundle))
         else:
-            log.info("bundle_facade using GetChangesMapArgs API to deploy bundle changes")
+            log.critical("bundle_facade using GetChangesMapArgs API to deploy bundle changes")
             self.plan = await self.bundle_facade.GetChangesMapArgs(
                 bundleurl=entity_id,
                 yaml=yaml.dump(self.bundle))
```

Then run:
```sh
tox -e example -- examples/deploy_bundle.py
```

You should see in the output of the example:
```sh
Connecting to model
Deploying bundle
bundle_facade using GetChangesMapArgs API to deploy bundle changes
Waiting for active
Successfully deployed!
Removing bundle
Disconnecting from model
Success
```