### PR TITLE
Fix for simple bug in bundle deployment code self.charm -> self['charm']

### DIFF
--- a/juju/bundle.py
+++ b/juju/bundle.py
@@ -243,7 +243,7 @@ class BundleHandler:
                 deployed[name] = name
 
                 if is_local_charm(spec['charm']):
-                    spec.charm = self.model.applications[name]
+                    spec['charm'] = self.model.applications[name]
                     continue
                 if spec['charm'] == app.charm_url:
                     continue


### PR DESCRIPTION
Simple fix in bundle deploy code.

Fixes #557 

/cc @techalchemy