### PR TITLE
Fixes multiple subordinate leader problem

### DIFF
--- a/juju/unit.py
+++ b/juju/unit.py
@@ -258,7 +258,6 @@ class Unit(model.ModelEntity):
         """
         unit_parts = self.name.split("/")
         app = unit_parts[0]
-        unit_index = unit_parts[1]
 
         client_facade = client.ClientFacade.from_connection(self.connection)
 
@@ -286,7 +285,6 @@ class Unit(model.ModelEntity):
 
         for target_app in target_apps:
             app_data = status.applications[target_app]
-            target_unit = target_app + "/" + unit_index
 
             if not app_data.get('units'):
                 continue

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -1,0 +1,83 @@
+import asynctest
+import mock
+import pytest
+
+from juju.model import Model
+from juju.unit import Unit
+
+from .. import base
+
+
+@asynctest.patch('juju.client.client.ClientFacade')
+@pytest.mark.asyncio
+async def test_unit_is_leader(mock_cf):
+    tests = [
+        {
+            'applications': {
+                'test': {
+                    'units': {
+                        'test/0': {
+                            'subordinates': {
+                                'test-sub/0': {
+                                    'leader': True
+                                }
+                            }
+                        }
+                    }
+                },
+                'test-sub': {
+                    'subordinate-to': [
+                        'test'
+                    ]
+                }
+            },
+            'description': "Tests that subordinate units report is leader correctly",
+            'unit': 'test-sub/0',
+            'rval': True
+        },
+        {
+            'applications': {
+                'test': {
+                    'units': {
+                        'test/0': {
+                            'leader': True
+                        }
+                    }
+                }
+            },
+            'description': "Tests that unit reports is leader correctly",
+            'unit': 'test/0',
+            'rval': True
+        },
+        {
+            'applications': {},
+            'description': "Tests that non existent apps return False as leader",
+            'unit': 'test/0',
+            'rval': False
+        },
+        {
+            'applications': {
+                'test': {
+                    'units': {}
+                }
+            },
+            'description': "Tests that apps with no units report False as leader",
+            'unit': 'test/0',
+            'rval': False
+        },
+    ]
+
+    model = Model()
+    model._connector = mock.MagicMock()
+
+    for test in tests:
+        status = mock.Mock()
+        status.applications = test['applications']
+        client_facade = mock_cf.from_connection()
+        client_facade.FullStatus = base.AsyncMock(return_value=status)
+
+        unit = Unit("test", model)
+        unit.name = test['unit']
+
+        rval = await unit.is_leader_from_status()
+        assert rval == test['rval']

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -31,7 +31,7 @@ async def test_unit_is_leader(mock_cf):
                     ]
                 }
             },
-            'description': "Tests that subordinate units report is leader correctly",
+            'description': "Tests that subordinate units reports is leader correctly",
             'unit': 'test-sub/0',
             'rval': True
         },
@@ -65,6 +65,72 @@ async def test_unit_is_leader(mock_cf):
             'unit': 'test/0',
             'rval': False
         },
+        {
+            'applications': {
+                'test': {
+                    'units': {
+                        'test/0': {
+                            'subordinates': {
+                                'test-sub/0': {}
+                            }
+                        }
+                    }
+                },
+                'test1': {
+                    'units': {
+                        'test1/0': {
+                            'subordinates': {
+                                'test-sub/1': {
+                                    'leader': True
+                                }
+                            }
+                        }
+                    }
+                },
+                'test-sub': {
+                    'subordinate-to': [
+                        'test',
+                        'test1'
+                    ]
+                }
+            },
+            'description': "Tests that subordinate units of multiple applications reports is leader correctly",
+            'unit': 'test-sub/1',
+            'rval': True
+        },
+        {
+            'applications': {
+                'test': {
+                    'units': {
+                        'test/0': {
+                            'subordinates': {
+                                'test-sub/0': {
+                                    'leader': True
+                                }
+                            }
+                        }
+                    }
+                },
+                'test1': {
+                    'units': {
+                        'test1/0': {
+                            'subordinates': {
+                                'test-sub/1': {}
+                            }
+                        }
+                    }
+                },
+                'test-sub': {
+                    'subordinate-to': [
+                        'test',
+                        'test1'
+                    ]
+                }
+            },
+            'description': "Tests that subordinate units of multiple applications reports is leader correctly",
+            'unit': 'test-sub/1',
+            'rval': False
+        }
     ]
 
     model = Model()


### PR DESCRIPTION
An app/unit that is a subordinate to multiple applications now is handled correctly.

Further work for #375 

Repo steps:

```
juju deploy ubuntu ubuntu0
juju deploy ubuntu ubuntu1
juju deploy telegraf telegraf
juju add-relation ubuntu0 telegraf
juju add-relation ubuntu1 telegraf
```

To see parsing output:
```
juju --debug --logging-config TRACE status
```