### PR TITLE
[JUJU-157] Add note for removing services

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,7 +2,7 @@ Changelog
 ---------
 
 Next Release
-^^^^^
+^^^^^^^^^^^^
 
 * Legacy "services" are removed in https://github.com/juju/python-libjuju/pull/566
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+Next Release
+^^^^^
+
+* Legacy "services" are removed in https://github.com/juju/python-libjuju/pull/566
+
 2.9.4
 ^^^^^
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 Next Release
 ^^^^^^^^^^^^
 
-* Legacy "services" are removed in https://github.com/juju/python-libjuju/pull/566
+* Legacy "services" for describing "applications" within bundles are no longer supported. "applications" can be used as a direct replacement for "services" in bundles.yaml.
 
 2.9.4
 ^^^^^


### PR DESCRIPTION
### Description

Legacy "services" are removed per https://github.com/juju/charm/pull/326 , so this PR adds a note to the `changelog.rst` under Next Releases.

### QA Steps

```sh
N/A
```

### Notes & Discussion
