### PR TITLE
[JUJU-213] Local type `file` resource support

### DIFF
--- a/examples/deploy_local_file_resource.py
+++ b/examples/deploy_local_file_resource.py
@@ -18,6 +18,7 @@ async def main():
     # connect to current model with current user, per Juju CLI
     await model.connect()
 
+    application = None
     try:
         print('Deploying local-charm')
         base_dir = Path(__file__).absolute().parent.parent
@@ -33,6 +34,11 @@ async def main():
 
         print('Removing Charm')
         await application.remove()
+    except Exception as e:
+        print(e)
+        if application:
+            await application.remove()
+        await model.disconnect()
     finally:
         print('Disconnecting from model')
         await model.disconnect()

--- a/examples/deploy_local_file_resource.py
+++ b/examples/deploy_local_file_resource.py
@@ -1,0 +1,42 @@
+"""
+This example:
+
+1. Connects to the current model
+2. Deploy a local charm with a oci-image resource and waits until it reports
+   itself active
+3. Destroys the unit and application
+
+"""
+from juju import jasyncio
+from juju.model import Model
+from pathlib import Path
+
+
+async def main():
+    model = Model()
+    print('Connecting to model')
+    # connect to current model with current user, per Juju CLI
+    await model.connect()
+
+    try:
+        print('Deploying local-charm')
+        base_dir = Path(__file__).absolute().parent.parent
+        charm_path = '{}/tests/integration/file-resource-charm'.format(base_dir)
+        resources = {"file-res": "test.file"}
+        application = await model.deploy(
+            charm_path,
+            resources=resources,
+        )
+
+        print('Waiting for active')
+        await model.wait_for_idle()
+
+        print('Removing Charm')
+        await application.remove()
+    finally:
+        print('Disconnecting from model')
+        await model.disconnect()
+
+
+if __name__ == '__main__':
+    jasyncio.run(main())

--- a/juju/model.py
+++ b/juju/model.py
@@ -1829,7 +1829,7 @@ class Model:
 
         for name, path in resources.items():
             resource_type = metadata["resources"][name]["type"]
-            if resource_type not in ["oci-image", "file"]:
+            if resource_type not in {"oci-image", "file"}:
                 log.info("Resource {} of type {} is not supported".format(name, resource_type))
                 continue
 
@@ -1862,39 +1862,35 @@ class Model:
                 }
 
                 data = yaml.dump(docker_image_details)
-            else:
-                p = Path(path)
-                # f = p.open()
-                data = p.read_text() if p.exists() else ''
 
-            if sys.version_info[0:2] == (3, 5):
-                hash_alg = hashlib.sha384
-            else:
-                hash_alg = hashlib.sha3_384
+                if sys.version_info[0:2] == (3, 5):
+                    hash_alg = hashlib.sha384
+                else:
+                    hash_alg = hashlib.sha3_384
 
-            charmresource['fingerprint'] = hash_alg(bytes(data, 'utf-8')).digest()
+                charmresource['fingerprint'] = hash_alg(bytes(data, 'utf-8')).digest()
 
-            conn, headers, path_prefix = self.connection().https_connection()
+                conn, headers, path_prefix = self.connection().https_connection()
 
-            query = "?pendingid={}".format(pending_id)
-            url = "{}/applications/{}/resources/{}{}".format(
-                path_prefix, application, name, query)
-            if resource_type == "oci-image":
-                disp = "multipart/form-data; filename=\"{}\"".format(path)
-            else:
-                disp = "form-data; filename=\"{}\"".format(path)
+                query = "?pendingid={}".format(pending_id)
+                url = "{}/applications/{}/resources/{}{}".format(
+                    path_prefix, application, name, query)
+                if resource_type == "oci-image":
+                    disp = "multipart/form-data; filename=\"{}\"".format(path)
+                else:
+                    disp = "form-data; filename=\"{}\"".format(path)
 
-            headers['Content-Type'] = 'application/octet-stream'
-            headers['Content-Length'] = len(data)
-            headers['Content-Sha384'] = charmresource['fingerprint'].hex()
-            headers['Content-Disposition'] = disp
+                headers['Content-Type'] = 'application/octet-stream'
+                headers['Content-Length'] = len(data)
+                headers['Content-Sha384'] = charmresource['fingerprint'].hex()
+                headers['Content-Disposition'] = disp
 
-            conn.request('PUT', url, data, headers)
+                conn.request('PUT', url, data, headers)
 
-            response = conn.getresponse()
-            result = response.read().decode()
-            if not response.status == 200:
-                raise JujuError(result)
+                response = conn.getresponse()
+                result = response.read().decode()
+                if not response.status == 200:
+                    raise JujuError(result)
 
         return resource_map
 

--- a/tests/integration/file-resource-charm/dispatch
+++ b/tests/integration/file-resource-charm/dispatch
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+resource_file="$(resource-get file-res)"
+if [[ -z "$resource_file" ]]; then
+  status-set waiting
+elif grep -q "ubuntu/latest" "$resource_file"; then
+  status-set active
+else
+  status-set error
+fi

--- a/tests/integration/file-resource-charm/metadata.yaml
+++ b/tests/integration/file-resource-charm/metadata.yaml
@@ -1,0 +1,10 @@
+name: file-resource-charm
+series: ["focal"]
+summary: "test local file resource"
+description: "charm for test deploy local file resource"
+maintainers: ["test"]
+resources:
+  file-res:
+    type: file
+    filename: 'test.file'
+    description: 'Test File Resource'

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -603,11 +603,15 @@ async def test_local_file_resource_charm(event_loop):
     charm_path = TESTS_DIR / 'integration' / 'file-resource-charm'
     async with base.CleanModel() as model:
         resources = {"file-res": "test.file"}
-        charm = await model.deploy(str(charm_path), resources=resources)
+        app = await model.deploy(str(charm_path), resources=resources)
         assert 'file-resource-charm' in model.applications
 
         await model.wait_for_idle()
-        assert charm.units[0].agent_status == 'idle'
+        assert app.units[0].agent_status == 'idle'
+
+        ress = await app.get_resources()
+        assert 'file-res' in ress
+        assert ress['file-res']
 
 
 @base.bootstrapped

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -599,6 +599,19 @@ async def test_local_oci_image_resource_charm(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+async def test_local_file_resource_charm(event_loop):
+    charm_path = TESTS_DIR / 'integration' / 'file-resource-charm'
+    async with base.CleanModel() as model:
+        resources = {"file-res": "test.file"}
+        charm = await model.deploy(str(charm_path), resources=resources)
+        assert 'file-resource-charm' in model.applications
+
+        await model.wait_for_idle()
+        assert charm.units[0].agent_status == 'idle'
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
 async def test_store_resources_bundle(event_loop):
     pytest.skip('test_store_resources_bundle intermittent test failure')
     async with base.CleanModel() as model:


### PR DESCRIPTION
#### Description

Local charms that define resources, when deployed with libjuju end up with no resources defined in the controller, so none can be attached.

Attempts to fix #223. 

Currently it doesn't have the full thing, so it's a draft PR.

#### QA Steps

```sh
tox -e integration -- tests/integration/test_model.py::test_local_file_resource_charm
```

Also
```sh
python examples/deploy_local_file_resource.py
```

#### Notes & Discussion


