### PR TITLE
[JUJU-138] Streamlining asyncio tasks/events

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Next Release
 ^^^^^^^^^^^^
 
 * Legacy "services" for describing "applications" within bundles are no longer supported. "applications" can be used as a direct replacement for "services" in bundles.yaml.
+* The websocket (ws) in a Connection object became a read-only property.
 
 2.9.4
 ^^^^^

--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -425,7 +425,10 @@ class Connection:
     async def _recv(self, request_id):
         if not self.is_open:
             raise websockets.exceptions.ConnectionClosed(0, 'websocket closed')
-        return await self.messages.get(request_id)
+        try:
+            return await self.messages.get(request_id)
+        except GeneratorExit:
+            return {}
 
     def _close_debug_log_target(self):
         if self.debug_log_target is not sys.stdout:

--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -389,7 +389,6 @@ class Connection:
             max_size=self.max_frame_size,
             server_hostname=server_hostname,
             sock=sock,
-            ping_interval=None
         )), url, endpoint, cacert
 
     async def close(self, to_reconnect=False):

--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -756,7 +756,6 @@ class Connection:
         elif not self.is_debug_log_connection and not self._receiver_task:
             self._receiver_task = jasyncio.create_task(self._receiver())
 
-
         log.debug("Driver connected to juju %s", self.addr)
         self.monitor.close_called.clear()
 

--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -341,6 +341,11 @@ class Connection:
         raise Exception("Unable to connect to websocket")
 
     @property
+    def ws(self):
+        log.warning('Direct access to the websocket object may cause disruptions in asyncio event handling.')
+        return self._ws
+
+    @property
     def username(self):
         if not self.usertag:
             return None

--- a/juju/client/connector.py
+++ b/juju/client/connector.py
@@ -69,6 +69,8 @@ class Connector:
             assert self._connection
             self._log_connection = await Connection.connect(**kwargs)
         else:
+            if self._connection:
+                await self._connection.close()
             self._connection = await Connection.connect(**kwargs)
 
     async def disconnect(self):

--- a/juju/controller.py
+++ b/juju/controller.py
@@ -855,3 +855,27 @@ class Controller:
         log.debug('Starting watcher task for model summaries')
         jasyncio.ensure_future(_watcher(stop_event))
         return stop_event
+
+
+class ConnectedController(Controller):
+    def __init__(
+        self,
+        connection,
+        max_frame_size=None,
+        bakery_client=None,
+        jujudata=None,
+    ):
+        super().__init__(
+            max_frame_size=max_frame_size,
+            bakery_client=bakery_client,
+            jujudata=jujudata)
+        self._conn = connection
+
+    async def __aenter__(self):
+        kwargs = self._conn.connect_params()
+        kwargs.pop('uuid')
+        await self._connect_direct(**kwargs)
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.disconnect()

--- a/juju/jasyncio.py
+++ b/juju/jasyncio.py
@@ -22,6 +22,8 @@
 
 import asyncio
 import signal
+import functools
+import websockets
 
 from asyncio import Event, TimeoutError, Queue, ensure_future, \
     gather, sleep, wait_for, create_subprocess_exec, subprocess, \
@@ -42,6 +44,39 @@ try:
 except ImportError:
     def create_task(coro):
         return asyncio.ensure_future(coro)
+
+
+def create_task_with_handler(coro, task_name, logger):
+    """Wrapper around "asyncio.create_task" to make sure the task
+    exceptions are handled properly.
+
+    asyncio loop event_handler is only called on task exceptions when
+    the Task object is cleared from memory. But the GC doesn't clear
+    the Task if we keep a reference for it (e.g. _pinger_task in
+    connection.py) until the very end.
+
+    This makes sure the exceptions are retrieved and properly
+    handled/logged whenever the Task is destroyed.
+    """
+    def _task_result_exp_handler(task, task_name=task_name, logger=logger):
+        try:
+            task.result()
+        except CancelledError:
+            pass
+        except websockets.exceptions.ConnectionClosed:
+            return
+        except Exception as e:
+            # This really is an arbitrary exception we need to catch
+            #
+            # No need to re-raise, though, because after this point
+            # the only thing that can catch this is asyncio loop base
+            # event_handler, which won't do anything but yell 'Task
+            # exception was never retrieved' anyways.
+            logger.exception("Task %s raised an exception: %s" % (task_name, e))
+
+    task = create_task(coro)
+    task.add_done_callback(functools.partial(_task_result_exp_handler, task_name=task_name, logger=logger))
+    return task
 
 
 def run(*steps):

