### PR TITLE
CharmHub - Info

### DIFF
--- a/examples/charmhub.py
+++ b/examples/charmhub.py
@@ -1,0 +1,29 @@
+"""
+Example to show how to connect to the current model and query the charm-hub
+store for information about a given charm.
+"""
+import logging
+
+from juju import loop
+from juju.model import Model
+
+log = logging.getLogger(__name__)
+
+
+async def main():
+    model = Model()
+    try:
+        # connect to the current model with the current user, per the Juju CLI
+        await model.connect()
+
+        charm = await model.charmhub.info("mattermost")
+        print(charm)
+    finally:
+        if model.is_connected():
+            print('Disconnecting from model')
+            await model.disconnect()
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    loop.run(main())

--- a/examples/charmhub_info.py
+++ b/examples/charmhub_info.py
@@ -1,6 +1,6 @@
 """
 Example to show how to connect to the current model and query the charm-hub
-store for information about a given charm.
+repository for information about a given charm.
 """
 import logging
 

--- a/juju/charmhub.py
+++ b/juju/charmhub.py
@@ -1,0 +1,24 @@
+from .client import client
+from .errors import JujuError
+
+
+class CharmHub:
+    def __init__(self, model):
+        self.model = model
+
+    async def info(self, name, channel=None):
+        """info displays detailed information about a CharmHub charm. The charm
+        can be specified by name or by path.
+
+        """
+        if not name:
+            raise JujuError("name expected")
+
+        if channel is None:
+            channel = "latest"
+
+        facade = self._facade()
+        return await facade.Info(tag="application-{}".format(name), channel=channel)
+
+    def _facade(self):
+        return client.CharmHubFacade.from_connection(self.model.connection())

--- a/juju/charmhub.py
+++ b/juju/charmhub.py
@@ -8,14 +8,18 @@ class CharmHub:
 
     async def info(self, name, channel=None):
         """info displays detailed information about a CharmHub charm. The charm
-        can be specified by name or by path.
+        can be specified by the exact name.
+
+        Channel is a hint for providing the metadata for a given channel.
+        Without the channel hint then only the default release will have the
+        metadata.
 
         """
         if not name:
             raise JujuError("name expected")
 
         if channel is None:
-            channel = "latest"
+            channel = ""
 
         facade = self._facade()
         return await facade.Info(tag="application-{}".format(name), channel=channel)

--- a/juju/model.py
+++ b/juju/model.py
@@ -23,6 +23,7 @@ import websockets
 from . import provisioner, tag, utils
 from .annotationhelper import _get_annotations, _set_annotations
 from .bundle import BundleHandler, get_charm_series
+from .charmhub import CharmHub
 from .client import client, connector
 from .client.client import ConfigValue, Value
 from .client.overrides import Caveat, Macaroon
@@ -775,6 +776,14 @@ class Model:
 
         """
         return list(self.state.relations.values())
+
+    @property
+    def charmhub(self):
+        """Return a charmhub store for requesting charm information using
+        the charm-hub-url model config.
+
+        """
+        return CharmHub(self)
 
     async def get_info(self):
         """Return a client.ModelInfo object for this Model.

--- a/juju/model.py
+++ b/juju/model.py
@@ -779,7 +779,7 @@ class Model:
 
     @property
     def charmhub(self):
-        """Return a charmhub store for requesting charm information using
+        """Return a charmhub repository for requesting charm information using
         the charm-hub-url model config.
 
         """

--- a/tests/integration/test_charmhub.py
+++ b/tests/integration/test_charmhub.py
@@ -1,0 +1,35 @@
+import pytest
+
+from .. import base
+from juju.errors import JujuAPIError
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_info(event_loop):
+    async with base.CleanModel() as model:
+        result = await model.charmhub.info("mattermost")
+
+        assert result.result.name == "mattermost"
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_info_with_channel(event_loop):
+    async with base.CleanModel() as model:
+        result = await model.charmhub.info("mattermost", "latest/stable")
+
+        assert result.result.name == "mattermost"
+        assert "latest/stable" in result.result.channel_map
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_info_not_found(event_loop):
+    async with base.CleanModel() as model:
+        try:
+            await model.charmhub.info("badnameforapp")
+        except JujuAPIError as e:
+            assert e.message == "No charm or bundle with name 'badnameforapp'."
+        else:
+            raise


### PR DESCRIPTION
The following introduces queries to the charmhub store API. Now that all
requests go through a juju controller it makes it very trivial for other
clients like pylibjuju to gain the same powers as the go CLI.

The code is rather simple, it farms off a new type to encapsulate the
charmhub related calls (info and find which will follow) as the model
type is large and unwieldly, once there we just create a new facade and
perform the query.

Offically it would be nice to have to channel validation, but for now
we'll let the controller handle that.