### PR TITLE
Fix the typo in the param name

### DIFF
--- a/juju/application.py
+++ b/juju/application.py
@@ -162,9 +162,9 @@ class Application(model.ModelEntity):
             self.name, 'to' if scale else 'by', scale or scale_change)
 
         await app_facade.ScaleApplications(applications=[
-            client.ScaleApplicationParam(application_tag=self.tag,
-                                         scale=scale,
-                                         scale_change=scale_change)
+            client.ScaleApplicationParams(application_tag=self.tag,
+                                          scale=scale,
+                                          scale_change=scale_change)
         ])
 
     def allocate(self, budget, value):


### PR DESCRIPTION
The name of the param is ScaleApplicationParams not
ScaleApplicationParam. This should have really be caught in a test, but
for now, fix this so we can get a release out.

Fixes: #477