--- a/juju/model.py
+++ b/juju/model.py
@@ -1035,10 +1035,6 @@ class Model:
                         results = await utils.run_with_interrupt(
                             allwatcher.Next(),
                             self._watch_stopping)
-                    except GeneratorExit:
-                        # this means we're in the middle of a
-                        # tear-down, so everything should shutdown
-                        break
                     except JujuAPIError as e:
                         if 'watcher was stopped' not in str(e):
                             raise

--- a/juju/model.py
+++ b/juju/model.py
@@ -28,7 +28,7 @@ from .client import client, connector
 from .client.client import ConfigValue, Value
 from .client.overrides import Caveat, Macaroon
 from .constraints import parse as parse_constraints
-from .controller import Controller
+from .controller import Controller, ConnectedController
 from .delta import get_entity_class, get_entity_delta
 from .errors import JujuAPIError, JujuError, JujuModelConfigError, JujuBackupError
 from .errors import JujuAppError, JujuUnitError, JujuAgentError, JujuMachineError
@@ -1344,8 +1344,8 @@ class Model:
                 raise JujuError("cannot add relation to {}: remote endpoints not supported".format(remote_endpoint.string()))
 
             if remote_endpoint.has_empty_source():
-                current = await self.get_controller()
-                remote_endpoint.source = current.controller_name
+                async with ConnectedController(self.connection()) as current:
+                    remote_endpoint.source = current.controller_name
             # consume the remote endpoint
             await self.consume(remote_endpoint.string(),
                                application_alias=remote_endpoint.application,
@@ -2401,20 +2401,18 @@ class Model:
         @param endpoint: holds the application and endpoint you want to offer
         @param offer_name: over ride the offer name to help the consumer
         """
-        controller = await self.get_controller()
-        offer_result = await controller.create_offer(self.info.uuid, endpoint,
-                                                     offer_name=offer_name,
-                                                     application_name=application_name)
-        await controller.disconnect()
-        return offer_result
+        async with ConnectedController(self.connection()) as controller:
+            return await controller.create_offer(self.info.uuid, endpoint,
+                                                 offer_name=offer_name,
+                                                 application_name=application_name)
 
     async def list_offers(self):
         """
         Offers list information about applications' endpoints that have been
         shared and who is connected.
         """
-        controller = await self.get_controller()
-        return await controller.list_offers(self.info.name)
+        async with ConnectedController(self.connection()) as controller:
+            return await controller.list_offers(self.info.name)
 
     async def remove_offer(self, endpoint, force=False):
         """
@@ -2423,8 +2421,8 @@ class Model:
         Offers will also remove relations to those offers, use force to do
         so, without an error.
         """
-        controller = await self.get_controller()
-        return await controller.remove_offer(self.info.uuid, endpoint, force)
+        async with ConnectedController(self.connection()) as controller:
+            return await controller.remove_offer(self.info.uuid, endpoint, force)
 
     async def consume(self, endpoint, application_alias="", controller_name=None, controller=None):
         """
@@ -2522,9 +2520,9 @@ class Model:
     async def _get_source_api(self, url, controller_name=None):
         controller = Controller()
         if url.has_empty_source():
-            current = await self.get_controller()
-            if current.controller_name is not None:
-                controller_name = current.controller_name
+            async with ConnectedController(self.connection()) as current:
+                if current.controller_name is not None:
+                    controller_name = current.controller_name
         await controller.connect(controller_name=controller_name)
         return controller
 

--- a/juju/model.py
+++ b/juju/model.py
@@ -2402,9 +2402,11 @@ class Model:
         @param offer_name: over ride the offer name to help the consumer
         """
         controller = await self.get_controller()
-        return await controller.create_offer(self.info.uuid, endpoint,
-                                             offer_name=offer_name,
-                                             application_name=application_name)
+        offer_result = await controller.create_offer(self.info.uuid, endpoint,
+                                                     offer_name=offer_name,
+                                                     application_name=application_name)
+        await controller.disconnect()
+        return offer_result
 
     async def list_offers(self):
         """

--- a/juju/model.py
+++ b/juju/model.py
@@ -1035,6 +1035,10 @@ class Model:
                         results = await utils.run_with_interrupt(
                             allwatcher.Next(),
                             self._watch_stopping)
+                    except GeneratorExit:
+                        # this means we're in the middle of a
+                        # tear-down, so everything should shutdown
+                        break
                     except JujuAPIError as e:
                         if 'watcher was stopped' not in str(e):
                             raise

--- a/juju/utils.py
+++ b/juju/utils.py
@@ -143,7 +143,7 @@ async def wait_for_bundle(model, bundle, **kwargs):
     await model.wait_for_idle(apps, **kwargs)
 
 
-async def run_with_interrupt(task, *events):
+async def run_with_interrupt(task, *events, log=None):
     """
     Awaits a task while allowing it to be interrupted by one or more
     `asyncio.Event`s.
@@ -156,7 +156,7 @@ async def run_with_interrupt(task, *events):
     :param events: One or more `asyncio.Event`s which, if set, will interrupt
         `task` and cause it to be cancelled.
     """
-    task = jasyncio.ensure_future(task)
+    task = jasyncio.create_task_with_handler(task, 'tmp', log)
     event_tasks = [jasyncio.ensure_future(event.wait()) for event in events]
     done, pending = await jasyncio.wait([task] + event_tasks,
                                         return_when=jasyncio.FIRST_COMPLETED)

--- a/tests/integration/test_connection.py
+++ b/tests/integration/test_connection.py
@@ -44,7 +44,7 @@ async def test_monitor_catches_error(event_loop):
             # grab the reconnect lock to prevent automatic
             # reconnecting during the test
             async with conn.monitor.reconnecting:
-                await conn.ws.close()  # this could be racy with reconnect
+                await conn._ws.close()  # this could be racy with reconnect
                 # if auto-reconnect is not disabled by lock, force this
                 # test to fail by deferring to the reconnect task via sleep
                 await jasyncio.sleep(0.1)
@@ -78,7 +78,7 @@ async def test_reconnect(event_loop):
         try:
             await jasyncio.sleep(0.1)
             assert conn.is_open
-            await conn.ws.close()
+            await conn._ws.close()
             assert not conn.is_open
             await model.block_until(lambda: conn.is_open, timeout=3)
         finally:

--- a/tests/integration/test_controller.py
+++ b/tests/integration/test_controller.py
@@ -99,7 +99,9 @@ async def test_reset_user_password(event_loop):
             pass
         finally:
             # No connection with old password
-            assert new_connection is None
+            if new_connection:
+                await new_connection.close()
+                raise AssertionError()
 
 
 @base.bootstrapped

--- a/tests/integration/test_crossmodel.py
+++ b/tests/integration/test_crossmodel.py
@@ -14,7 +14,7 @@ async def test_offer(event_loop):
         await model.deploy(
             'cs:~jameinel/ubuntu-lite-7',
             application_name='ubuntu',
-            series='bionic',
+            series='focal',
             channel='stable',
         )
         assert 'ubuntu' in model.applications
@@ -35,7 +35,7 @@ async def test_consume(event_loop):
         await model_1.deploy(
             'cs:~jameinel/ubuntu-lite-7',
             application_name='ubuntu',
-            series='bionic',
+            series='focal',
             channel='stable',
         )
         assert 'ubuntu' in model_1.applications
@@ -65,7 +65,7 @@ async def test_remove_saas(event_loop):
         await model_1.deploy(
             'cs:~jameinel/ubuntu-lite-7',
             application_name='ubuntu',
-            series='bionic',
+            series='focal',
             channel='stable',
         )
         assert 'ubuntu' in model_1.applications
@@ -98,7 +98,7 @@ async def test_add_relation_with_offer(event_loop):
         application = await model_1.deploy(
             'ch:mysql',
             application_name='mysql',
-            series='xenial',
+            series='focal',
             channel='stable',
         )
         assert 'mysql' in model_1.applications
@@ -115,7 +115,7 @@ async def test_add_relation_with_offer(event_loop):
             await model_2.deploy(
                 'ch:mediawiki',
                 application_name='mediawiki',
-                series='xenial',
+                series='focal',
                 channel='stable',
             )
             await model_2.block_until(

--- a/tests/integration/test_crossmodel.py
+++ b/tests/integration/test_crossmodel.py
@@ -96,9 +96,9 @@ async def test_remove_saas(event_loop):
 async def test_add_relation_with_offer(event_loop):
     async with base.CleanModel() as model_1:
         application = await model_1.deploy(
-            'cs:mysql-58',
+            'ch:mysql',
             application_name='mysql',
-            series='bionic',
+            series='xenial',
             channel='stable',
         )
         assert 'mysql' in model_1.applications
@@ -113,8 +113,8 @@ async def test_add_relation_with_offer(event_loop):
         # farm off a new model to test the consumption
         async with base.CleanModel() as model_2:
             await model_2.deploy(
-                'cs:trusty/wordpress-5',
-                application_name='wordpress',
+                'ch:mediawiki',
+                application_name='mediawiki',
                 series='xenial',
                 channel='stable',
             )
@@ -122,8 +122,7 @@ async def test_add_relation_with_offer(event_loop):
                 lambda: all(unit.agent_status == 'idle'
                             for unit in application.units))
 
-            await model_2.add_relation("wordpress", "admin/{}.mysql".format(model_1.info.name))
-
+            await model_2.add_relation("mediawiki:db", "admin/{}.mysql".format(model_1.info.name))
             status = await model_2.get_status()
             if 'mysql' not in status.remote_applications:
                 raise Exception("Expected mysql in saas")

--- a/tests/integration/test_juju.py
+++ b/tests/integration/test_juju.py
@@ -19,3 +19,4 @@ async def test_get_controllers(event_loop):
         cc = await j.get_controller(controller.controller_name)
         assert isinstance(cc, Controller)
         assert controller.connection().endpoint == cc.connection().endpoint
+        await cc.disconnect()

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -819,6 +819,7 @@ async def test_backups(event_loop):
 
     # Cleanup
     os.remove(local_file_name)
+    await m.disconnect()
 
 
 @base.bootstrapped
@@ -832,18 +833,23 @@ async def test_model_cache_update(event_loop):
         await controller.connect_current()
 
         model_name = "new-test-model"
-        await controller.add_model(model_name)
+        m = await controller.add_model(model_name)
 
         model_uuids = await controller.model_uuids()
         assert model_name in model_uuids
 
         model = Model()
+
         try:
             await model.connect(model_name=model_name)
         except JujuConnectionError:
             # avoid leaking the model if the test fails
+            await model.disconnect()
+            await m.disconnect()
             await controller.destroy_models(model_name)
             raise
 
         # cleanup
+        await model.disconnect()
+        await m.disconnect()
         await controller.destroy_models(model_name)

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -667,7 +667,7 @@ async def test_get_machines(event_loop):
 @pytest.mark.asyncio
 async def test_watcher_reconnect(event_loop):
     async with base.CleanModel() as model:
-        await model.connection().ws.close()
+        await model.connection().close()
         await block_until(model.is_connected, timeout=3)
 
 


### PR DESCRIPTION
### Description

A bunch of background noise is happening in the concurrent asyncio events resulting in repeated error logs to build up, despite that nothing in the foreground is failing. These are often:

1. Actual exceptions that are ignored in the main task/thread.
2. Error logs bleeding from other libraries (potentially when trying to handle the ignored exceptions in (1)
(b/c `asyncio` manages their events as well).
3. Tasks that are not gathered properly at teardown.

This PR attempts to streamline all the tasks and events that are happening on our `connection.py` and make sure we're:
* not producing any background exceptions,
* not producing any unnecessary/useless/excess error logs, and 
* tearing down properly.

Hopefully will fix #576 

Jira card [#138](https://warthogs.atlassian.net/browse/JUJU-138)

### QA Steps

In the CI test runs (especially in the ones with failed tests), we should only see the pass info and exception stacktraces that are relevant to the test logic (i.e. there shouldn't be any asyncio related errors in there).

### Notes & Discussion 

* This first commit ensures the `Pinger` facade is available when the `_pinger_task` is created, by moving the `_pinger_task` creation after `_build_facade` calls.

* Also disables the `_pinger_task` completely for `debug_log` connections, because debug_log connections are not doing any RPCs, they directly connect through the WebSocketClientProtocol, so we're not getting any facades from the apiserver (like we do in the case of `_connect_with_login` etc)

* A relevant bug here is https://bugs.python.org/issue36709 : which is about `asyncio.sslproto.SSLProtocol` raising an error whenever the event_loop is closed during an alive websocket connection. So in our `client/connection.py` we avoid keeping the connection alive (by removing `ping_interval=None`).

* The websocket object (_ws) is tightly coupled with the asyncio-managed tasks (e.g. Pinger) as well as the Monitor, so interacting with it directly (e.g. doing conn._ws.close() instead of conn.close()) pushes things out of sync/control. So it shouldn't be used directly (e.g. avoid `conn.ws.close()`, instead use `conn.close()`)

* Functions such as `model.get_controller` returns a newly constructed Controller object that is already connected with the model's own connection parameters. This puts the responsibility of closing out the connection (and destroying the spawned asyncio tasks etc) to the caller. If not done, everyone (asyncio, websockets etc) yells at pylibjuju about lingering tasks and open connections. So we introduce a `ConnectedController` object that when it's used with the `async with` form automatically disconnects after done.

* asyncio loop event_handler is only called on Task exceptions when the Task object is cleared from the memory. But the garbabe collector doesn't clear the Task if we keep a reference for it (e.g. putting it in a neverending Task ---like Pinger) until the very end. So installing our own handler makes sure that the exceptions are retrieved and properly handled and logged regardless of when the Task is being destroyed.