### PR TITLE
Derived application status

### DIFF
--- a/juju/application.py
+++ b/juju/application.py
@@ -84,7 +84,7 @@ class Application(model.ModelEntity):
                 unit_status.append(unit.workload_status)
             return derive_status(unit_status)
 
-        return self.safe_data['status']['current']
+        return status
 
     @property
     def status_message(self):

--- a/juju/application.py
+++ b/juju/application.py
@@ -17,6 +17,7 @@ import json
 import logging
 
 from . import model, tag
+from .status import derive_status
 from .annotationhelper import _get_annotations, _set_annotations
 from .client import client
 from .errors import JujuError
@@ -76,6 +77,13 @@ class Application(model.ModelEntity):
         """Get the application status, as set by the charm's leader.
 
         """
+        status = self.safe_data['status']['current']
+        if status == 'unset':
+            unit_status = []
+            for unit in self.units:
+                unit_status.append(unit.workload_status)
+            return derive_status(unit_status)
+
         return self.safe_data['status']['current']
 
     @property

--- a/juju/status.py
+++ b/juju/status.py
@@ -1,0 +1,28 @@
+""" derive_status is used to determine the application status from a set of unit
+status values.
+
+:param statues: list of known unit workload statues
+
+"""
+
+
+def derive_status(statues):
+    current = 'unknown'
+    for status in statues:
+        if status in serverities and serverities[status] > serverities[current]:
+            current = status
+    return current
+
+
+""" serverities holds status values with a severity measure.
+Status values with higher severity are used in preference to others.
+"""
+serverities = {
+    'error': 100,
+    'blocked': 90,
+    'waiting': 80,
+    'maintenance': 70,
+    'active': 60,
+    'terminated': 50,
+    'unknown': 40
+}

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -47,6 +47,21 @@ async def test_action(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+async def test_status(event_loop):
+
+    async with base.CleanModel() as model:
+        app = await model.deploy(
+            'ubuntu-0',
+            application_name='ubuntu',
+            series='trusty',
+            channel='stable',
+        )
+
+        assert app.status != 'unset'
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
 async def test_add_units(event_loop):
     from juju.unit import Unit
 

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -1,0 +1,23 @@
+import unittest
+
+
+from juju.status import derive_status
+from random import sample
+
+
+class TestStatus(unittest.TestCase):
+    def test_derive_status_with_empty_list(self):
+        result = derive_status([])
+        self.assertEqual(result, 'unknown')
+
+    def test_derive_status_with_unknown(self):
+        result = derive_status(['unknown'])
+        self.assertEqual(result, 'unknown')
+
+    def test_derive_status_with_invalid(self):
+        result = derive_status(['boom'])
+        self.assertEqual(result, 'unknown')
+
+    def test_derive_status_with_highest_value(self):
+        result = derive_status(sample(['error', 'active', 'terminated'], 3))
+        self.assertEqual(result, 'error')


### PR DESCRIPTION
The following updates pylibjuju to the same logic as 2.8.1, whereby the
derived application status that's in juju is ported across to libjuju.

It uses the same logic as juju[1], which can be found here. The code is
really simple and should work as intended to find out what the correct
application status is, if the application status has been set to
"unset".

1. https://github.com/juju/juju/commit/8bc76070c55c5991c0863e8f8c42df4780acdcbe#diff-7f5882040ea646fab639d5c6351b19f2R129