### PR TITLE
docs: correct model destroying idiom

### DIFF
--- a/docs/narrative/model.rst
+++ b/docs/narrative/model.rst
@@ -110,8 +110,9 @@ py:method:`juju.controller.Controller.destroy_model` for more info.
   # Do stuff with our model...
 
   # Destroy the model
+  model_uuid = model.info.uuid
   await model.disconnect()
-  await controller.destroy_model(model.info.uuid)
+  await controller.destroy_model(model_uuid)
   model = None
 
 


### PR DESCRIPTION
model.info is None after disconnecting to the model so the original
idiom will not work.