### PR TITLE
CharmHub - Find

### DIFF
--- a/examples/charmhub_find.py
+++ b/examples/charmhub_find.py
@@ -1,0 +1,33 @@
+"""
+Example to show how to connect to the current model and search the charm-hub
+repository for charms.
+"""
+import logging
+
+from juju import loop
+from juju.model import Model
+
+log = logging.getLogger(__name__)
+
+
+async def main():
+    model = Model()
+    try:
+        # connect to the current model with the current user, per the Juju CLI
+        await model.connect()
+
+        # do a partial query so that we get more results.
+        charms = await model.charmhub.find("kuber")
+
+        print("Bundle\tName")
+        for resp in charms.result:
+            print("{}\t{}".format("N" if resp.type_ == "charm" else "Y", resp.name))
+    finally:
+        if model.is_connected():
+            print('Disconnecting from model')
+            await model.disconnect()
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    loop.run(main())

--- a/juju/charmhub.py
+++ b/juju/charmhub.py
@@ -24,5 +24,12 @@ class CharmHub:
         facade = self._facade()
         return await facade.Info(tag="application-{}".format(name), channel=channel)
 
+    async def find(self, query):
+        """find queries the CharmHub store for available charms or bundles.
+
+        """
+        facade = self._facade()
+        return await facade.Find(query=query)
+
     def _facade(self):
         return client.CharmHubFacade.from_connection(self.model.connection())

--- a/tests/integration/test_charmhub.py
+++ b/tests/integration/test_charmhub.py
@@ -33,3 +33,27 @@ async def test_info_not_found(event_loop):
             assert e.message == "No charm or bundle with name 'badnameforapp'."
         else:
             raise
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_find(event_loop):
+    async with base.CleanModel() as model:
+        result = await model.charmhub.find("kube")
+
+        assert len(result.result) > 0
+        for resp in result.result:
+            assert resp.name != ""
+            assert resp.type_ in ["charm", "bundle"]
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_find_all(event_loop):
+    async with base.CleanModel() as model:
+        result = await model.charmhub.find("")
+
+        assert len(result.result) > 0
+        for resp in result.result:
+            assert resp.name != ""
+            assert resp.type_ in ["charm", "bundle"]


### PR DESCRIPTION
This requires #460 to land first.

The following adds the ability to query the charmhub repository. It uses
the controller to query the charmhub repository so is really easy for
clients to also use the same logic/code path as the go CLI.