### PR TITLE
Surpress KeyError when applications are missing

### DIFF
--- a/examples/model.py
+++ b/examples/model.py
@@ -1,3 +1,11 @@
+"""
+This example shows how to reconnect to a model if you encounter an error
+
+1. Connects to current model.
+2. Attempts to get an application that doesn't exist.
+3. Disconnect then reconnect.
+
+"""
 from juju import loop
 from juju.model import Model
 from juju.errors import JujuEntityNotFoundError

--- a/examples/model.py
+++ b/examples/model.py
@@ -1,0 +1,22 @@
+from juju import loop
+from juju.model import Model
+from juju.errors import JujuEntityNotFoundError
+
+
+async def main():
+    model = Model()
+
+    retryCount = 3
+    for i in range(0, retryCount):
+        await model.connect_current()
+        try:
+            model.applications['foo'].relations
+        except JujuEntityNotFoundError as e:
+            print(e.entity_name)
+        finally:
+            await model.disconnect()
+        # Everything worked out, continue on wards.
+
+
+if __name__ == '__main__':
+    loop.run(main())

--- a/juju/charm.py
+++ b/juju/charm.py
@@ -14,33 +14,10 @@
 
 import logging
 
-from . import model, tag
+from . import model
 
 log = logging.getLogger(__name__)
 
 
-class RemoteApplication(model.ModelEntity):
-
-    @property
-    def status(self):
-        """Get the application status, as set by the charm's leader.
-
-        """
-        return self.safe_data['status']['current']
-
-    @property
-    def status_message(self):
-        """Get the application status message, as set by the charm's leader.
-
-        """
-        return self.safe_data['status']['message']
-
-    @property
-    def tag(self):
-        return tag.application(self.name)
-
-
-class ApplicationOffer(model.ModelEntity):
-    @property
-    def tag(self):
-        return tag.application(self.name)
+class Charm(model.ModelEntity):
+    pass

--- a/juju/delta.py
+++ b/juju/delta.py
@@ -79,6 +79,26 @@ class RemoteApplicationDelta(EntityDelta):
         return RemoteApplication
 
 
+class CharmDelta(EntityDelta):
+    def get_id(self):
+        return self.data['charm-url']
+
+    @classmethod
+    def get_entity_class(self):
+        from .charm import Charm
+        return Charm
+
+
+class ApplicationOfferDelta(EntityDelta):
+    def get_id(self):
+        return self.data['application-name']
+
+    @classmethod
+    def get_entity_class(self):
+        from .remoteapplication import ApplicationOffer
+        return ApplicationOffer
+
+
 _delta_types = {
     'action': ActionDelta,
     'application': ApplicationDelta,
@@ -87,4 +107,6 @@ _delta_types = {
     'unit': UnitDelta,
     'relation': RelationDelta,
     'remoteApplication': RemoteApplicationDelta,
+    'charm': CharmDelta,
+    'applicationOffer': ApplicationOfferDelta,
 }

--- a/juju/errors.py
+++ b/juju/errors.py
@@ -49,3 +49,15 @@ class JujuRedirectException(Exception):
             for servers in self.redirect_info['servers']
             for s in servers if s['scope'] == 'public' or not self.follow_redirect
         ]
+
+
+class JujuEntityNotFoundError(JujuError):
+    """Exception indicating that an entity was not found in the state. It was
+       expected that the entity was found in state and this is a terminal
+       condition.
+       To fix this condition, you should disconnect and reconnect to ensure that
+       any missing entities are correctly picked up."""
+    def __init__(self, entity_name, entity_types=None):
+        self.entity_name = entity_name
+        self.entity_types = entity_types
+        super().__init__("Entity not found: {}".format(entity_name))

--- a/juju/model.py
+++ b/juju/model.py
@@ -902,7 +902,7 @@ class Model:
                             # the all watcher. Currently they're ignored, causing
                             # issue.
                             # raise JujuError("unknown delta type {}".format(e.args))
-                            log.debug("unknown delta type: %s", e.args[0])
+                            log.warn("unknown delta type: %s", e.args[0])
                     self._watch_received.set()
             except CancelledError:
                 pass

--- a/juju/model.py
+++ b/juju/model.py
@@ -144,6 +144,13 @@ class ModelState:
         return self._live_entity_map('remoteApplication')
 
     @property
+    def application_offers(self):
+        """Return a map of application-name:Application for all applications
+        offers currently in the model.
+        """
+        return self._live_entity_map('applicationOffer')
+
+    @property
     def machines(self):
         """Return a map of machine-id:Machine for all machines currently in
         the model.
@@ -733,6 +740,13 @@ class Model:
         return self.state.remote_applications
 
     @property
+    def application_offers(self):
+        """Return a map of application-name:Application for all applications
+        offers currently in the model.
+        """
+        return self.state.application_offers
+
+    @property
     def machines(self):
         """Return a map of machine-id:Machine for all machines currently in
         the model.
@@ -883,6 +897,11 @@ class Model:
                             old_obj, new_obj = self.state.apply_delta(delta)
                             await self._notify_observers(delta, old_obj, new_obj)
                         except KeyError as e:
+                            # TODO (stickupkid): we should raise the unknown delta
+                            # type, so we handle correctly all the types comming from
+                            # the all watcher. Currently they're ignored, causing
+                            # issue.
+                            # raise JujuError("unknown delta type {}".format(e.args))
                             log.debug("unknown delta type: %s", e.args[0])
                     self._watch_received.set()
             except CancelledError:

--- a/juju/relation.py
+++ b/juju/relation.py
@@ -1,6 +1,7 @@
 import logging
 
 from . import model
+from .errors import JujuEntityNotFoundError
 
 log = logging.getLogger(__name__)
 
