### PR TITLE
Skip macaroon tests issue 534

### DIFF
--- a/tests/integration/test_macaroon_auth.py
+++ b/tests/integration/test_macaroon_auth.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
 
 @base.bootstrapped
 @pytest.mark.asyncio
-#@pytest.mark.xfail
+# @pytest.mark.xfail
 @pytest.mark.skip('one of old macaroon_auth tests, needs to be revised')
 async def test_macaroon_auth(event_loop):
     auth_info, username = agent_auth_info()
@@ -38,7 +38,7 @@ async def test_macaroon_auth(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-#@pytest.mark.xfail
+# @pytest.mark.xfail
 @pytest.mark.skip('one of old macaroon_auth tests, needs to be revised')
 async def test_macaroon_auth_with_bad_key(event_loop):
     auth_info, username = agent_auth_info()
@@ -67,7 +67,7 @@ async def test_macaroon_auth_with_bad_key(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-#@pytest.mark.xfail
+# @pytest.mark.xfail
 @pytest.mark.skip('one of old macaroon_auth tests, needs to be revised')
 async def test_macaroon_auth_with_unauthorized_user(event_loop):
     auth_info, username = agent_auth_info()

--- a/tests/integration/test_macaroon_auth.py
+++ b/tests/integration/test_macaroon_auth.py
@@ -16,7 +16,8 @@ log = logging.getLogger(__name__)
 
 @base.bootstrapped
 @pytest.mark.asyncio
-@pytest.mark.xfail
+#@pytest.mark.xfail
+@pytest.mark.skip('one of old macaroon_auth tests, needs to be revised')
 async def test_macaroon_auth(event_loop):
     auth_info, username = agent_auth_info()
     # Create a bakery client that can do agent authentication.
@@ -37,7 +38,8 @@ async def test_macaroon_auth(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-@pytest.mark.xfail
+#@pytest.mark.xfail
+@pytest.mark.skip('one of old macaroon_auth tests, needs to be revised')
 async def test_macaroon_auth_with_bad_key(event_loop):
     auth_info, username = agent_auth_info()
     # Use a random key rather than the correct key.
@@ -65,7 +67,8 @@ async def test_macaroon_auth_with_bad_key(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-@pytest.mark.xfail
+#@pytest.mark.xfail
+@pytest.mark.skip('one of old macaroon_auth tests, needs to be revised')
 async def test_macaroon_auth_with_unauthorized_user(event_loop):
     auth_info, username = agent_auth_info()
     # Create a bakery client can do agent authentication.


### PR DESCRIPTION
### Description

Marks the `test_macaroon_auth` tests (there are 3 of them) with `skip`.

Fixes #534 

### Notes & Discussion

These tests are several years old, and they were always failing, in fact, they were also marked with `xfail` by their author, currently they seem to have started to block the entire test run on the CI, so they need to be revised. 
Until then, skipping them seems to be reasonable.
