### PR TITLE
Handle relation matches

### DIFF
--- a/tests/integration/test_crossmodel.py
+++ b/tests/integration/test_crossmodel.py
@@ -129,7 +129,7 @@ async def test_add_relation_with_offer(event_loop):
                 channel='stable',
             )
             await model_2.block_until(
-                lambda: all(unit.agent_status == 'executing'
+                lambda: all(unit.agent_status == 'idle'
                             for unit in application.units))
 
             await model_2.add_relation("wordpress", "admin/{}.mysql".format(model_1.info.name))

--- a/tests/unit/test_relation.py
+++ b/tests/unit/test_relation.py
@@ -4,7 +4,6 @@ import mock
 
 from juju.model import Model
 from juju.relation import Relation
-from juju.errors import JujuEntityNotFoundError
 
 
 def _make_delta(entity, type_, data=None):
@@ -60,4 +59,4 @@ class TestRelation(unittest.TestCase):
         model.state.apply_delta(delta)
 
         rel = Relation("uuid-1234", model)
-        self.assertRaises(JujuEntityNotFoundError, rel.matches, ["xxx"])
+        self.assertFalse(rel.matches(["xxx"]))


### PR DESCRIPTION
The following code handles relation matches with a different approach.
Instead of attempting to find the underlying model application and
shadow applications (remoteApplication, applicationOffer) for an
endpoint, we should use just the application. The matches code can then
validate that the existance of an application exists in the state whilst
it's traversing.

Hopefully cleaning up the role of the endpoint.application property
method, will make things much clearer.

Additionally I've exposed the endpoint application_name, so we can use
that whilst testing if the application name exists.

While this does clean up the code somewhat, I'm still unsure why we
validate that the application exists, other than we can, not whether we
actually should?

-----

Additionally, I ensured that the integration tests ran locally as travis sometimes doesn't go through all the integration test.
```sh
➜ tox -e integration -- tests/integration/test_crossmodel.py
...
tests/integration/test_crossmodel.py::test_add_relation_with_offer 
tests/integration/test_crossmodel.py::test_add_bundle 
tests/integration/test_crossmodel.py::test_remove_saas 
tests/integration/test_crossmodel.py::test_offer 
tests/integration/test_crossmodel.py::test_consume 
[gw0] [ 20%] PASSED tests/integration/test_crossmodel.py::test_offer 
[gw1] [ 40%] PASSED tests/integration/test_crossmodel.py::test_consume 
[gw2] [ 60%] PASSED tests/integration/test_crossmodel.py::test_remove_saas 
[gw4] [ 80%] PASSED tests/integration/test_crossmodel.py::test_add_bundle 
[gw3] [100%] PASSED tests/integration/test_crossmodel.py::test_add_relation_with_offer
```

Fixes: #366 