### PR TITLE
Export the CAAS model operator facade

### DIFF
--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -41,6 +41,7 @@ client_facades = {
     'CAASOperatorProvisioner': {'versions': [1]},
     'CAASUnitProvisioner': {'versions': [1]},
     'CAASOperatorUpgrader': {'versions': [1]},
+    'CAASModelOperator': {'versions': [1]},
     'Controller': {'versions': [3, 4, 5, 6, 7, 8, 9]},
     'CrossModelRelations': {'versions': [1]},
     'CrossController': {'versions': [1]},


### PR DESCRIPTION
This is because nobody exported the facade for use in pylibjuju.

----

Fixes bug: https://github.com/juju/python-libjuju/issues/434