### PR TITLE
Expand wait_for_idle to support waiting for status

### DIFF
--- a/tests/charm/config.yaml
+++ b/tests/charm/config.yaml
@@ -1,0 +1,4 @@
+options:
+  status:
+    type: string
+    default: "active"

--- a/tests/charm/dispatch
+++ b/tests/charm/dispatch
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-status-set active
+status-set "$(config-get status)"


### PR DESCRIPTION
Improve the `Model.wait_for_idle` helper to allow waiting for the workload status to become "active" as well, and to raise on "blocked" status in addition to "error".

Also adds log messages to track progress of waiting.