### PR TITLE
Handle None in results

### DIFF
--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -482,7 +482,7 @@ class Connection:
             # errors, or perhaps a keyword parameter to the rpc method
             # could be added to trigger this behaviour.
             err_results = []
-            for res in result['response']['results']:
+            for res in result['response']['results'] or []:
                 if res.get('error', {}).get('message'):
                     err_results.append(res['error']['message'])
             if err_results:


### PR DESCRIPTION
Apparently, `list_offers` can return a result with a None value instead of an empty list (or no response key), leading to an error like the following:

```python-traceback
Traceback (most recent call last):
  File "/home/johnsca/juju/projects/kubernetes-jenkins/jobs/integration/conftest.py", line 233, in k8s_model
    offers = [offer.offer_name for offer in (await k8s_model.list_offers()).results]
  File "/home/johnsca/juju/projects/kubernetes-jenkins/.tox/py3/lib/python3.8/site-packages/juju/model.py", line 1989, in list_offers
    return await controller.list_offers(self.info.name)
  File "/home/johnsca/juju/projects/kubernetes-jenkins/.tox/py3/lib/python3.8/site-packages/juju/controller.py", line 769, in list_offers
    return await facade.ListApplicationOffers(filters=[params])
  File "/home/johnsca/juju/projects/kubernetes-jenkins/.tox/py3/lib/python3.8/site-packages/juju/client/facade.py", line 480, in wrapper
    reply = await f(*args, **kwargs)
  File "/home/johnsca/juju/projects/kubernetes-jenkins/.tox/py3/lib/python3.8/site-packages/juju/client/_client2.py", line 2413, in ListApplicationOffers
    reply = await self.rpc(msg)
  File "/home/johnsca/juju/projects/kubernetes-jenkins/.tox/py3/lib/python3.8/site-packages/juju/client/facade.py", line 623, in rpc
    result = await self.connection.rpc(msg, encoder=TypeEncoder)
  File "/home/johnsca/juju/projects/kubernetes-jenkins/.tox/py3/lib/python3.8/site-packages/juju/client/connection.py", line 484, in rpc
    for res in result['response']['results']:
TypeError: 'NoneType' object is not iterable
```