### PR TITLE
Fix issue 530: Check the controller for unsynched models

### DIFF
--- a/juju/client/connector.py
+++ b/juju/client/connector.py
@@ -141,9 +141,6 @@ class Connector:
             for user_model in response.user_models:
                 if 'admin/' + user_model.model.name == model_name:
                     model_uuid = user_model.model.uuid
-            # TODO refresh the local cache
-            # then self.jujudata.refresh()
-            # then self.jujudata.models()
 
         if model_uuid is None:
             raise JujuConnectionError('Model not found: {}'.format(model_name))

--- a/juju/client/connector.py
+++ b/juju/client/connector.py
@@ -8,6 +8,7 @@ from juju.client.gocookies import GoCookieJar, go_to_py_cookie
 from juju.client.jujudata import FileJujuData
 from juju.client.proxy.factory import proxy_from_config
 from juju.errors import JujuConnectionError, JujuError
+from juju.client import client
 
 log = logging.getLogger('connector')
 
@@ -125,20 +126,34 @@ class Connector:
         account = self.jujudata.accounts().get(controller_name, {})
         models = self.jujudata.models().get(controller_name, {}).get('models',
                                                                      {})
+        model_uuid = None
+        if model_name in models:
+            model_uuid = models[model_name]['uuid']
+        else:
+            # let's try to find it through the actual controller
+            await self.connect_controllerc(controller_name=controller_name)
+            # get the facade
+            controller_facade = client.ControllerFacade.from_connection(
+                self.connection())
+            # get all the user models from the api
+            response = await controller_facade.AllModels()
+            # search the one that contains admin/model_name
+            for user_model in response.user_models:
+                if 'admin/' + user_model.model.name == model_name:
+                    model_uuid = user_model.model.uuid
+            # TODO refresh the local cache
+            # then self.jujudata.refresh()
+            # then self.jujudata.models()
 
-        if model_name not in models:
+        if model_uuid is None:
             raise JujuConnectionError('Model not found: {}'.format(model_name))
 
         proxy = proxy_from_config(controller.get('proxy-config', None))
 
-        # TODO if there's no record for the required model name, connect
-        # to the controller to find out the model's uuid, then connect
-        # to that. This will let connect_model work with models that
-        # haven't necessarily synced with the local juju data,
-        # and also remove the need for base.CleanModel to
-        # subclass JujuData.
+        # TODO remove the need for base.CleanModel to subclass
+        # JujuData.
         kwargs.update(endpoint=endpoints,
-                      uuid=models[model_name]['uuid'],
+                      uuid=model_uuid,
                       username=account.get('user'),
                       password=account.get('password'),
                       cacert=controller.get('ca-cert'),

--- a/juju/client/connector.py
+++ b/juju/client/connector.py
@@ -131,7 +131,7 @@ class Connector:
             model_uuid = models[model_name]['uuid']
         else:
             # let's try to find it through the actual controller
-            await self.connect_controllerc(controller_name=controller_name)
+            await self.connect_controller(controller_name=controller_name)
             # get the facade
             controller_facade = client.ControllerFacade.from_connection(
                 self.connection())
@@ -160,6 +160,8 @@ class Connector:
                       bakery_client=self.bakery_client_for_controller(controller_name),
                       proxy=proxy)
         await self.connect(**kwargs)
+        # TODO this might be a good spot to trigger refreshing the
+        # local cache (the connection to the model might help)
         self.controller_name = controller_name
         self.model_name = controller_name + ':' + model_name
 


### PR DESCRIPTION
### Description

The issue occurs when a `model.connect` runs before the model is synced with the local cache (`~/.local/share/juju/models.yaml`). This patch fixes it by consulting to the controller for the model `uuid` in case the model is not synced with the local cache yet.

#### Contains 3 commits

1. implements the patch
2. adds a test that targets this issue/patch
3. fixes a typo

### QA Steps

A new test is added just for this so the following should pass:

```
$ tox -e integration -- tests/integration/test_model.py::test_model_cache_update
```

### Discussion:

- After succesfully getting the `uuid` of the model (or after connecting to it) it might be nice to trigger an update on the local cache. 
- If we have a way of triggering an update on the local cache (before connecting to anything), then an alternative solution to all of this might be to just update the local cache before querying it for the model `uuid` (instead of going through the controller).