### PR TITLE
Fix Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: required
 language: python
 cache: pip
 before_install:
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then sudo add-apt-repository -y ppa:jonathonf/python-3.6; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == '3.7-dev' ]]; then sudo add-apt-repository -y ppa:deadsnakes/ppa; fi
   - sudo apt-get update -q
   - sudo apt-get remove -qy --purge lxd lxd-client
   - sudo apt-get install snapd libsodium-dev -y
@@ -27,9 +25,13 @@ matrix:
     env: JUJU_CHANNEL=edge
   - python: 3.6
     env: JUJU_CHANNEL=stable
-  - python: 3.7-dev
+  - python: 3.7
     env: JUJU_CHANNEL=stable
-  - python: 3.7-dev
+  - python: 3.7
+    env: JUJU_CHANNEL=edge
+  - python: 3.8
+    env: JUJU_CHANNEL=stable
+  - python: 3.8
     env: JUJU_CHANNEL=edge
 before_script:
   - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,6 @@ before_script:
   - lxd init --auto --network-address='[::]' --network-port=8443 --storage-backend=dir
   - lxc network set lxdbr0 ipv6.address none
 
-  # Horrible workaround to LP Bug #1738614
-  - sudo mkdir /var/snap/lxd/common/lxd/storage-pools/juju-zfs
-  - lxc storage create juju-zfs dir source=/var/snap/lxd/common/lxd/storage-pools/juju-zfs
-
 script:
   - set -e
   - juju bootstrap localhost test --config 'identity-url=https://api.staging.jujucharms.com/identity' --config 'allow-model-access=true'


### PR DESCRIPTION
Travis builds have been failing on the PPAs, and it's not clear that they're actually needed any longer.