### PR TITLE
Remove machine work around

### DIFF
--- a/juju/machine.py
+++ b/juju/machine.py
@@ -5,7 +5,7 @@ import os
 
 import pyrfc3339
 
-from . import model, tag, utils
+from . import model, tag
 from .annotationhelper import _get_annotations, _set_annotations
 from .client import client
 from .errors import JujuError
@@ -16,88 +16,6 @@ log = logging.getLogger(__name__)
 class Machine(model.ModelEntity):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.model.loop.create_task(self._queue_workarounds())
-
-    async def _queue_workarounds(self):
-        model = self.model
-        if not model.info:
-            await utils.run_with_interrupt(model.get_info(),
-                                           model._watch_stopping,
-                                           loop=model.loop)
-        if model._watch_stopping.is_set():
-            return
-        if model.info.agent_version < client.Number.from_json('2.2.3'):
-            self.on_change(self._workaround_1695335)
-
-    async def _workaround_1695335(self, delta, old, new, model):
-        """
-        This is a (hacky) temporary work around for a bug in Juju where the
-        instance status and agent version fields don't get updated properly
-        by the AllWatcher.
-
-        Deltas never contain a value for `data['agent-status']['version']`,
-        and once the `instance-status` reaches `pending`, we no longer get
-        any updates for it (the deltas come in, but the `instance-status`
-        data is always the same after that).
-
-        To work around this, whenever a delta comes in for this machine, we
-        query FullStatus and use the data from there if and only if it's newer.
-        Luckily, the timestamps on the `since` field does seem to be accurate.
-
-        See https://bugs.launchpad.net/juju/+bug/1695335
-
-        NOTE: this was fixed in 2.2.3 and 2.3-beta1.
-        """
-        if delta.data.get('synthetic', False):
-            # prevent infinite loops re-processing already processed deltas
-            return
-
-        full_status = await utils.run_with_interrupt(model.get_status(),
-                                                     model._watch_stopping,
-                                                     loop=model.loop)
-        if model._watch_stopping.is_set():
-            return
-
-        if self.id not in full_status.machines:
-            return
-
-        if not full_status.machines[self.id]['instance-status']['since']:
-            return
-
-        machine = full_status.machines[self.id]
-
-        change_log = []
-        key_map = {
-            'status': 'current',
-            'info': 'message',
-            'since': 'since',
-        }
-
-        # handle agent version specially, because it's never set in
-        # deltas, and we don't want even a newer delta to clear it
-        agent_version = machine['agent-status']['version']
-        if agent_version:
-            delta.data['agent-status']['version'] = agent_version
-            change_log.append(('agent-version', '', agent_version))
-
-        # only update (other) delta fields if status data is newer
-        status_since = pyrfc3339.parse(machine['instance-status']['since'])
-        delta_since = pyrfc3339.parse(delta.data['instance-status']['since'])
-        if status_since > delta_since:
-            for status_key in ('status', 'info', 'since'):
-                delta_key = key_map[status_key]
-                status_value = machine['instance-status'][status_key]
-                delta_value = delta.data['instance-status'][delta_key]
-                change_log.append((delta_key, delta_value, status_value))
-                delta.data['instance-status'][delta_key] = status_value
-
-        if change_log:
-            log.debug('Overriding machine delta with FullStatus data')
-            for log_item in change_log:
-                log.debug('    {}: {} -> {}'.format(*log_item))
-            delta.data['synthetic'] = True
-            old_obj, new_obj = self.model.state.apply_delta(delta)
-            await model._notify_observers(delta, old_obj, new_obj)
 
     async def destroy(self, force=False):
         """Remove this machine from the model.


### PR DESCRIPTION
The following change removes the workaround for the 2.2.3 release and
subsequent 2.3-beta1 release. As these are older releases that users
should have moved away from, it's time to remove the workarounds.

The code in question was highly contentious anyway, as it was never
awaited on the machine, so might not have been doing what we wanted it
to do in the long run.