### PR TITLE
get the config dir resolve logic into one place

### DIFF
--- a/juju/client/jujudata.py
+++ b/juju/client/jujudata.py
@@ -8,6 +8,7 @@ import yaml
 from juju import tag
 from juju.client.gocookies import GoCookieJar
 from juju.errors import JujuError
+from juju.utils import juju_config_dir
 
 
 class NoModelException(Exception):
@@ -121,8 +122,7 @@ class FileJujuData(JujuData):
     '''Provide access to the Juju client configuration files.
     Any configuration file is read once and then cached.'''
     def __init__(self):
-        self.path = os.environ.get('JUJU_DATA') or '~/.local/share/juju'
-        self.path = os.path.abspath(os.path.expanduser(self.path))
+        self.path = juju_config_dir()
         # _loaded keeps track of the loaded YAML from
         # the Juju data files so we don't need to load the same
         # file many times.

--- a/juju/machine.py
+++ b/juju/machine.py
@@ -1,7 +1,6 @@
 import asyncio
 import ipaddress
 import logging
-import os
 
 import pyrfc3339
 
@@ -9,6 +8,7 @@ from . import model, tag
 from .annotationhelper import _get_annotations, _set_annotations
 from .client import client
 from .errors import JujuError
+from juju.utils import juju_ssh_key_paths
 
 log = logging.getLogger(__name__)
 
@@ -124,9 +124,10 @@ class Machine(model.ModelEntity):
         """ Execute an scp command. Requires a fully qualified source and
         destination.
         """
+        _, id_path = juju_ssh_key_paths()
         cmd = [
             'scp',
-            '-i', os.path.expanduser('~/.local/share/juju/ssh/juju_id_rsa'),
+            '-i', id_path,
             '-o', 'StrictHostKeyChecking=no',
             '-q',
             '-B'
@@ -153,9 +154,10 @@ class Machine(model.ModelEntity):
             raise NotImplementedError('proxy option is not implemented')
         address = self.dns_name
         destination = "{}@{}".format(user, address)
+        _, id_path = juju_ssh_key_paths()
         cmd = [
             'ssh',
-            '-i', os.path.expanduser('~/.local/share/juju/ssh/juju_id_rsa'),
+            '-i', id_path,
             '-o', 'StrictHostKeyChecking=no',
             '-q',
             destination

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,27 +1,14 @@
-import os
+import unittest
 
-from pathlib import Path
 from juju.utils import juju_config_dir, juju_ssh_key_paths
 
 
-def test_config_dir():
-    config_dir = juju_config_dir()
-    assert os.path.exists(config_dir)
-    assert os.path.isdir(config_dir)
+class TestDirResolve(unittest.TestCase):
+    def test_config_dir(self):
+        config_dir = juju_config_dir()
+        assert 'local/share/juju' in config_dir
 
-    assert os.path.exists(os.path.join(config_dir, 'controllers.yaml'))
-
-
-def test_juju_ssh_key_paths():
-    public, private = juju_ssh_key_paths()
-    assert os.path.exists(public)
-    assert os.path.isfile(public)
-
-    assert os.path.exists(private)
-    assert os.path.isfile(private)
-
-    with Path(public).open('r') as f:
-        assert "ssh-rsa" in f.read()
-
-    with Path(private).open('r') as g:
-        assert "PRIVATE KEY" in g.read()
+    def test_juju_ssh_key_paths(self):
+        public, private = juju_ssh_key_paths()
+        assert public.endswith('ssh/juju_id_rsa.pub')
+        assert private.endswith('ssh/juju_id_rsa')

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,27 @@
+import os
+
+from pathlib import Path
+from juju.utils import juju_config_dir, juju_ssh_key_paths
+
+
+def test_config_dir():
+    config_dir = juju_config_dir()
+    assert os.path.exists(config_dir)
+    assert os.path.isdir(config_dir)
+
+    assert os.path.exists(os.path.join(config_dir, 'controllers.yaml'))
+
+
+def test_juju_ssh_key_paths():
+    public, private = juju_ssh_key_paths()
+    assert os.path.exists(public)
+    assert os.path.isfile(public)
+
+    assert os.path.exists(private)
+    assert os.path.isfile(private)
+
+    with Path(public).open('r') as f:
+        assert "ssh-rsa" in f.read()
+
+    with Path(private).open('r') as g:
+        assert "PRIVATE KEY" in g.read()


### PR DESCRIPTION
### Description

This PR introduces two utility functions `juju_config_dir` and `juju_ssh_pey_paths` that holds the logic of discovering the configuration directory and the ssh keys in one place. It works by 1) checking `JUJU_DATA` env variable, 2) checking `XDG_DATA_HOME` variable, 3) manually sets it to `~/.local/share/juju` (in this order). Anyone wants to use a custom directory have multiple different options.

### QA Steps 

```
tox -e py3 -- tests/unit/test_utils.py
tox -e integration -- tests/integration/test_machine.py
tox -e integration -- tests/integration/test_unit.py
```

### Notes & Discussion

Fixes #554