### PR TITLE
Handle strict mode

### DIFF
--- a/juju/client/jujudata.py
+++ b/juju/client/jujudata.py
@@ -121,7 +121,8 @@ class FileJujuData(JujuData):
     '''Provide access to the Juju client configuration files.
     Any configuration file is read once and then cached.'''
     def __init__(self):
-        self.path = os.environ.get('JUJU_DATA') or '~/.local/share/juju'
+        default_data_dir = pathlib.Path(pathlib.Path.home(), ".local", "share", "juju")
+        self.path = os.environ.get('JUJU_DATA', default_data_dir)
         self.path = os.path.abspath(os.path.expanduser(self.path))
         # _loaded keeps track of the loaded YAML from
         # the Juju data files so we don't need to load the same

--- a/juju/client/jujudata.py
+++ b/juju/client/jujudata.py
@@ -121,8 +121,7 @@ class FileJujuData(JujuData):
     '''Provide access to the Juju client configuration files.
     Any configuration file is read once and then cached.'''
     def __init__(self):
-        default_data_dir = pathlib.Path(pathlib.Path.home(), ".local", "share", "juju")
-        self.path = os.environ.get('JUJU_DATA', default_data_dir)
+        self.path = os.environ.get('JUJU_DATA') or '~/.local/share/juju'
         self.path = os.path.abspath(os.path.expanduser(self.path))
         # _loaded keeps track of the loaded YAML from
         # the Juju data files so we don't need to load the same

--- a/juju/delta.py
+++ b/juju/delta.py
@@ -46,6 +46,9 @@ class AnnotationDelta(EntityDelta):
 
 
 class ModelDelta(EntityDelta):
+    def get_id(self):
+        return self.data['model-uuid']
+
     @classmethod
     def get_entity_class(self):
         from .model import ModelInfo

--- a/juju/model.py
+++ b/juju/model.py
@@ -917,12 +917,15 @@ class Model:
                             pass  # can't stop on a closed conn
                         break
                     for delta in results.deltas:
+                        entity = None
                         try:
                             entity = get_entity_delta(delta)
                         except KeyError:
                             if self.strict_mode:
                                 raise JujuError("unknown delta type '{}'".format(delta.entity))
 
+                        if not self.strict_mode and entity is None:
+                            continue
                         old_obj, new_obj = self.state.apply_delta(entity)
                         await self._notify_observers(entity, old_obj, new_obj)
                         # Post step ensure that we can handle any settings

--- a/juju/model.py
+++ b/juju/model.py
@@ -919,14 +919,15 @@ class Model:
                     for delta in results.deltas:
                         try:
                             entity = get_entity_delta(delta)
-                            old_obj, new_obj = self.state.apply_delta(entity)
-                            await self._notify_observers(entity, old_obj, new_obj)
-                            # Post step ensure that we can handle any settings
-                            # that need to be correctly set as a post step.
-                            _post_step(new_obj)
                         except KeyError:
                             if self.strict_mode:
                                 raise JujuError("unknown delta type '{}'".format(delta.entity))
+
+                        old_obj, new_obj = self.state.apply_delta(entity)
+                        await self._notify_observers(entity, old_obj, new_obj)
+                        # Post step ensure that we can handle any settings
+                        # that need to be correctly set as a post step.
+                        _post_step(new_obj)
                     self._watch_received.set()
             except CancelledError:
                 pass

--- a/juju/model.py
+++ b/juju/model.py
@@ -304,8 +304,8 @@ class ModelEntity:
         # Allow the overriding of entity names from the type instead of from
         # the class name. Useful because Model and ModelInfo clash and we really
         # want ModelInfo to be called Model.
-        if hasattr(self.__class__, "entity_name") and callable(self.__class__.entity_name):
-            return self.__class__.entity_name()
+        if hasattr(self.__class__, "type_name_override") and callable(self.__class__.type_name_override):
+            return self.__class__.type_name_override()
 
         def first_lower(s):
             if len(s) == 0:
@@ -2300,5 +2300,5 @@ class ModelInfo(ModelEntity):
         return tag.model(self.uuid)
 
     @staticmethod
-    def entity_name():
+    def type_name_override():
         return "model"


### PR DESCRIPTION
Strict mode is a new feature in Juju 2.9. The mode allows more things to
fail early if the mode is switched to strict. If no mode is detected
then it will fallback to a more passive mode, where it will fallback to
other solutions and try to carry on.

The purpose of strict mode is to enable people developing with
Juju/pylibjuju is highlight errors more early on and to prevent less
magic in Juju.

The PR for implementing strict mode is simple, EXCEPT when I turned it
one, it found the first error! ModelInfo delta was wrongly implemented
and wasn't gaining all the history correctly from the deltas over time.

This requires[1] juju/juju#12183 to land before this PR is really
useful.

To enable it at bootstrap time:

```sh
juju bootstrap lxd test --config mode=strict
```

 1. https://github.com/juju/juju/pull/12183