### PR TITLE
add debug-log

### DIFF
--- a/examples/debug-log.py
+++ b/examples/debug-log.py
@@ -1,0 +1,38 @@
+"""
+This example demonstrate how debug-log works
+
+"""
+import asyncio
+from juju import loop
+import logging
+import sys
+from logging import getLogger
+from juju.model import Model
+
+LOG = getLogger(__name__)
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+
+async def main():
+    model = Model()
+    await model.connect_current()
+
+    await model.debug_log()
+
+    application = await model.deploy(
+        'cs:ubuntu-10',
+        application_name='ubuntu',
+        series='trusty',
+        channel='stable',
+    )
+
+    await asyncio.sleep(10)
+    await model.block_until(
+        lambda: all(unit.workload_status == 'active'
+                    for unit in application.units))
+
+    await application.remove()
+    await model.disconnect()
+
+if __name__ == '__main__':
+    loop.run(main())

--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -1,3 +1,4 @@
+import sys
 import asyncio
 import base64
 import json
@@ -7,6 +8,7 @@ import urllib.request
 import weakref
 from concurrent.futures import CancelledError
 from http.client import HTTPSConnection
+from dateutil.parser import parse
 
 import macaroonbakery.bakery as bakery
 import macaroonbakery.httpbakery as httpbakery
@@ -194,7 +196,11 @@ class Monitor:
             return self.DISCONNECTING
 
         # connection closed uncleanly (we didn't call connection.close)
-        stopped = connection._receiver_task.stopped.is_set()
+        if connection.is_debug_log_connection:
+            stopped = connection._debug_log_task.stopped.is_set()
+        else:
+            stopped = connection._receiver_task.stopped.is_set()
+
         if stopped or not connection.ws.open:
             return self.ERROR
 
@@ -232,6 +238,7 @@ class Connection:
             retry_backoff=10,
             specified_facades=None,
             proxy=None,
+            debug_log_conn=None
     ):
         """Connect to the websocket.
 
@@ -260,6 +267,7 @@ class Connection:
             would wait 10s, 20s, and 30s).
         :param specified_facades: Define a series of facade versions you wish to override
             to prevent using the conservative client pinning with in the client.
+        :param TextIOWrapper debug_log_conn: target if this is a debug log connection
         """
         self = cls()
         if endpoint is None:
@@ -293,9 +301,13 @@ class Connection:
         self.cacert = None
         self.info = None
 
+        self.debug_log_target = debug_log_conn
+        self.is_debug_log_connection = debug_log_conn is not None
+
         # Create that _Task objects but don't start the tasks yet.
         self._pinger_task = _Task(self._pinger, self.loop)
         self._receiver_task = _Task(self._receiver, self.loop)
+        self._debug_log_task = _Task(self._debug_logger, self.loop)
 
         self._retries = retries
         self._retry_backoff = retry_backoff
@@ -317,7 +329,12 @@ class Connection:
         lastError = None
         for _ep in _endpoints:
             try:
-                await self._connect_with_redirect([_ep])
+                if debug_log_conn:
+                    # make a direct connection with basic auth if
+                    # debug-log (i.e. no redirection or login)
+                    await self._connect([_ep])
+                else:
+                    await self._connect_with_redirect([_ep])
                 return self
             except ssl.SSLError as e:
                 lastError = e
@@ -355,7 +372,12 @@ class Connection:
         return context
 
     async def _open(self, endpoint, cacert):
-        if self.uuid:
+
+        if self.is_debug_log_connection:
+            assert self.uuid
+            url = "wss://user-{}:{}@{}/model/{}/log".format(
+                self.username, self.password, endpoint, self.uuid)
+        elif self.uuid:
             url = "wss://{}/model/{}/api".format(endpoint, self.uuid)
         else:
             url = "wss://{}/api".format(endpoint)
@@ -383,7 +405,11 @@ class Connection:
             return
         self.monitor.close_called.set()
         await self._pinger_task.stopped.wait()
-        await self._receiver_task.stopped.wait()
+        if self.is_debug_log_connection:
+            self._close_debug_log_target()
+            await self._debug_log_task.stopped.wait()
+        else:
+            await self._receiver_task.stopped.wait()
         await self.ws.close()
         self.ws = None
 
@@ -394,6 +420,48 @@ class Connection:
         if not self.is_open:
             raise websockets.exceptions.ConnectionClosed(0, 'websocket closed')
         return await self.messages.get(request_id)
+
+    def _close_debug_log_target(self):
+        if self.debug_log_target is not sys.stdout:
+            self.debug_log_target.close()
+
+    async def _debug_logger(self):
+        try:
+            while self.is_open:
+                result = await utils.run_with_interrupt(
+                    self.ws.recv(),
+                    self.monitor.close_called,
+                    loop=self.loop)
+                if self.monitor.close_called.is_set():
+                    break
+                if result is not None and result != '{}\n':
+                    result = json.loads(result)
+
+                    tag = result['tag']
+                    ts = parse(result['ts'])
+                    sev = result['sev']
+                    mod = result['mod']
+                    msg = result['msg']
+
+                    self.debug_log_target.write("%s %s:%s:%s %s %s %s\n" % (tag, ts.hour, ts.minute, ts.second, sev, mod, msg))
+                    log.debug("debug log line is : %s" % result)
+        except KeyError as e:
+            log.exception('Unexpected debug line -- %s' % e)
+            self._close_debug_log_target()
+            raise
+        except CancelledError:
+            self._close_debug_log_target()
+            pass
+        except websockets.ConnectionClosed:
+            log.warning('Debug Logger: Connection closed, reconnecting')
+            # the reconnect has to be done as a task because the receiver will
+            # be cancelled by the reconnect and we don't want the reconnect
+            # to be aborted half-way through
+            self.loop.create_task(self.reconnect())
+            raise
+        except Exception as e:
+            log.exception("Error in debug logger : %s" % e)
+            raise
 
     async def _receiver(self):
         try:
