### PR TITLE
Handle application set status

### DIFF
--- a/juju/application.py
+++ b/juju/application.py
@@ -80,10 +80,12 @@ class Application(model.ModelEntity):
         workload status and highlight the most relevant (severity).
         """
         status = self.safe_data['status']['current']
-        unit_status = [status]
-        for unit in self.units:
-            unit_status.append(unit.workload_status)
-        return derive_status(unit_status)
+        if status == "unset":
+            unit_status = []
+            for unit in self.units:
+                unit_status.append(unit.workload_status)
+            return derive_status(unit_status)
+        return status
 
     @property
     def status_message(self):


### PR DESCRIPTION
Because pylibjuju has an internal cache, very similar to how juju model
cache works, we need to correctly handle when the application status is
set by the charm author, vs how the application is dervied via the unit
status.