### PR TITLE
Implementing `backup` functionality

### DIFF
--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -784,3 +784,26 @@ async def test_unit_annotations(event_loop):
 
         annotations = await unit.get_annotations()
         assert annotations == expected
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_backups(event_loop):
+    m = Model()
+    await m.connect(model_name='controller')
+    backups = await m.get_backups()
+    assert backups == []  # no backup yet
+
+    created_backup = await m.create_backup(notes="hi", keep_copy=True)
+    assert 'id' in created_backup
+    created_id = created_backup['id']
+
+    assert 'checksum' in created_backup
+    assert created_backup['notes'] == "hi"
+
+    after_create_backups = await m.get_backups()
+    assert len(after_create_backups) == 1
+
+    await m.remove_backup(created_id)
+    after_remove_backup = await m.get_backups()
+    assert len(after_remove_backup) == 0


### PR DESCRIPTION
### Description

This is in response to Issue #528 , implementing rudimentary `backup` functionality by adding `create_backup`, `get_backups` and `remove_backup` functions. `download_backup`, `upload_backup` and `restore_backup` need to be implemented for full functionality.

There are two commits:

- adds the implementation
- adds the test case for the implementation

### QA Steps

To run the newly added test case individually:
<in the main directory of `python-libjuju`>
```
$ make .tox
$ tox -e integration -- tests/integration/test_model.py::test_backups
```