### PR TITLE
Support expose_endpoints parameter for applications

### DIFF
--- a/examples/expose-application.py
+++ b/examples/expose-application.py
@@ -1,0 +1,75 @@
+"""
+This example:
+
+1. Connects to the current model.
+2. Deploys a charm and waits until it reports itself active.
+3. Demonstrates exposing application endpoints to space and CIDR combinations.
+3. Demonstrates unexposing application endpoints.
+
+NOTE: this test must be run against a 2.9 controller.
+"""
+from juju import loop
+from juju.model import Model
+from juju.application import ExposedEndpoint
+
+import logging
+
+async def main():
+    model = Model()
+    print('Connecting to model')
+    # connect to current model with current user, per Juju CLI
+    await model.connect()
+
+    try:
+        print('Deploying ubuntu')
+        application = await model.deploy(
+            'cs:~jameinel/ubuntu-lite-7',
+            application_name='ubuntu',
+            series='trusty',
+            channel='stable',
+        )
+
+        print('Waiting for active')
+        await model.block_until(
+            lambda: all(unit.workload_status == 'active'
+                        for unit in application.units))
+
+        print('Expose all opened port ranges')
+        await application.expose()
+
+        print('Expose all opened port ranges to the CIDRs that correspond to a list of spaces')
+        await application.expose(exposed_endpoints={
+            "": ExposedEndpoint(to_spaces=["alpha"])
+        })
+
+        print('Expose all opened port ranges to a list of CIDRs')
+        await application.expose(exposed_endpoints={
+            "": ExposedEndpoint(to_cidrs=["10.0.0.0/24"])
+        })
+
+        print('Expose all opened port ranges to a list of spaces and CIDRs')
+        await application.expose(exposed_endpoints={
+            "": ExposedEndpoint(to_spaces=["alpha"], to_cidrs=["10.0.0.0/24"])
+        })
+
+        print('Expose individual endpoints to different space/CIDR combinations')
+        await application.expose(exposed_endpoints={
+            "": ExposedEndpoint(to_spaces=["alpha"], to_cidrs=["10.0.0.0/24"]),
+            "ubuntu": ExposedEndpoint(to_cidrs=["10.42.42.0/24"])
+        })
+
+        print('Unexpose individual endpoints (other endpoints remain exposed)')
+        await application.unexpose(exposed_endpoints=["ubuntu"])
+
+        print('Unexpose application')
+        await application.unexpose()
+
+        print('Removing ubuntu')
+        await application.remove()
+    finally:
+        print('Disconnecting from model')
+        await model.disconnect()
+
+
+if __name__ == '__main__':
+    loop.run(main())

--- a/examples/expose-application.py
+++ b/examples/expose-application.py
@@ -12,7 +12,6 @@ from juju import loop
 from juju.model import Model
 from juju.application import ExposedEndpoint
 
-import logging
 
 async def main():
     model = Model()

--- a/juju/application.py
+++ b/juju/application.py
@@ -341,8 +341,7 @@ class Application(model.ModelEntity):
             if facade_version < 13:
                 raise JujuError("controller does not support granular expose parameters; applying this change would unexpose the application")
 
-            log.debug("Unexposing endpoints %s of %s",
-                      ",".join(exposed_endpoints), self.name)
+            log.debug("Unexposing endpoints %s of %s", ",".join(exposed_endpoints), self.name)
             return await app_facade.Unexpose(application=self.name,
                                              exposed_endpoints=exposed_endpoints)
 
@@ -350,10 +349,8 @@ class Application(model.ModelEntity):
         log.debug("Unexposing %s", self.name)
         return await app_facade.Unexpose(application=self.name)
 
-
     async def get_config(self):
         """Return the configuration settings dict for this application.
-
         """
         app_facade = self._facade()
 

--- a/juju/application.py
+++ b/juju/application.py
@@ -31,6 +31,9 @@ class Application(model.ModelEntity):
     def _unit_match_pattern(self):
         return r'^{}.*$'.format(self.entity_id)
 
