### PR TITLE
Unknown facade

### DIFF
--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -690,8 +690,10 @@ class Connection:
                 # client can define the non-conservitive facade client pinning.
                 if name in self.specified_facades:
                     known = self.specified_facades[name]['versions']
-                else:
+                elif name in client_facades:
                     known = client_facades[name]['versions']
+                else:
+                    raise errors.JujuConnectionError("unexpected facade {}".format(name))
                 discovered = facade['versions']
                 version = max(set(known).intersection(set(discovered)))
             except ValueError:
@@ -699,6 +701,12 @@ class Connection:
                 # there is just no way to know how to communicate with the
                 # facades we're trying to call.
                 log.warning("unknown common facade version for {}".format(name))
+            except errors.JujuConnectionError:
+                # If the facade isn't with in the local facades then it's not
+                # possible to reason about what version should be used. In this
+                # case we should log the facade was found, but we couldn't
+                # handle it.
+                log.warning("unexpected facade {} found, unable to decipher version to use".format(name))
             else:
                 self.facades[name] = version
 


### PR DESCRIPTION
The following changes how we handle future compatibility. In an effort
to improve compatibility with Juju and it's clients. Previously the
client would attempt to negotiate every facade that Juju would have ever
released, which allows backwards compatibility but not forward.

With the following changes we're essentially unrestricting forward
compatibility. Allowing the client to speak to future Juju's even if the
facade version isn't known.

We warn the user as much as possible about the missing facade version,
before ignoring it and allowing accessing to be done.

In reality this means if you try and access a facade that doesn't exist
in the library, but does in Juju, it won't work.