### PR TITLE
Consistently getting a unit's public address

### DIFF
--- a/juju/unit.py
+++ b/juju/unit.py
@@ -119,7 +119,7 @@ class Unit(model.ModelEntity):
             if self.public_address is None:
                 await self.model.block_until(
                     lambda: self.public_address,
-                    timeout=60)
+                    timeout=timeout)
         except jasyncio.TimeoutError:
             return None
         return self.public_address

--- a/juju/unit.py
+++ b/juju/unit.py
@@ -102,6 +102,21 @@ class Unit(model.ModelEntity):
         return await app_facade.DestroyUnits(unit_names=[self.name])
     remove = destroy
 
+    async def get_public_address(self, timeout=60):
+        """Return the public address of this unit. Waits until the unit is
+        assigned a public address.
+
+        :param int timeout (60): Maximum seconds to wait for unit to
+        be assigned an address.
+
+        :return int public-address
+        """
+        if self.public_address is None:
+            await self.model.block_until(
+                lambda: self.public_address,
+                timeout=60)
+        return self.public_address
+
     def get_resources(self, details=False):
         """Return resources for this unit.
 

--- a/tests/integration/test_unit.py
+++ b/tests/integration/test_unit.py
@@ -19,7 +19,7 @@ async def test_unit_public_address(event_loop):
         )
 
         for unit in app.units:
-            addr = await unit.get_public_address()
+            addr = await unit.get_public_address(timeout=60 * 4)
             assert addr, 'unit public address not set'
 
 

--- a/tests/integration/test_unit.py
+++ b/tests/integration/test_unit.py
@@ -16,7 +16,15 @@ async def test_unit_public_address(event_loop):
             application_name='ubuntu',
             series='trusty',
             channel='stable',
+            num_units=2,
         )
+
+        await model.block_until(
+            lambda: app.units,
+            timeout=480,
+        )
+
+        assert len(app.units) >= 1
 
         for unit in app.units:
             addr = await unit.get_public_address(timeout=60 * 4)

--- a/tests/integration/test_unit.py
+++ b/tests/integration/test_unit.py
@@ -19,15 +19,14 @@ async def test_unit_public_address(event_loop):
             num_units=2,
         )
 
-        await model.block_until(
-            lambda: app.units,
-            timeout=480,
-        )
+        # wait for the units to come up
+        await model.block_until(lambda: app.units, timeout=480)
 
+        # make sure we have some units to test with
         assert len(app.units) >= 1
 
         for unit in app.units:
-            addr = await unit.get_public_address(timeout=60 * 4)
+            addr = await unit.get_public_address(timeout=480)
             assert addr, 'unit public address not set'
 
 

--- a/tests/integration/test_unit.py
+++ b/tests/integration/test_unit.py
@@ -9,6 +9,22 @@ from .. import base
 
 @base.bootstrapped
 @pytest.mark.asyncio
+async def test_unit_public_address(event_loop):
+    async with base.CleanModel() as model:
+        app = await model.deploy(
+            'cs:ubuntu-0',
+            application_name='ubuntu',
+            series='trusty',
+            channel='stable',
+        )
+
+        for unit in app.units:
+            addr = await unit.get_public_address()
+            assert addr, 'unit public address not set'
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
 async def test_run(event_loop):
     from juju.action import Action
 

--- a/tests/integration/test_unit.py
+++ b/tests/integration/test_unit.py
@@ -12,9 +12,9 @@ from .. import base
 async def test_unit_public_address(event_loop):
     async with base.CleanModel() as model:
         app = await model.deploy(
-            'cs:ubuntu-0',
+            'ch:ubuntu',
             application_name='ubuntu',
-            series='trusty',
+            series='bionic',
             channel='stable',
             num_units=2,
         )


### PR DESCRIPTION
### Description

Assigning a unit's public address may take a little time, which makes the result of `unit.public_address` depend on when it's called, thereby creating inconsistency. This PR adds a method, namely `get_public_address`, that waits (with a timeout) until the unit is assigned an address and returns the address when it's assigned.

Fixes #551

Jira card [#141](https://warthogs.atlassian.net/browse/JUJU-141)

### QA Steps

```sh
tox -e integration -- tests/integration/test_unit.py::test_unit_public_address
```

### Notes & Discussion

**A minor design decision:** is that in the case of a timeout, `get_public_address` returns a `None`, rather than a `TimeoutError`.
