### PR TITLE
Find parameters

### DIFF
--- a/juju/charmhub.py
+++ b/juju/charmhub.py
@@ -24,9 +24,9 @@ class CharmHub:
         facade = self._facade()
         return await facade.Info(tag="application-{}".format(name), channel=channel)
 
-    async def find(self, query, category=None, channel=None, 
-                    charm_type=None, platforms=None, publisher=None, 
-                    relation_requires=None, relation_provides=None):
+    async def find(self, query, category=None, channel=None,
+                   charm_type=None, platforms=None, publisher=None,
+                   relation_requires=None, relation_provides=None):
         """find queries the CharmHub store for available charms or bundles.
 
         """
@@ -35,8 +35,8 @@ class CharmHub:
 
         facade = self._facade()
         return await facade.Find(query=query, category=category, channel=channel,
-            type_=charm_type, platforms=platforms, publisher=publisher,
-            relation_provides=relation_provides, relation_requires=relation_requires)
+                                 type_=charm_type, platforms=platforms, publisher=publisher,
+                                 relation_provides=relation_provides, relation_requires=relation_requires)
 
     def _facade(self):
         return client.CharmHubFacade.from_connection(self.model.connection())

--- a/juju/charmhub.py
+++ b/juju/charmhub.py
@@ -24,12 +24,19 @@ class CharmHub:
         facade = self._facade()
         return await facade.Info(tag="application-{}".format(name), channel=channel)
 
-    async def find(self, query):
+    async def find(self, query, category=None, channel=None, 
+                    charm_type=None, platforms=None, publisher=None, 
+                    relation_requires=None, relation_provides=None):
         """find queries the CharmHub store for available charms or bundles.
 
         """
+        if charm_type is not None and charm_type not in ["charm", "bundle"]:
+            raise JujuError("expected either charm or bundle for charm_type")
+
         facade = self._facade()
-        return await facade.Find(query=query)
+        return await facade.Find(query=query, category=category, channel=channel,
+            type_=charm_type, platforms=platforms, publisher=publisher,
+            relation_provides=relation_provides, relation_requires=relation_requires)
 
     def _facade(self):
         return client.CharmHubFacade.from_connection(self.model.connection())

--- a/tests/integration/test_charmhub.py
+++ b/tests/integration/test_charmhub.py
@@ -30,9 +30,9 @@ async def test_info_not_found(event_loop):
         try:
             await model.charmhub.info("badnameforapp")
         except JujuAPIError as e:
-            assert e.message == "No charm or bundle with name 'badnameforapp'."
+            assert e.message == "badnameforapp not found"
         else:
-            raise
+            assert False
 
 
 @base.bootstrapped
@@ -45,6 +45,18 @@ async def test_find(event_loop):
         for resp in result.result:
             assert resp.name != ""
             assert resp.type_ in ["charm", "bundle"]
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_find_bundles(event_loop):
+    async with base.CleanModel() as model:
+        result = await model.charmhub.find("kube", charm_type="bundle")
+
+        assert len(result.result) > 0
+        for resp in result.result:
+            assert resp.name != ""
+            assert resp.type_ in ["bundle"]
 
 
 @base.bootstrapped


### PR DESCRIPTION
The following adds the optional find parameters that are exposed in the
API. The find API already existed, this is just to augment what was
already there.

It's now possible to just request bundles.

```py
result = await model.charmhub.find("kuber", charm_type="bundle")
```