### PR TITLE
Deploy charmhub bundles

### DIFF
--- a/examples/deploy_bundle_charmhub.py
+++ b/examples/deploy_bundle_charmhub.py
@@ -1,0 +1,33 @@
+"""
+This example:
+1. Connects to the current model
+2. Deploy a bundle from charmhub and waits until it reports itself active
+3. Destroys the unit and application
+"""
+from juju import loop
+from juju.model import Model
+
+
+async def main():
+    model = Model()
+    print("Connecting to model")
+    # connect to current model with current user, per Juju CLI
+    await model.connect()
+
+    try:
+        print("Deploying lma-light")
+        applications = await model.deploy("ch:lma-light", channel="edge", trust=True)
+
+        print("Waiting for active")
+        await model.wait_for_idle(status="active")
+
+        print("Removing lma-light")
+        for application in applications:
+            await application.remove()
+    finally:
+        print("Disconnecting from model")
+        await model.disconnect()
+
+
+if __name__ == "__main__":
+    loop.run(main())


### PR DESCRIPTION
### Description

This PR fixes deploying bundles from charmhub, by providing a correct `CharmOrigin` object for the charmhub to locate and deploy the charms and resources.

Fixes #568 

### QA Steps

```
make test
```

### Notes & Discussion

This also adds the first example from #567 , the second one is redundant (see [charmhub_deploy_k8s.py](https://github.com/juju/python-libjuju/blob/master/examples/charmhub_deploy_k8s.py) and [charmhub_deploy_machine.py](https://github.com/juju/python-libjuju/blob/master/examples/charmhub_deploy_machine.py)).