### PR TITLE
extract resources info from apps in locally deployed bundle

### DIFF
--- a/examples/deploy_local_bundle_with_resources.py
+++ b/examples/deploy_local_bundle_with_resources.py
@@ -19,7 +19,7 @@ async def main():
     try:
         print('Deploying bundle')
         applications = await model.deploy(
-            'examples/k8s-local-bundle/bundle.yaml',
+            './examples/k8s-local-bundle/bundle.yaml',
         )
 
         print('Waiting for active')

--- a/juju/bundle.py
+++ b/juju/bundle.py
@@ -492,8 +492,11 @@ class AddApplicationChange(ChangeInfo):
         if Schema.CHARM_STORE.matches(url.schema):
             resources = await context.model._add_store_resources(
                 self.application, charm, overrides=self.resources)
+        elif Schema.CHARM_HUB.matches(url.schema):
+            resources = await context.model._add_charmhub_resources(
+                self.application, charm, 'store', overrides=self.resources)
         else:
-            resources = {}
+            resources = context.bundle.get("applications", {}).get(self.application, {}).get("resources", {})
 
         channel = None
         if self.channel is not None and self.channel != "":

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -236,7 +236,7 @@ class TestAddApplicationChangeRun:
 
         model = mock.Mock()
         model._deploy = base.AsyncMock(return_value=None)
-        model._add_store_resources = base.AsyncMock(return_value=["resource1"])
+        model._add_charmhub_resources = base.AsyncMock(return_value=["resource1"])
         model.applications = {}
 
         context = mock.Mock()
@@ -255,7 +255,7 @@ class TestAddApplicationChangeRun:
                                          config="options",
                                          constraints="constraints",
                                          endpoint_bindings="endpoint_bindings",
-                                         resources={},
+                                         resources=["resource1"],
                                          storage="storage",
                                          devices="devices",
                                          num_units="num_units")


### PR DESCRIPTION
### Description

Problem is described in #550. This PR solves it by getting resources information from the deployed bundle (instead of setting it to empty as before).

### QA Steps

```
$ pyton3 -m tox -e py3 -- tests/unit/test_bundle.py

all tests should pass

$ python3 examples/deploy_local_bundle_with_resources.py 

Connecting to model
unknown facade CAASModelConfigManager
unexpected facade CAASModelConfigManager found, unable to decipher version to use
unknown facade RaftLease
unexpected facade RaftLease found, unable to decipher version to use
unknown facade Secrets
unexpected facade Secrets found, unable to decipher version to use
unknown facade SecretsManager
unexpected facade SecretsManager found, unable to decipher version to use
unknown facade SecretsRotationWatcher
unexpected facade SecretsRotationWatcher found, unable to decipher version to use
Deploying bundle
Waiting for active
Successfully deployed!
Removing bundle
Disconnecting from model
Success
```

### Notes & Discussion

Fixes #550