### PR TITLE
Derive the application status

### DIFF
--- a/juju/application.py
+++ b/juju/application.py
@@ -74,17 +74,16 @@ class Application(model.ModelEntity):
 
     @property
     def status(self):
-        """Get the application status, as set by the charm's leader.
+        """Get the application status.
 
+        If the application is unknown it will attempt to derive the unit
+        workload status and highlight the most relevant (severity).
         """
         status = self.safe_data['status']['current']
-        if status == 'unset':
-            unit_status = []
-            for unit in self.units:
-                unit_status.append(unit.workload_status)
-            return derive_status(unit_status)
-
-        return status
+        unit_status = [status]
+        for unit in self.units:
+            unit_status.append(unit.workload_status)
+        return derive_status(unit_status)
 
     @property
     def status_message(self):

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -47,8 +47,7 @@ async def test_action(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_status(event_loop):
-
+async def test_status_is_not_unset(event_loop):
     async with base.CleanModel() as model:
         app = await model.deploy(
             'ubuntu-0',
@@ -58,6 +57,21 @@ async def test_status(event_loop):
         )
 
         assert app.status != 'unset'
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_status(event_loop):
+    async with base.CleanModel() as model:
+        app = await model.deploy('cs:~juju-qa/blocked-0')
+
+        def app_ready():
+            if not app.units:
+                return False
+            return app.status == 'blocked'
+
+        await asyncio.wait_for(model.block_until(app_ready), timeout=480)
+        assert app.status == 'blocked'
 
 
 @base.bootstrapped


### PR DESCRIPTION
With changes to juju, the application status was changed for the CLI to
use the model cache to derive the status of the application from the
unit status. Unfortunately, the logic didn't reach the all watcher and in
doing so always reports the last application status.

Unfortunately, the facade version wasn't bumped, which makes facade
checking for old and new logic almost impossible. Instead of the solution
here is to always query the unit status, BUT add the application status
in to the derive_status() call so that we always bubble the most relevant
severity to the top.

This should happily work in a backward compatibility way, so if the
application is blocked and any units are waiting, then the application
status will always win. Similarly, if the units are blocked and the
application status is waiting, then blocked will be shown.

The one caveat is, that if the older juju didn't bubble up the worst
severity to the application status, then you could end up with a
mismatch. For example; the unit sets to error, but the application status
is waiting. Then juju CLI would show waiting, but pylibjuju would show
an error.

I'm unsure if that is actually a fundamental problem, as I don't believe
it should happen, but in theory, it should be at least known.

Fixes: #441 