### PR TITLE
Wait for applications to terminate on model reset

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -845,6 +845,9 @@ class Model:
         log.debug('Resetting model')
         for app in self.applications.values():
             await app.destroy()
+        await self.block_until(
+            lambda: len(self.applications) == 0
+        )
         for machine in self.machines.values():
             await machine.destroy(force=force)
         await self.block_until(


### PR DESCRIPTION
Model.reset() does not wait for all applications to terminiate
even though it does wait for all machines to terminate. This
commit fixes the issue by blocking until the application count
is zero.