### PR TITLE
Bundle: Exposed endpoints missing

### DIFF
--- a/juju/bundle.py
+++ b/juju/bundle.py
@@ -800,6 +800,7 @@ class ExposeChange(ChangeInfo):
     def __init__(self, change_id, requires, params=None):
         super(ExposeChange, self).__init__(change_id, requires)
 
+        self.exposed_endpoints = None
         if isinstance(params, list):
             self.application = params[0]
         elif isinstance(params, dict):

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -621,7 +621,8 @@ class TestExposeChange(unittest.TestCase):
         change = ExposeChange(1, [], params=["application"])
         self.assertEqual({"change_id": 1,
                           "requires": [],
-                          "application": "application"}, change.__dict__)
+                          "application": "application",
+                          "exposed_endpoints": None}, change.__dict__)
 
     def test_dict_params(self):
         change = ExposeChange(1, [], params={"application": "application"})

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ deps =
     pytest-xdist
     Twine
     websockets
+    kubernetes
     # use fork to pick up fix for https://github.com/aaugustin/websockets/pull/528
     git+https://github.com/johnsca/websockets@bug/client-redirects#egg=websockets ; python_version<'3.9'
 


### PR DESCRIPTION
The following fixes #501 where exposed-endpoints is missing from the
API. We always set one, even if it's None.