### PR TITLE
a random small bug fix

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -2158,10 +2158,12 @@ class Model:
         config_facade = client.ModelConfigFacade.from_connection(
             self.connection()
         )
+
+        new_conf = {}
         for key, value in config.items():
             if isinstance(value, ConfigValue):
-                config[key] = value.value
-        await config_facade.ModelSet(config=config)
+                new_conf[key] = value.value
+        await config_facade.ModelSet(config=new_conf)
 
     async def set_constraints(self, constraints):
         """Set machine constraints on this model.


### PR DESCRIPTION
### Description

Directly modifying the inputs to the functions should be avoided, as Python is call-by-reference. 

Basically, if we modify the argument directly, and if the caller of the function still wants to do something with it after the call to callee is completed, then it would see a different (mutated) object.