### PR TITLE
Handle OSError Network Unreachable

### DIFF
--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -302,12 +302,17 @@ class Connection:
         if max_frame_size is None:
             max_frame_size = self.MAX_FRAME_SIZE
         self.max_frame_size = max_frame_size
-        await self._connect_with_redirect(
-            [(endpoint, cacert)]
-            if isinstance(endpoint, str)
-            else [(e, cacert) for e in endpoint]
-        )
-        return self
+
+        _endpoints = [(endpoint, cacert)] if isinstance(endpoint, str) else [(e, cacert) for e in endpoint]
+        for _ep in _endpoints:
+            try:
+                await self._connect_with_redirect([_ep])
+                return self
+            except OSError as e:
+                logging.debug(
+                    "Cannot access endpoint {}: {}".format(_ep, e.strerror))
+                continue
+        raise Exception("Unable to connect to websocket")
 
     @property
     def username(self):


### PR DESCRIPTION
Try each endpoint for the controller until success, only throw an
exception if all endpoints have been attempted and failed.

Without this change, the client will throw an OSError exception when for
example trying to access the fan network from a host that is not on that
fan network.

Closes Issue: https://github.com/juju/python-libjuju/issues/426