### PR TITLE
bring juju/juju.py into life

### DIFF
--- a/juju/application.py
+++ b/juju/application.py
@@ -175,15 +175,6 @@ class Application(model.ModelEntity):
                                           scale_change=scale_change)
         ])
 
-    def allocate(self, budget, value):
-        """Allocate budget to this application.
-
-        :param str budget: Name of budget
-        :param int value: Budget limit
-
-        """
-        raise NotImplementedError()
-
     def attach(self, resource_name, file_path):
         """Upload a file as a resource for this application.
 

--- a/juju/juju.py
+++ b/juju/juju.py
@@ -1,4 +1,11 @@
+from juju.client.jujudata import FileJujuData
+
+
 class Juju(object):
+
+    def __init__(self, jujudata=None):
+        self.jujudata = jujudata or FileJujuData()
+
     def add_cloud(self, name, definition, replace=False):
         """Add a user-defined cloud to Juju from among known cloud types.
 
@@ -58,9 +65,8 @@ class Juju(object):
     def get_controllers(self):
         """Return list of all available controllers.
 
-        (maybe move this to Cloud?)
         """
-        raise NotImplementedError()
+        return self.jujudata.controllers()
 
     def get_plans(self, charm_url):
         """Return list of plans available for the specified charm.

--- a/juju/juju.py
+++ b/juju/juju.py
@@ -82,7 +82,7 @@ class Juju(object):
         :param str name: Name of controller
         :param bool include_passwords: Include passwords for accounts
 
-        (maybe move this to Cloud?)
+        The returned controller will try and connect to be ready to use.
         """
 
         # check if name is in the controllers.yaml

--- a/juju/juju.py
+++ b/juju/juju.py
@@ -40,12 +40,6 @@ class Juju(object):
         """
         raise NotImplementedError()
 
-    def get_agreements(self):
-        """Return list of terms to which the current user has agreed.
-
-        """
-        raise NotImplementedError()
-
     def get_clouds(self):
         """Return list of all available clouds.
 

--- a/juju/juju.py
+++ b/juju/juju.py
@@ -1,4 +1,6 @@
+from juju.controller import Controller
 from juju.client.jujudata import FileJujuData
+from juju.errors import JujuError
 
 
 class Juju(object):
@@ -101,7 +103,7 @@ class Juju(object):
         """
         raise NotImplementedError()
 
-    def get_controller(self, name, include_passwords=False):
+    async def get_controller(self, name, include_passwords=False):
         """Get a controller by name.
 
         :param str name: Name of controller
@@ -109,7 +111,18 @@ class Juju(object):
 
         (maybe move this to Cloud?)
         """
-        raise NotImplementedError()
+
+        # check if name is in the controllers.yaml
+        controllers = self.jujudata.controllers()
+        assert isinstance(controllers, dict)
+        if name not in controllers:
+            raise JujuError('%s is not among the controllers: %s' % (name, controllers.keys()))
+
+        # make a new Controller object that's connected to the
+        # controller with the given name
+        controller = Controller()
+        await controller.connect(name)
+        return controller
 
     def update_clouds(self):
         """Update public cloud info available to Juju.

--- a/juju/juju.py
+++ b/juju/juju.py
@@ -40,20 +40,8 @@ class Juju(object):
         """
         raise NotImplementedError()
 
-    def create_budget(self):
-        """Create a new budget.
-
-        """
-        raise NotImplementedError()
-
     def get_agreements(self):
         """Return list of terms to which the current user has agreed.
-
-        """
-        raise NotImplementedError()
-
-    def get_budgets(self):
-        """Return list of available budgets.
 
         """
         raise NotImplementedError()
@@ -82,15 +70,6 @@ class Juju(object):
         """Register a user to a controller.
 
         :param str registration_string: The registration string
-
-        """
-        raise NotImplementedError()
-
-    def set_budget(self, name, limit):
-        """Set a monthly budget limit.
-
-        :param str name: Name of budget
-        :param int limit: Monthly limit
 
         """
         raise NotImplementedError()

--- a/juju/model.py
+++ b/juju/model.py
@@ -2243,14 +2243,6 @@ class Model:
             results[tag.untag('action-', a.action.tag)] = a.status
         return results
 
-    def get_budget(self, budget_name):
-        """Get budget usage info.
-
-        :param str budget_name: Name of budget
-
-        """
-        raise NotImplementedError()
-
     async def get_status(self, filters=None, utc=False):
         """Return the status of the model.
 

--- a/tests/integration/test_juju.py
+++ b/tests/integration/test_juju.py
@@ -1,5 +1,6 @@
 import pytest
 
+from juju.controller import Controller
 from juju.juju import Juju
 from .. import base
 
@@ -14,3 +15,7 @@ async def test_get_controllers(event_loop):
         assert isinstance(controllers, dict)
         assert len(controllers) >= 1
         assert controller.controller_name in controllers
+
+        cc = await j.get_controller(controller.controller_name)
+        assert isinstance(cc, Controller)
+        assert controller.connection().endpoint == cc.connection().endpoint

--- a/tests/integration/test_juju.py
+++ b/tests/integration/test_juju.py
@@ -1,0 +1,16 @@
+import pytest
+
+from juju.juju import Juju
+from .. import base
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_get_controllers(event_loop):
+    async with base.CleanController() as controller:
+        j = Juju()
+
+        controllers = j.get_controllers()
+        assert isinstance(controllers, dict)
+        assert len(controllers) >= 1
+        assert controller.controller_name in controllers


### PR DESCRIPTION
### Description

This PR adds some functions into the long dormant `Juju` class in `juju/juju.py`, cleans it up a little bit and add some tests for the added codes.

#### Includes 5 commits to:
- add `get_controllers` that returns a dictionary of info about the available controllers
- add `get_controller` that returns a ready-to-use `Controller` object that is connected to the controller with the given name
- remove a bunch of stub functions that were initially included for `budget` functionality (that is being deprecated)
- remove `get_agreements`
- fix function description

This also fixes #529 

### QA Steps

```bash
  $ tox -e integration -- tests/integration/test_juju.py
```

### Notes & Discussion

There might be more stub functions to be removed about functionalities that are being deprecated (I suspect `plans`). I simply don't know which ones are, so if you do, then please add a comment below and I'll update the PR.
