### PR TITLE
assign resources empty if local to avoid unnasigned variable

### DIFF
--- a/juju/bundle.py
+++ b/juju/bundle.py
@@ -322,6 +322,8 @@ class AddApplicationChange(ChangeInfo):
         if not charm.startswith('local:'):
             resources = await context.model._add_store_resources(
                 self.application, charm, overrides=self.resources)
+        else:
+            resources = {}
         await context.model._deploy(
             charm_url=charm,
             application=self.application,

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -192,6 +192,41 @@ class TestAddApplicationChangeRun:
                                          devices="devices",
                                          num_units="num_units")
 
+    @pytest.mark.asyncio
+    async def test_run_local(self, event_loop):
+        change = AddApplicationChange(1, [], params={"charm": "local:charm",
+                                                     "series": "series",
+                                                     "application": "application",
+                                                     "options": "options",
+                                                     "constraints": "constraints",
+                                                     "storage": "storage",
+                                                     "endpoint-bindings": "endpoint_bindings",
+                                                     "devices": "devices",
+                                                     "num-units": "num_units"})
+
+        model = mock.Mock()
+        model._deploy = base.AsyncMock(return_value=None)
+
+        context = mock.Mock()
+        context.resolve.return_value = "local:charm1"
+        context.trusted = False
+        context.model = model
+
+        result = await change.run(context)
+        assert result == "application"
+
+        model._deploy.assert_called_once()
+        model._deploy.assert_called_with(charm_url="local:charm1",
+                                         application="application",
+                                         series="series",
+                                         config="options",
+                                         constraints="constraints",
+                                         endpoint_bindings="endpoint_bindings",
+                                         resources={},
+                                         storage="storage",
+                                         devices="devices",
+                                         num_units="num_units")
+
 
 class TestAddCharmChange(unittest.TestCase):
 


### PR DESCRIPTION
When using local charm within a bundle, resources variable does not get assigned. Assignment happens only if `not charm.startswith('local:')`, since it is otherwise assigned a dict, it seems fair to assign empty dict when not applied.

https://github.com/huntdatacenter/jujuna/issues/50

```
tox -e test-xenial
test-xenial create: /home/runner/work/charm-megaraid-check/charm-megaraid-check/.tox/test-xenial
test-xenial installdeps: jujuna
test-xenial installed: argcomplete==1.10.0,async-timeout==3.0.1,bcrypt==3.1.7,certifi==2019.11.28,cffi==1.13.2,chardet==3.0.4,cryptography==2.8,idna==2.8,juju==2.6.3,jujubundlelib==0.5.6,jujuna==0.2.0,macaroonbakery==1.2.3,paramiko==2.7.0,protobuf==3.11.1,pyasn1==0.4.8,pycparser==2.19,pymacaroons==0.13.0,PyNaCl==1.3.0,pyRFC3339==1.1,pytz==2019.3,PyYAML==5.2,requests==2.22.0,six==1.13.0,theblues==0.5.2,toposort==1.5,urllib3==1.25.7,websockets==7.0
test-xenial run-test-pre: PYTHONHASHSEED='2133000312'
test-xenial run-test: commands[0] | jujuna deploy --wait tests/bundles/xenial.yaml
2019-12-04 18:56:58,863 - jujuna.deploy - INFO - Reading bundle: tests/bundles/xenial.yaml
2019-12-04 18:56:58,941 - jujuna.deploy - INFO - Deploy: local:tests/bundles/xenial.yaml
ERROR:root:Traceback (most recent call last):
ERROR:root:  File "/home/runner/work/charm-megaraid-check/charm-megaraid-check/.tox/test-xenial/lib/python3.7/site-packages/jujuna/__main__.py", line 203, in main
    run_action(action, timeout, args)
ERROR:root:  File "/home/runner/work/charm-megaraid-check/charm-megaraid-check/.tox/test-xenial/lib/python3.7/site-packages/juju/loop.py", line 38, in run
    raise task.exception()
ERROR:root:  File "/home/runner/work/charm-megaraid-check/charm-megaraid-check/.tox/test-xenial/lib/python3.7/site-packages/jujuna/__main__.py", line 145, in run_action
    return await selected_action(**args)
ERROR:root:  File "/home/runner/work/charm-megaraid-check/charm-megaraid-check/.tox/test-xenial/lib/python3.7/site-packages/jujuna/deploy.py", line 58, in deploy
    entity_url
ERROR:root:  File "/home/runner/work/charm-megaraid-check/charm-megaraid-check/.tox/test-xenial/lib/python3.7/site-packages/juju/model.py", line 1375, in deploy
    await handler.execute_plan()
ERROR:root:  File "/home/runner/work/charm-megaraid-check/charm-megaraid-check/.tox/test-xenial/lib/python3.7/site-packages/juju/bundle.py", line 153, in execute_plan
    self.references[step.id_] = await change.run(self)
ERROR:root:  File "/home/runner/work/charm-megaraid-check/charm-megaraid-check/.tox/test-xenial/lib/python3.7/site-packages/juju/bundle.py", line 331, in run
    resources=resources,
ERROR:root:UnboundLocalError: local variable 'resources' referenced before assignment
ERROR: InvocationError for command /home/runner/work/charm-megaraid-check/charm-megaraid-check/.tox/test-xenial/bin/jujuna deploy --wait tests/bundles/xenial.yaml (exited with code 1)
```