### PR TITLE
Fix series being required for local charms

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -1483,7 +1483,9 @@ class Model:
                 series = series or get_charm_series(charm_dir)
                 if not series:
                     config = await self.get_config()
-                    series = config.get("default-series")
+                    default_series = config.get("default-series")
+                    if default_series:
+                        series = default_series.value
                 if not series:
                     raise JujuError(
                         "Couldn't determine series for charm at {}. "

--- a/juju/model.py
+++ b/juju/model.py
@@ -1482,8 +1482,8 @@ class Model:
                     os.path.expanduser(entity_id))
                 series = series or get_charm_series(charm_dir)
                 if not series:
-                    config = await self.get_config()
-                    default_series = config.get("default-series")
+                    model_config = await self.get_config()
+                    default_series = model_config.get("default-series")
                     if default_series:
                         series = default_series.value
                 if not series:

--- a/juju/model.py
+++ b/juju/model.py
@@ -1482,6 +1482,9 @@ class Model:
                     os.path.expanduser(entity_id))
                 series = series or get_charm_series(charm_dir)
                 if not series:
+                    config = await self.get_config()
+                    series = config.get("default-series")
+                if not series:
                     raise JujuError(
                         "Couldn't determine series for charm at {}. "
                         "Pass a 'series' kwarg to Model.deploy().".format(


### PR DESCRIPTION
Local charms may no longer need a series if they are metadata v2 container charms. The Juju CLI uses the model default instead.

Fixes [lp:1929076][]

[lp:1929076]: https://bugs.launchpad.net/juju/+bug/1929076