### PR TITLE
Allow ApplicationFacade set_config with non-string values

### DIFF
--- a/juju/application.py
+++ b/juju/application.py
@@ -517,7 +517,12 @@ class Application(model.ModelEntity):
         log.debug(
             'Setting config for %s: %s', self.name, config)
 
-        return await app_facade.Set(application=self.name, options=config)
+        str_config = {}
+        for k, v in config.items():
+            if v.get('value') is not None:
+                str_config[k] = str(v.get('value'))
+
+        await app_facade.Set(application=self.name, options=str_config)
 
     async def reset_config(self, to_default):
         """

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -48,6 +48,31 @@ async def test_action(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+async def test_get_set_config(event_loop):
+    async with base.CleanModel() as model:
+        ubuntu_app = await model.deploy(
+            'percona-cluster',
+            application_name='mysql',
+            series='xenial',
+            channel='stable',
+            config={
+                'tuning-level': 'safest',
+            },
+            constraints={
+                'arch': 'amd64',
+                'mem': 256 * MB,
+            },
+        )
+
+        config = await ubuntu_app.get_config()
+        await ubuntu_app.set_config(config)
+
+        config2 = await ubuntu_app.get_config()
+        assert config == config2
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
 async def test_status_is_not_unset(event_loop):
     async with base.CleanModel() as model:
         app = await model.deploy(

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -1001,29 +1001,45 @@ class TestBundleHandler:
 
         bundle = await handler._handle_local_charms(bundle, bundle_dir)
 
-        model.add_local_resources.assert_has_calls([
-            mock.call(
-                "oci-image-charm",
-                "charm_uri",
-                yaml.load(Path("tests/integration/oci-image-charm/metadata.yaml").read_text(), Loader=yaml.FullLoader),
-                resources={"oci-image": "ubuntu:latest"},
-            ),
-            mock.call(
-                "oci-image-charm-2",
-                "charm_uri",
-                yaml.load(Path("tests/integration/oci-image-charm-no-series/metadata.yaml").read_text(), Loader=yaml.FullLoader),
-                resources={"oci-image": "ubuntu:latest"},
-            ),
-            mock.call(
-                "oci-image-charm-3",
-                "charm_uri",
-                yaml.load(Path("tests/integration/oci-image-charm-no-series/metadata.yaml").read_text(), Loader=yaml.FullLoader),
-                resources={"oci-image": "ubuntu:latest"},
-            )]
+        # TODO: for some reason 'assert_has_calls' is failing in
+        # Python3.5, refactor this with 'assert_has_calls' when
+        # Python3.5 support is dropped
+
+        m1 = mock.call(
+            "oci-image-charm",
+            "charm_uri",
+            yaml.load(Path("tests/integration/oci-image-charm/metadata.yaml").read_text(), Loader=yaml.FullLoader),
+            resources={"oci-image": "ubuntu:latest"},
         )
-        model.add_local_charm_dir.assert_has_calls([
-            mock.call(charm_path_1, "focal"),
-            mock.call(charm_path_2, "focal"),
-            mock.call(charm_path_2, "focal")
-        ])
+
+        m2 = mock.call(
+            "oci-image-charm-2",
+            "charm_uri",
+            yaml.load(Path("tests/integration/oci-image-charm-no-series/metadata.yaml").read_text(), Loader=yaml.FullLoader),
+            resources={"oci-image": "ubuntu:latest"},
+        )
+
+        m3 = mock.call(
+            "oci-image-charm-3",
+            "charm_uri",
+            yaml.load(Path("tests/integration/oci-image-charm-no-series/metadata.yaml").read_text(), Loader=yaml.FullLoader),
+            resources={"oci-image": "ubuntu:latest"},
+        )
+
+        m_add_local_resources_calls = model.add_local_resources.mock_calls
+        assert len(m_add_local_resources_calls) == 3
+        assert m1 in m_add_local_resources_calls and \
+            m2 in m_add_local_resources_calls and \
+            m3 in m_add_local_resources_calls
+
+        mc_1 = mock.call(charm_path_1, "focal")
+        mc_2 = mock.call(charm_path_2, "focal")
+        mc_3 = mock.call(charm_path_2, "focal")
+
+        m_add_local_charm_dir_calls = model.add_local_charm_dir.mock_calls
+        assert len(m_add_local_charm_dir_calls) == 3
+        assert mc_1 in m_add_local_charm_dir_calls and \
+            mc_2 in m_add_local_charm_dir_calls and \
+            mc_3 in m_add_local_charm_dir_calls
+
         assert bundle["applications"]["oci-image-charm"]["resources"]["oci-image"] == "id"


### PR DESCRIPTION
### Description

So we want to be able to do the following:

```python
    config = await application.get_config()
    await application.set_config(config)
```

However, the issue was, that on the Juju side while the `get_config` returns a `map[string]value`, the `set_config` expects a `map[string]string`. This patch fixes it by casting everything into `str` on `pylibjuju` side before it's passed into the api.

Fixes #388

### QA Steps

There's a test included in the patch that targets this, so the following should pass:
```
 $ tox -e integration -- tests/integration/test_application.py::test_get_set_config
```

### Notes & Discussion

So clearly this is not the ideal solution, which would be to have Juju accept configs that look like `map[string]value` and cast things individually as it sees fit. However, @SimonRichardson suggests that that has the potential of breaking a lot of things, so looks like we'll leave this as a future work. 

Note that this also means that any library (other than `pylibjuju`) that wants to use `Set` has to do the same thing on their own, or abandon their project and start using `pylibjuju` instead, which would be the cooler option.