+    def _facade(self):
+        return client.ApplicationFacade.from_connection(self.connection)
+
     def on_unit_add(self, callable_):
         """Add a "unit added" observer to this entity, which will be called
         whenever a unit is added to this application.
@@ -123,7 +126,7 @@ class Application(model.ModelEntity):
             If None, a new machine is provisioned.
 
         """
-        app_facade = client.ApplicationFacade.from_connection(self.connection)
+        app_facade = self._facade()
 
         log.debug(
             'Adding %s unit%s to %s',
@@ -152,7 +155,7 @@ class Application(model.ModelEntity):
         :param int scale_change: Amount by which to adjust the scale of this
             application (can be positive or negative).
         """
-        app_facade = client.ApplicationFacade.from_connection(self.connection)
+        app_facade = self._facade()
 
         if (scale, scale_change) == (None, None):
             raise ValueError('Must provide either scale or scale_change')
@@ -202,7 +205,7 @@ class Application(model.ModelEntity):
         if ':' not in local_relation:
             local_relation = '{}:{}'.format(self.name, local_relation)
 
-        app_facade = client.ApplicationFacade.from_connection(self.connection)
+        app_facade = self._facade()
 
         log.debug(
             'Destroying relation %s <-> %s', local_relation, remote_relation)
@@ -222,7 +225,7 @@ class Application(model.ModelEntity):
         """Remove this application from the model.
 
         """
-        app_facade = client.ApplicationFacade.from_connection(self.connection)
+        app_facade = self._facade()
 
         log.debug(
             'Destroying %s', self.name)
@@ -234,7 +237,7 @@ class Application(model.ModelEntity):
         """Make this application publicly available over the network.
 
         """
-        app_facade = client.ApplicationFacade.from_connection(self.connection)
+        app_facade = self._facade()
 
         log.debug(
             'Exposing %s', self.name)
@@ -245,7 +248,7 @@ class Application(model.ModelEntity):
         """Return the configuration settings dict for this application.
 
         """
-        app_facade = client.ApplicationFacade.from_connection(self.connection)
+        app_facade = self._facade()
 
         log.debug(
             'Getting config for %s', self.name)
@@ -259,7 +262,7 @@ class Application(model.ModelEntity):
         if self.model.info.agent_version < client.Number.from_json('2.4.0'):
             raise NotImplementedError("trusted is not supported on model version {}".format(self.model.info.agent_version))
 
-        app_facade = client.ApplicationFacade.from_connection(self.connection)
+        app_facade = self._facade()
 
         log.debug(
             'Getting config for %s', self.name)
@@ -281,7 +284,7 @@ class Application(model.ModelEntity):
 
         # clamp trust to exactly the value juju expects, rather than allowing
         # anything in the config.
-        app_facade = client.ApplicationFacade.from_connection(self.connection)
+        app_facade = self._facade()
 
         config = {'trust': json.dumps(True if trust is True else False)}
         log.debug(
@@ -296,7 +299,7 @@ class Application(model.ModelEntity):
         """Return the machine constraints dict for this application.
 
         """
-        app_facade = client.ApplicationFacade.from_connection(self.connection)
+        app_facade = self._facade()
 
         log.debug(
             'Getting constraints for %s', self.name)
@@ -384,7 +387,7 @@ class Application(model.ModelEntity):
 
         :param config: Dict of configuration to set
         """
-        app_facade = client.ApplicationFacade.from_connection(self.connection)
+        app_facade = self._facade()
 
         log.debug(
             'Setting config for %s: %s', self.name, config)
@@ -398,7 +401,7 @@ class Application(model.ModelEntity):
         :param list to_default: A list of config options to be reset to their
         default value.
         """
-        app_facade = client.ApplicationFacade.from_connection(self.connection)
+        app_facade = self._facade()
 
         log.debug(
             'Restoring default config for %s: %s', self.name, to_default)
@@ -411,7 +414,7 @@ class Application(model.ModelEntity):
         :param dict constraints: Dict of machine constraints
 
         """
-        app_facade = client.ApplicationFacade.from_connection(self.connection)
+        app_facade = self._facade()
 
         log.debug(
             'Setting constraints for %s: %s', self.name, constraints)
@@ -439,7 +442,7 @@ class Application(model.ModelEntity):
         """Remove public availability over the network for this application.
 
         """
-        app_facade = client.ApplicationFacade.from_connection(self.connection)
+        app_facade = self._facade()
 
         log.debug(
             'Unexposing %s', self.name)
@@ -483,7 +486,7 @@ class Application(model.ModelEntity):
         client_facade = client.ClientFacade.from_connection(self.connection)
         resources_facade = client.ResourcesFacade.from_connection(
             self.connection)
-        app_facade = client.ApplicationFacade.from_connection(self.connection)
+        app_facade = self._facade()
 
         charmstore = self.model.charmstore
         charmstore_entity = None

--- a/juju/bundle.py
+++ b/juju/bundle.py
@@ -742,7 +742,10 @@ class ConsumeOfferChange(ChangeInfo):
 
 
 class ExposeChange(ChangeInfo):
-    _toPy = {'application': 'application'}
+    _toPy = {
+        'application': 'application',
+        'exposed-endpoints': 'exposed_endpoints',
+    }
     """ExposeChange holds a change for exposing an application.
 
     :change_id: id of the change that will be used to identify the current
@@ -755,6 +758,10 @@ class ExposeChange(ChangeInfo):
     Params holds the following values:
         :application: placeholder name of the application that must be
             exposed.
+        :exposed_endpoints: a an optional dictionary where keys are endpoint
+            names and values are dicts that specify the space names and CIDRs
+            that should be able to access the port ranges that the application
+            has opened for each endpoint.
     """
     def __init__(self, change_id, requires, params=None):
         super(ExposeChange, self).__init__(change_id, requires)
@@ -781,7 +788,7 @@ class ExposeChange(ChangeInfo):
         """
         application = context.resolve(self.application)
         log.info('Exposing %s', application)
-        return await context.model.applications[application].expose()
+        return await context.model.applications[application].expose(self.exposed_endpoints)
 
     def __str__(self):
         return "expose {application}".format(application=self.application)

--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -23,7 +23,7 @@ client_facades = {
     'Agent': {'versions': [2]},
     'AgentTools': {'versions': [1]},
     'Annotations': {'versions': [2]},
-    'Application': {'versions': [1, 2, 3, 4, 5, 6, 7, 8]},
+    'Application': {'versions': [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]},
     'ApplicationOffers': {'versions': [1, 2]},
     'ApplicationScaler': {'versions': [1]},
     'Backups': {'versions': [1, 2]},

--- a/tests/integration/test_expose.py
+++ b/tests/integration/test_expose.py
@@ -1,0 +1,103 @@
+import pytest
+
+from juju.application import ExposedEndpoint
+
+from .. import base
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_expose_unexpose(event_loop):
+    async with base.CleanModel() as model:
+        app = await model.deploy(
+            "cs:~jameinel/ubuntu-lite-7",
+        )
+
+        if not app.supports_granular_expose_parameters():
+            pytest.skip("this test requires a 2.9 or greated controller")
+
+        # Expose all opened port ranges
+        await app.expose()
+        exposed_endpoints = await get_exposed_endpoints(model, app)
+        assert exposed_endpoints == {
+            "": {
+                "expose-to-cidrs": ["0.0.0.0/0", "::/0"],
+                "expose-to-spaces": None
+            }
+        }
+
+        # Expose all opened port ranges to the CIDRs that correspond to a list
+        # of spaces.
+        await app.expose(exposed_endpoints={
+            "": ExposedEndpoint(to_spaces=["alpha"])
+        })
+        exposed_endpoints = await get_exposed_endpoints(model, app)
+        assert exposed_endpoints == {
+            "": {
+                "expose-to-cidrs": None,
+                "expose-to-spaces": ["alpha"]
+            }
+        }
+
+        # Expose all opened port ranges to a list of CIDRs.
+        await app.expose(exposed_endpoints={
+            "": ExposedEndpoint(to_cidrs=["10.0.0.0/24"])
+        })
+        exposed_endpoints = await get_exposed_endpoints(model, app)
+        assert exposed_endpoints == {
+            "": {
+                "expose-to-cidrs": ["10.0.0.0/24"],
+                "expose-to-spaces": None
+            }
+        }
+
+        # Expose all opened port ranges to a list of spaces and CIDRs.
+        await app.expose(exposed_endpoints={
+            "": ExposedEndpoint(to_spaces=["alpha"], to_cidrs=["10.0.0.0/24"])
+        })
+        exposed_endpoints = await get_exposed_endpoints(model, app)
+        assert exposed_endpoints == {
+            "": {
+                "expose-to-spaces": ["alpha"],
+                "expose-to-cidrs": ["10.0.0.0/24"]
+            }
+        }
+
+        # Expose individual endpoints to different space/CIDR combinations
+        await app.expose(exposed_endpoints={
+            "": ExposedEndpoint(to_spaces=["alpha"], to_cidrs=["10.0.0.0/24"]),
+            "ubuntu": ExposedEndpoint(to_cidrs=["10.42.42.0/24"])
+        })
+        exposed_endpoints = await get_exposed_endpoints(model, app)
+        assert exposed_endpoints == {
+            "": {
+                "expose-to-spaces": ["alpha"],
+                "expose-to-cidrs": ["10.0.0.0/24"]
+            },
+            "ubuntu": {
+                "expose-to-cidrs": ["10.42.42.0/24"],
+                "expose-to-spaces": None
+            }
+        }
+
+        # Unexpose individual endpoints (other endpoints remain exposed).
+        await app.unexpose(exposed_endpoints=["ubuntu"])
+        exposed_endpoints = await get_exposed_endpoints(model, app)
+        assert exposed_endpoints == {
+            "": {
+                "expose-to-spaces": ["alpha"],
+                "expose-to-cidrs": ["10.0.0.0/24"]
+            },
+        }
+
+        # Unexpose application
+        await app.unexpose()
+        exposed_endpoints = await get_exposed_endpoints(model, app)
+        assert exposed_endpoints == {}
+
+
+async def get_exposed_endpoints(model, app):
+    app_name = app.name
+    status = await model.get_status(filters=[app_name])
+    exposed_endpoints = status.applications[app_name].exposed_endpoints
+    return {k: v.serialize() for k, v in exposed_endpoints.items()}

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -94,28 +94,28 @@ class TestExposeApplication(asynctest.TestCase):
         # Case 1: exposed_endpoints includes an entry with a space list.
         with self.assertRaises(JujuError):
             await app.expose(exposed_endpoints={
-             "": ExposedEndpoint(to_spaces=["alpha"]),
+                "": ExposedEndpoint(to_spaces=["alpha"]),
             })
 
         # Case 2: exposed_endpoints only includes the wildcard endpoints key
         # with a non-wildcard CIDR.
         with self.assertRaises(JujuError):
             await app.expose(exposed_endpoints={
-             "": ExposedEndpoint(to_cidrs=["0.0.0.0/0", "10.0.0.0/24"]),
+                "": ExposedEndpoint(to_cidrs=["0.0.0.0/0", "10.0.0.0/24"]),
             })
 
         # Case 3: exposed_endpoints has a single entry for the
         # non-wildcard endpoint.
         with self.assertRaises(JujuError):
             await app.expose(exposed_endpoints={
-             "": ExposedEndpoint(to_cidrs=["0.0.0.0/0", "10.0.0.0/24"]),
+                "": ExposedEndpoint(to_cidrs=["0.0.0.0/0", "10.0.0.0/24"]),
             })
 
         # Case 4: exposed_endpoints has multiple keys.
         with self.assertRaises(JujuError):
             await app.expose(exposed_endpoints={
-             "foo": ExposedEndpoint(to_cidrs=["0.0.0.0/0"]),
-             "bar": ExposedEndpoint(to_spaces=["alpha"]),
+                "foo": ExposedEndpoint(to_cidrs=["0.0.0.0/0"]),
+                "bar": ExposedEndpoint(to_spaces=["alpha"]),
             })
 
         # Check that we call the facade with the right arity.
@@ -139,7 +139,7 @@ class TestUnExposeApplication(asynctest.TestCase):
         # If we try to unexpose individual endpoints on an older controller
         # (app facade < 13) we should get an error back.
         with self.assertRaises(JujuError):
-            await app.unexpose(exposed_endpoints=["outer","inner"])
+            await app.unexpose(exposed_endpoints=["outer", "inner"])
 
         # Check that we call the facade with the right arity.
         await app.unexpose()

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -1,0 +1,165 @@
+import mock
+import asynctest
+import asyncio
+
+from juju.model import Model
+from juju.application import (Application, ExposedEndpoint)
+from juju.errors import JujuError
+
+
+class TestExposeApplication(asynctest.TestCase):
+    @asynctest.patch("juju.model.Model.connection")
+    async def test_expose_with_exposed_endpoints_as_raw_dict(self, mock_conn):
+        mock_facade_version = mock.MagicMock(return_value=13)
+        mock_facade = mock.MagicMock(name="application_facade")
+        mock_facade().Expose.return_value = asyncio.Future()
+        mock_facade().Expose.return_value.set_result([])
+
+        app = Application(entity_id="app-id", model=Model())
+        app.name = "panther"
+        app._facade = mock_facade
+        app._facade_version = mock_facade_version
+
+        # Check that if we pass a dict as would be the case when processing an
+        # expose change, it gets correctly converted to ExposedEndpoint values,
+        # validated and converted to a dictionary with the right format before
+        # it gets passed to the facade.
+        await app.expose(exposed_endpoints={
+            "": {
+                "expose-to-spaces": ["alpha"],
+                "expose-to-cidrs": ["0.0.0.0/0"]
+            }
+        })
+
+        mock_facade().Expose.assert_called_once_with(
+            application="panther",
+            exposed_endpoints={
+                "": {
+                    "expose-to-spaces": ["alpha"],
+                    "expose-to-cidrs": ["0.0.0.0/0"]
+                }
+            })
+
+    @asynctest.patch("juju.model.Model.connection")
+    async def test_expose_with_exposed_endpoints(self, mock_conn):
+        mock_facade_version = mock.MagicMock(return_value=13)
+        mock_facade = mock.MagicMock(name="application_facade")
+        mock_facade().Expose.return_value = asyncio.Future()
+        mock_facade().Expose.return_value.set_result([])
+
+        app = Application(entity_id="app-id", model=Model())
+        app.name = "panther"
+        app._facade = mock_facade
+        app._facade_version = mock_facade_version
+
+        # Check that if we pass a dict with ExposedEndpoint values, they get
+        # validated and converted to a dictionary with the right format before
+        # it gets passed to the facade.
+        await app.expose(exposed_endpoints={
+            "": ExposedEndpoint(to_spaces=["alpha"], to_cidrs=["0.0.0.0/0"]),
+            "x": ExposedEndpoint(to_spaces=["beta"]),
+            "y": ExposedEndpoint(to_cidrs=["10.0.0.0/24"])
+        })
+
+        mock_facade().Expose.assert_called_once_with(
+            application="panther",
+            exposed_endpoints={
+                "": {
+                    "expose-to-spaces": ["alpha"],
+                    "expose-to-cidrs": ["0.0.0.0/0"]
+                },
+                "x": {
+                    "expose-to-spaces": ["beta"],
+                },
+                "y": {
+                    "expose-to-cidrs": ["10.0.0.0/24"],
+                },
+            })
+
+    @asynctest.patch("juju.model.Model.connection")
+    async def test_expose_endpoints_on_older_controller(self, mock_conn):
+        mock_facade_version = mock.MagicMock(return_value=12)
+        mock_facade = mock.MagicMock(name="application_facade")
+        mock_facade().Expose.return_value = asyncio.Future()
+        mock_facade().Expose.return_value.set_result([])
+
+        app = Application(entity_id="app-id", model=Model())
+        app.name = "panther"
+        app._facade = mock_facade
+        app._facade_version = mock_facade_version
+
+        # If we try to expose individual endpoints on an older controller
+        # (app facade < 13) we should get an error back.
+
+        # Case 1: exposed_endpoints includes an entry with a space list.
+        with self.assertRaises(JujuError):
+            await app.expose(exposed_endpoints={
+             "": ExposedEndpoint(to_spaces=["alpha"]),
+            })
+
+        # Case 2: exposed_endpoints only includes the wildcard endpoints key
+        # with a non-wildcard CIDR.
+        with self.assertRaises(JujuError):
+            await app.expose(exposed_endpoints={
+             "": ExposedEndpoint(to_cidrs=["0.0.0.0/0", "10.0.0.0/24"]),
+            })
+
+        # Case 3: exposed_endpoints has a single entry for the
+        # non-wildcard endpoint.
+        with self.assertRaises(JujuError):
+            await app.expose(exposed_endpoints={
+             "": ExposedEndpoint(to_cidrs=["0.0.0.0/0", "10.0.0.0/24"]),
+            })
+
+        # Case 4: exposed_endpoints has multiple keys.
+        with self.assertRaises(JujuError):
+            await app.expose(exposed_endpoints={
+             "foo": ExposedEndpoint(to_cidrs=["0.0.0.0/0"]),
+             "bar": ExposedEndpoint(to_spaces=["alpha"]),
+            })
+
+        # Check that we call the facade with the right arity.
+        await app.expose()
+        mock_facade().Expose.assert_called_once_with(application="panther")
+
+
+class TestUnExposeApplication(asynctest.TestCase):
+    @asynctest.patch("juju.model.Model.connection")
+    async def test_unexpose_endpoints_on_older_controller(self, mock_conn):
+        mock_facade_version = mock.MagicMock(return_value=12)
+        mock_facade = mock.MagicMock(name="application_facade")
+        mock_facade().Unexpose.return_value = asyncio.Future()
+        mock_facade().Unexpose.return_value.set_result([])
+
+        app = Application(entity_id="app-id", model=Model())
+        app.name = "panther"
+        app._facade = mock_facade
+        app._facade_version = mock_facade_version
+
+        # If we try to unexpose individual endpoints on an older controller
+        # (app facade < 13) we should get an error back.
+        with self.assertRaises(JujuError):
+            await app.unexpose(exposed_endpoints=["outer","inner"])
+
+        # Check that we call the facade with the right arity.
+        await app.unexpose()
+        mock_facade().Unexpose.assert_called_once_with(application="panther")
+
+    @asynctest.patch("juju.model.Model.connection")
+    async def test_unexpose_endpoints_on_29_controller(self, mock_conn):
+        mock_facade_version = mock.MagicMock(return_value=13)
+        mock_facade = mock.MagicMock(name="application_facade")
+        mock_facade().Unexpose.return_value = asyncio.Future()
+        mock_facade().Unexpose.return_value.set_result([])
+
+        app = Application(entity_id="app-id", model=Model())
+        app.name = "panther"
+        app._facade = mock_facade
+        app._facade_version = mock_facade_version
+
+        await app.unexpose(exposed_endpoints=["alpha", "beta"])
+
+        mock_facade().Unexpose.assert_called_once_with(
+            application="panther",
+            exposed_endpoints=["alpha", "beta"]
+        )

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -634,14 +634,14 @@ class TestExposeChange(unittest.TestCase):
                           "requires": [],
                           "application": "application",
                           "exposed_endpoints": {
-                            "": {
-                                "to-spaces": ["alpha"],
-                                "to-cidrs": ["10.0.0.0/24"]
-                            },
-                            "foo": {
-                                "to-spaces": ["alien"],
-                                "to-cidrs": ["0.0.0.0/0", "::/0"]
-                            }
+                              "": {
+                                  "to-spaces": ["alpha"],
+                                  "to-cidrs": ["10.0.0.0/24"]
+                              },
+                              "foo": {
+                                  "to-spaces": ["alien"],
+                                  "to-cidrs": ["0.0.0.0/0", "::/0"]
+                              }
                           }}, change.__dict__)
 
 
@@ -678,14 +678,14 @@ class TestExposeChangeRun:
 
         model.applications["application1"].expose.assert_called_once()
         model.applications["application1"].expose.assert_called_with({
-                "": {
-                    "to-spaces": ["alpha"],
-                    "to-cidrs": ["10.0.0.0/24"]
-                },
-                "foo": {
-                    "to-spaces": ["alien"],
-                    "to-cidrs": ["0.0.0.0/0", "::/0"]
-                }
+            "": {
+                "to-spaces": ["alpha"],
+                "to-cidrs": ["10.0.0.0/24"]
+            },
+            "foo": {
+                "to-spaces": ["alien"],
+                "to-cidrs": ["0.0.0.0/0", "::/0"]
+            }
         })
 
 

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -605,20 +605,64 @@ class TestExposeChange(unittest.TestCase):
         change = ExposeChange(1, [], params={"application": "application"})
         self.assertEqual({"change_id": 1,
                           "requires": [],
-                          "application": "application"}, change.__dict__)
+                          "application": "application",
+                          "exposed_endpoints": None}, change.__dict__)
 
     def test_dict_params_missing_data(self):
         change = ExposeChange(1, [], params={})
         self.assertEqual({"change_id": 1,
                           "requires": [],
-                          "application": None}, change.__dict__)
+                          "application": None,
+                          "exposed_endpoints": None}, change.__dict__)
+
+    def test_dict_params_with_exposed_endpoints_data(self):
+        params = {
+            "application": "application",
+            "exposed-endpoints": {
+                "": {
+                    "to-spaces": ["alpha"],
+                    "to-cidrs": ["10.0.0.0/24"]
+                },
+                "foo": {
+                    "to-spaces": ["alien"],
+                    "to-cidrs": ["0.0.0.0/0", "::/0"]
+                }
+            }
+        }
+        change = ExposeChange(1, [], params=params)
+        self.assertEqual({"change_id": 1,
+                          "requires": [],
+                          "application": "application",
+                          "exposed_endpoints": {
+                            "": {
+                                "to-spaces": ["alpha"],
+                                "to-cidrs": ["10.0.0.0/24"]
+                            },
+                            "foo": {
+                                "to-spaces": ["alien"],
+                                "to-cidrs": ["0.0.0.0/0", "::/0"]
+                            }
+                          }}, change.__dict__)
 
 
 class TestExposeChangeRun:
 
     @pytest.mark.asyncio
     async def test_run(self, event_loop):
-        change = ExposeChange(1, [], params={"application": "application"})
+        params = {
+            "application": "application",
+            "exposed-endpoints": {
+                "": {
+                    "to-spaces": ["alpha"],
+                    "to-cidrs": ["10.0.0.0/24"]
+                },
+                "foo": {
+                    "to-spaces": ["alien"],
+                    "to-cidrs": ["0.0.0.0/0", "::/0"]
+                }
+            }
+        }
+        change = ExposeChange(1, [], params=params)
 
         app = mock.Mock()
         app.expose = base.AsyncMock(return_value=None)
@@ -633,6 +677,16 @@ class TestExposeChangeRun:
         assert result is None
 
         model.applications["application1"].expose.assert_called_once()
+        model.applications["application1"].expose.assert_called_with({
+                "": {
+                    "to-spaces": ["alpha"],
+                    "to-cidrs": ["10.0.0.0/24"]
+                },
+                "foo": {
+                    "to-spaces": ["alien"],
+                    "to-cidrs": ["0.0.0.0/0", "::/0"]
+                }
+        })
 
 
 class TestScaleChange(unittest.TestCase):


### PR DESCRIPTION
This PR adds support for granular, per-endpoint expose parameters to the expose/unexpose methods of the Application model as well as an example for using the new feature. For more details on using this feature please refer to https://discourse.juju.is/t/granular-control-of-application-expose-parameters-in-the-upcoming-2-9-juju-release/3597