### PR TITLE
[JUJU-238] Small bug fix for old ClientFacade support

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -1683,7 +1683,7 @@ class Model:
             return await charms_facade.AddCharm(charm_origin=origin, url=charm_url, force=False)
 
         client_facade = client.ClientFacade.from_connection(self.connection())
-        await client_facade.AddCharm(channel=str(origin.risk), url=charm_url, force=False)
+        return await client_facade.AddCharm(channel=str(origin.risk), url=charm_url, force=False)
 
     async def _resolve_charm(self, url, origin):
         charms_cls = client.CharmsFacade


### PR DESCRIPTION
#### Description

This fixes a small bug that happens when pylibjuju is used with an older version of Juju (i.e. when now deprecated `ClientFacade` is being used to deploy a charm). The issue can be seen at https://github.com/juju/python-libjuju/issues/586#issuecomment-979461905.

#### QA Steps

```sh
N/A
```

#### Notes & Discussion