@@ -20,7 +21,7 @@ class Endpoint:
             return self.model.applications[app_name]
         if app_name in self.model.remote_applications:
             return self.model.remote_applications[app_name]
-        return None
+        raise JujuEntityNotFoundError(app_name, ["application", "remoteApplication"])
 
     @property
     def name(self):

--- a/juju/relation.py
+++ b/juju/relation.py
@@ -20,7 +20,7 @@ class Endpoint:
             return self.model.applications[app_name]
         if app_name in self.model.remote_applications:
             return self.model.remote_applications[app_name]
-        raise KeyError(app_name)
+        return None
 
     @property
     def name(self):
@@ -107,6 +107,10 @@ class Relation(model.ModelEntity):
             else:
                 app_name, endpoint_name = spec, None
             for endpoint in self.endpoints:
+                # The all watcher hasn't updated the internal state, so it can
+                # appear that the remote application doesn't exist.
+                if endpoint.application is None:
+                    continue
                 if app_name == endpoint.application.name and \
                    endpoint_name in (endpoint.name, None):
                     # found a match for this spec, so move to next one

--- a/juju/relation.py
+++ b/juju/relation.py
@@ -21,6 +21,8 @@ class Endpoint:
             return self.model.applications[app_name]
         if app_name in self.model.remote_applications:
             return self.model.remote_applications[app_name]
+        if app_name in self.model.application_offers:
+            return self.model.application_offers[app_name]
         raise JujuEntityNotFoundError(app_name, ["application", "remoteApplication"])
 
     @property

--- a/tests/unit/test_relation.py
+++ b/tests/unit/test_relation.py
@@ -1,0 +1,62 @@
+import unittest
+
+import mock
+
+from juju.model import Model
+from juju.relation import Relation
+
+
+def _make_delta(entity, type_, data=None):
+    from juju.client.client import Delta
+    from juju.delta import get_entity_delta
+
+    delta = Delta([entity, type_, data])
+    return get_entity_delta(delta)
+
+
+class TestRelation(unittest.TestCase):
+    def test_relation_does_not_match(self):
+        model = Model()
+        model._connector = mock.MagicMock()
+
+        delta = _make_delta('application', 'add', dict(name='foo'))
+        model.state.apply_delta(delta)
+        delta = _make_delta('relation', 'bar', dict(id="uuid-1234", name='foo', endpoints=[{"application-name": "foo"}]))
+        model.state.apply_delta(delta)
+
+        rel = Relation("uuid-1234", model)
+        self.assertFalse(rel.matches(["endpoint"]))
+
+    def test_relation_does_match(self):
+        model = Model()
+        model._connector = mock.MagicMock()
+
+        delta = _make_delta('application', 'add', dict(name='foo'))
+        model.state.apply_delta(delta)
+        delta = _make_delta('relation', 'bar', dict(id="uuid-1234", name='foo', endpoints=[{"application-name": "foo"}]))
+        model.state.apply_delta(delta)
+
+        rel = Relation("uuid-1234", model)
+        self.assertFalse(rel.matches(["foo"]))
+
+    def test_relation_does_match_remote_app(self):
+        model = Model()
+        model._connector = mock.MagicMock()
+
+        delta = _make_delta('remoteApplication', 'add', dict(name='foo'))
+        model.state.apply_delta(delta)
+        delta = _make_delta('relation', 'bar', dict(id="uuid-1234", name='foo', endpoints=[{"application-name": "foo"}]))
+        model.state.apply_delta(delta)
+
+        rel = Relation("uuid-1234", model)
+        self.assertFalse(rel.matches(["foo"]))
+
+    def test_relation_does_not_match_anything(self):
+        model = Model()
+        model._connector = mock.MagicMock()
+
+        delta = _make_delta('relation', 'bar', dict(id="uuid-1234", name='foo', endpoints=[{"application-name": "foo"}]))
+        model.state.apply_delta(delta)
+
+        rel = Relation("uuid-1234", model)
+        self.assertFalse(rel.matches(["xxx"]))

--- a/tests/unit/test_relation.py
+++ b/tests/unit/test_relation.py
@@ -4,6 +4,7 @@ import mock
 
 from juju.model import Model
 from juju.relation import Relation
+from juju.errors import JujuEntityNotFoundError
 
 
 def _make_delta(entity, type_, data=None):
@@ -59,4 +60,4 @@ class TestRelation(unittest.TestCase):
         model.state.apply_delta(delta)
 
         rel = Relation("uuid-1234", model)
-        self.assertFalse(rel.matches(["xxx"]))
+        self.assertRaises(JujuEntityNotFoundError, rel.matches, ["xxx"])

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ deps =
 # default tox env excludes integration and serial tests
 commands =
     # These need to be installed in a specific order
-    pip install urllib3==1.22
+    pip install urllib3==1.25.7
     pip install pylxd
     py.test --tb native -ra -v -s -n auto -k 'not integration' -m 'not serial' {posargs}
 
@@ -50,7 +50,7 @@ deps =
 envdir = {toxworkdir}/py3
 commands =
     # These need to be installed in a specific order
-    pip install urllib3==1.22
+    pip install urllib3==1.25.7
     pip install pylxd
     py.test --tb native -ra -v -n auto -k 'integration' -m 'not serial' {posargs}
 


### PR DESCRIPTION
The following surpresses a KeyError when a application or a remote
application is missing. Instead we should return None and correctly
handle that a application or a remote-application could be missing.

This should be safe to do so and the fact that an update from the
all watcher should fill in the gaps eventually. If this is not the
case, we should in the future ensure that a remote-application can't
raise index/key errors when data is missing.

The missing data when raised/thrown criples the library from being
useful, instead we should really handle all the cases these exist and
correctly insert None or a fallback.