@@ -614,7 +682,8 @@ class Connection:
             return
         async with monitor.reconnecting:
             await self.close()
-            await self._connect_with_login(
+            connector = self._connect if self.is_debug_log_connection else self._connect_with_login
+            await connector(
                 [(self.endpoint, self.cacert)]
                 if not self.endpoints else
                 self.endpoints
@@ -665,7 +734,10 @@ class Connection:
         self.addr = result[1]
         self.endpoint = result[2]
         self.cacert = result[3]
-        self._receiver_task.start()
+        if self.is_debug_log_connection:
+            self._debug_log_task.start()
+        else:
+            self._receiver_task.start()
         log.debug("Driver connected to juju %s", self.addr)
         self.monitor.close_called.clear()
 

--- a/juju/client/connector.py
+++ b/juju/client/connector.py
@@ -36,6 +36,7 @@ class Connector:
         self.loop = loop or asyncio.get_event_loop()
         self.bakery_client = bakery_client
         self._connection = None
+        self._log_connection = None
         self.controller_name = None
         self.controller_uuid = None
         self.model_name = None
@@ -68,7 +69,11 @@ class Connector:
             jar = kwargs['bakery_client'].cookies
             for macaroon in kwargs.pop('macaroons'):
                 jar.set_cookie(go_to_py_cookie(macaroon))
-        self._connection = await Connection.connect(**kwargs)
+        if 'debug_log_conn' in kwargs:
+            assert self._connection
+            self._log_connection = await Connection.connect(**kwargs)
+        else:
+            self._connection = await Connection.connect(**kwargs)
 
     async def disconnect(self):
         """Shut down the watcher task and close websockets.
@@ -77,6 +82,10 @@ class Connector:
             log.debug('Closing model connection')
             await self._connection.close()
             self._connection = None
+        if self._log_connection:
+            log.debug('Also closing debug-log connection')
+            await self._log_connection.close()
+            self._log_connection = None
 
     async def connect_controller(self, controller_name=None, specified_facades=None):
         """Connect to a controller by name. If the name is empty, it

--- a/juju/model.py
+++ b/juju/model.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import logging
 import os
+import sys
 import re
 import stat
 import tempfile
@@ -679,7 +680,9 @@ class Model:
         :param specified_facades: Overwrite the facades with a series of
             specified facades.
         """
-        await self.disconnect()
+        is_debug_log_conn = 'debug_log_conn' in kwargs
+        if not is_debug_log_conn:
+            await self.disconnect()
         if 'endpoint' not in kwargs and len(args) < 2:
             if args and 'model_name' in kwargs:
                 raise TypeError('connect() got multiple values for model_name')
@@ -723,7 +726,8 @@ class Model:
                 raise ValueError('Authentication parameters are required '
                                  'if model_name not given')
             await self._connector.connect(**kwargs)
-        await self._after_connect()
+        if not is_debug_log_conn:
+            await self._after_connect()
 
     async def connect_model(self, model_name, **kwargs):
         """
@@ -1494,10 +1498,10 @@ class Model:
         """
         raise NotImplementedError()
 
-    def debug_log(
-            self, no_tail=False, exclude_module=None, include_module=None,
-            include=None, level=None, limit=0, lines=10, replay=False,
-            exclude=None):
+    async def debug_log(
+            self, target=sys.stdout, no_tail=False, exclude_module=None,
+            include_module=None, include=None, level=None, limit=0, lines=10,
+            replay=False, exclude=None):
         """Get log messages for this model.
 
         :param bool no_tail: Stop after returning existing log messages
@@ -1516,7 +1520,10 @@ class Model:
         :param list exclude: Do not show log messages for these entities
 
         """
-        raise NotImplementedError()
+        if not self.is_connected():
+            await self.connect()
+
+        await self.connect(debug_log_conn=target)
 
     def _get_series(self, entity_url, entity):
         # try to get the series from the provided charm URL


### PR DESCRIPTION
### Description

This PR adds `debug-log` functionality into pylibjuju, by adding a separate Connection object into the Connector of a Model. 

User runs `await model.debug_log()` with a writable target (defaults to `stdout`), we create a new connection with `/log` and start the receiving tasks. As the user continues to interact with the model, the debug log receiver tasks write the logs onto whatever target is provided. 

Fixes #549 

### QA Steps

```
python examples/debug-log.py
```

### Notes & Discussion

There are two things need to be done before this is ready to merge:

1. All the tasks need to be flushed before ending the program (that's why we're getting `ERROR:asyncio:Future exception was never retrieved` errors at the end when we run the example above). This is also closely related to #560 , which I'd prefer to complete and land before I fix this PR.

2. The filtering parameters of the debug-log (e.g. `no-tail`, `exclude-module`, `level`, `lines`, etc.) need to be passed through.