### PR TITLE
[JUJU-140] Model.wait_for_idle -- for apps with no units yet

### DIFF
--- a/juju/jasyncio.py
+++ b/juju/jasyncio.py
@@ -30,7 +30,7 @@ ROOT_LOGGER = logging.getLogger()
 
 from asyncio import Event, TimeoutError, Queue, ensure_future, \
     gather, sleep, wait_for, create_subprocess_exec, subprocess, \
-    wait, FIRST_COMPLETED, Lock, as_completed, \
+    wait, FIRST_COMPLETED, Lock, as_completed, new_event_loop, \
     get_event_loop_policy, CancelledError # noqa
 
 try:

--- a/juju/model.py
+++ b/juju/model.py
@@ -2550,7 +2550,7 @@ class Model:
 
     async def wait_for_idle(self, apps=None, raise_on_error=True, raise_on_blocked=False,
                             wait_for_active=False, timeout=10 * 60, idle_period=15, check_freq=0.5,
-                            status=None):
+                            status=None, wait_for_units=1):
         """Wait for applications in the model to settle into an idle state.
 
         :param apps (list[str]): Optional list of specific app names to wait on.
@@ -2585,6 +2585,10 @@ class Model:
 
         :param status (str): The status to wait for. If None, not waiting.
             The default is None (not waiting for any status).
+
+        :param wait_for_units (int): The least number of units to be expected before
+            going into the idle state.
+            The default is 1 unit.
         """
         if wait_for_active:
             warnings.warn("wait_for_active is deprecated; use status", DeprecationWarning)
@@ -2628,8 +2632,9 @@ class Model:
                     errors.setdefault("App", []).append(app.name)
                 if raise_on_blocked and app.status == "blocked":
                     blocks.setdefault("App", []).append(app.name)
-                if not app.units:
-                    busy.append(app.name + " (no units yet)")
+                if len(app.units) < wait_for_units:
+                    busy.append(app.name + " (not enough units yet - %s/%s)" %
+                                (len(app.units), wait_for_units))
                     continue
                 for unit in app.units:
                     if unit.machine is not None and unit.machine.status == "error":

--- a/juju/model.py
+++ b/juju/model.py
@@ -2619,15 +2619,18 @@ class Model:
             busy = []
             errors = {}
             blocks = {}
-            for app in apps:
-                if app not in self.applications:
-                    busy.append(app + " (missing)")
+            for app_name in apps:
+                if app_name not in self.applications:
+                    busy.append(app_name + " (missing)")
                     continue
-                app = self.applications[app]
+                app = self.applications[app_name]
                 if raise_on_error and app.status == "error":
                     errors.setdefault("App", []).append(app.name)
                 if raise_on_blocked and app.status == "blocked":
                     blocks.setdefault("App", []).append(app.name)
+                if not app.units:
+                    busy.append(app.name + " (no units yet)")
+                    continue
                 for unit in app.units:
                     if unit.machine is not None and unit.machine.status == "error":
                         errors.setdefault("Machine", []).append(unit.machine.id)

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -732,7 +732,7 @@ async def test_get_machines(event_loop):
 async def test_wait_for_idle_without_units(event_loop):
     async with base.CleanModel() as model:
         await model.deploy(
-            'cs:~jameinel/ubuntu-lite-7',
+            'ubuntu',
             application_name='ubuntu',
             series='bionic',
             channel='stable',
@@ -740,6 +740,35 @@ async def test_wait_for_idle_without_units(event_loop):
         )
         with pytest.raises(jasyncio.TimeoutError):
             await model.wait_for_idle(timeout=10)
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_wait_for_idle_with_not_enough_units(event_loop):
+    async with base.CleanModel() as model:
+        await model.deploy(
+            'ubuntu',
+            application_name='ubuntu',
+            series='bionic',
+            channel='stable',
+            num_units=2,
+        )
+        with pytest.raises(jasyncio.TimeoutError):
+            await model.wait_for_idle(timeout=5 * 60, wait_for_units=3)
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_wait_for_idle_with_enough_units(event_loop):
+    async with base.CleanModel() as model:
+        await model.deploy(
+            'ubuntu',
+            application_name='ubuntu',
+            series='bionic',
+            channel='stable',
+            num_units=3,
+        )
+        await model.wait_for_idle(timeout=5 * 60, wait_for_units=3)
 
 
 @base.bootstrapped

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import os
 import random
@@ -13,6 +12,7 @@ import paramiko
 
 import pylxd
 import pytest
+from juju import jasyncio
 from juju.client.client import ApplicationFacade, ConfigValue
 from juju.errors import JujuError, JujuUnitError, JujuConnectionError
 from juju.model import Model, ModelObserver
@@ -155,7 +155,7 @@ async def test_wait_local_charm_waiting_timeout(event_loop):
         await model.deploy(str(charm_path), config={'status': 'waiting'})
         assert 'charm' in model.applications
         await model.wait_for_idle()
-        with pytest.raises(asyncio.TimeoutError):
+        with pytest.raises(jasyncio.TimeoutError):
             await model.wait_for_idle(status="active", timeout=30)
 
 
@@ -530,8 +530,8 @@ async def test_relate(event_loop):
             num_units=0,
         )
 
-        relation_added = asyncio.Event()
-        timeout = asyncio.Event()
+        relation_added = jasyncio.Event()
+        timeout = jasyncio.Event()
 
         class TestObserver(ModelObserver):
             async def on_relation_add(self, delta, old, new, model):
@@ -579,7 +579,7 @@ async def _deploy_in_loop(new_loop, model_name, jujudata):
 async def test_explicit_loop_threaded(event_loop):
     async with base.CleanModel() as model:
         model_name = model.info.name
-        new_loop = asyncio.new_event_loop()
+        new_loop = jasyncio.new_event_loop()
         with ThreadPoolExecutor(1) as executor:
             f = executor.submit(
                 new_loop.run_until_complete,

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -729,6 +729,21 @@ async def test_get_machines(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+async def test_wait_for_idle_without_units(event_loop):
+    async with base.CleanModel() as model:
+        app = await model.deploy(
+            'cs:~jameinel/ubuntu-lite-7',
+            application_name='ubuntu',
+            series='bionic',
+            channel='stable',
+            num_units=0,
+        )
+        with pytest.raises(jasyncio.TimeoutError):
+            await model.wait_for_idle(timeout=10)
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
 async def test_watcher_reconnect(event_loop):
     async with base.CleanModel() as model:
         await model.connection().close()

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -731,7 +731,7 @@ async def test_get_machines(event_loop):
 @pytest.mark.asyncio
 async def test_wait_for_idle_without_units(event_loop):
     async with base.CleanModel() as model:
-        app = await model.deploy(
+        await model.deploy(
             'cs:~jameinel/ubuntu-lite-7',
             application_name='ubuntu',
             series='bionic',


### PR DESCRIPTION
#### Description

`Model.wait_for_idle`'s behavior is not specified for applications that have no units when `wait_for_idle` is called. In that case, it just returns without waiting for anything at all. This PR changes that behavior into waiting for units to show up (with timeout that already exists).

Fixes #574 

#### QA Steps

```
tox -e integration -- tests/integration/test_model.py::test_wait_for_idle_without_units
tox -e integration -- tests/integration/test_model.py::test_wait_for_idle_with_not_enough_units
tox -e integration -- tests/integration/test_model.py::test_wait_for_idle_with_enough_units
```

#### Notes & Discussion