### PR TITLE
[JUJU-239] Debug-log parameters

### DIFF
--- a/examples/debug-log.py
+++ b/examples/debug-log.py
@@ -10,7 +10,9 @@ async def main():
     model = Model()
     await model.connect_current()
 
-    await model.debug_log(limit=3)
+    await model.debug_log(
+        limit=15,
+        exclude_module=['juju.worker.logforwarder'])
 
     application = await model.deploy(
         'cs:ubuntu-10',

--- a/examples/debug-log.py
+++ b/examples/debug-log.py
@@ -12,7 +12,9 @@ async def main():
 
     await model.debug_log(
         limit=15,
-        exclude_module=['juju.worker.logforwarder'])
+        exclude_module=['juju.worker.logforwarder'],
+        include_module=['juju.worker.provisioner'], # <- only log provisioner
+    )
 
     application = await model.deploy(
         'cs:ubuntu-10',

--- a/examples/debug-log.py
+++ b/examples/debug-log.py
@@ -13,7 +13,9 @@ async def main():
     await model.debug_log(
         limit=15,
         exclude_module=['juju.worker.logforwarder'],
-        include_module=['juju.worker.provisioner'], # <- only log provisioner
+        # include_module=['juju.worker.dependency'], # <- only log dependency module
+        # include=['machine-0'], # <- only log from machine-0
+        # exclude=['machine-0'], # <- no log from machine-0
     )
 
     application = await model.deploy(

--- a/examples/debug-log.py
+++ b/examples/debug-log.py
@@ -16,7 +16,7 @@ async def main():
         # include_module=['juju.worker.dependency'], # <- only log dependency module
         # include=['machine-0'], # <- only log from machine-0
         # exclude=['machine-0'], # <- no log from machine-0
-        level='WARNING',
+        # level='WARNING',
     )
 
     application = await model.deploy(

--- a/examples/debug-log.py
+++ b/examples/debug-log.py
@@ -11,11 +11,12 @@ async def main():
     await model.connect_current()
 
     await model.debug_log(
-        limit=15,
-        exclude_module=['juju.worker.logforwarder'],
+        # limit=15,
+        # exclude_module=['juju.worker.logforwarder'],
         # include_module=['juju.worker.dependency'], # <- only log dependency module
         # include=['machine-0'], # <- only log from machine-0
         # exclude=['machine-0'], # <- no log from machine-0
+        level='WARNING',
     )
 
     application = await model.deploy(

--- a/examples/debug-log.py
+++ b/examples/debug-log.py
@@ -3,20 +3,14 @@ This example demonstrate how debug-log works
 
 """
 from juju import jasyncio
-import logging
-import sys
-from logging import getLogger
 from juju.model import Model
-
-LOG = getLogger(__name__)
-logging.basicConfig(stream=sys.stdout, level=logging.INFO)
 
 
 async def main():
     model = Model()
     await model.connect_current()
 
-    await model.debug_log()
+    await model.debug_log(limit=3)
 
     application = await model.deploy(
         'cs:ubuntu-10',

--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -447,28 +447,31 @@ class Connection:
 
         write_or_not = True
 
+        entity = result['tag']
         lev = result['sev']
         mod = result['mod']
         msg = result['msg']
 
+        excluded_entities = self.debug_log_params['exclude']
         excluded_modules = self.debug_log_params['exclude_module']
-        write_or_not = write_or_not and (mod not in excluded_modules)
+        write_or_not = write_or_not and \
+            (mod not in excluded_modules) and \
+            (entity not in excluded_entities)
 
+        included_entities = self.debug_log_params['include']
         only_these_modules = self.debug_log_params['include_module']
-        write_or_not = write_or_not and (only_these_modules is not [] and mod in only_these_modules)
+        write_or_not = write_or_not and \
+            (only_these_modules == [] or mod in only_these_modules) and \
+            (included_entities == [] or entity in included_entities)
 
-        # include = self.debug_log_params['include']
         # level = self.debug_log_params['level']
         # lines = self.debug_log_params['lines']
-        # replay = self.debug_log_params['replay']
-        # exclude = self.debug_log_params['exclude']
         # no_tail = self.debug_log_params['no_tail']
 
         if write_or_not:
-            tag = result['tag']
             ts = parse(result['ts'])
 
-            self.debug_log_target.write("%s %02d:%02d:%02d %s %s %s\n" % (tag, ts.hour, ts.minute, ts.second, lev, mod, msg))
+            self.debug_log_target.write("%s %02d:%02d:%02d %s %s %s\n" % (entity, ts.hour, ts.minute, ts.second, lev, mod, msg))
             return 1
         else:
             return 0

--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -451,16 +451,16 @@ class Connection:
         mod = result['mod']
         msg = result['msg']
 
-        # get the parameters for the debug_log to decide write_or_not
+        excluded_modules = self.debug_log_params['exclude_module']
+        write_or_not = write_or_not and (mod not in excluded_modules)
 
-        # no_tail = self.debug_log_params['no_tail']
-        # exclude_module = self.debug_log_params['exclude_module']
         # include_module = self.debug_log_params['include_module']
         # include = self.debug_log_params['include']
         # level = self.debug_log_params['level']
         # lines = self.debug_log_params['lines']
         # replay = self.debug_log_params['replay']
         # exclude = self.debug_log_params['exclude']
+        # no_tail = self.debug_log_params['no_tail']
 
         if write_or_not:
             tag = result['tag']

--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -454,7 +454,9 @@ class Connection:
         excluded_modules = self.debug_log_params['exclude_module']
         write_or_not = write_or_not and (mod not in excluded_modules)
 
-        # include_module = self.debug_log_params['include_module']
+        only_these_modules = self.debug_log_params['include_module']
+        write_or_not = write_or_not and (only_these_modules is not [] and mod in only_these_modules)
+
         # include = self.debug_log_params['include']
         # level = self.debug_log_params['level']
         # lines = self.debug_log_params['lines']

--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -1,4 +1,3 @@
-import sys
 import base64
 import json
 import logging
@@ -467,6 +466,7 @@ class Connection:
             write_or_not = write_or_not and \
                 (log_level == "" or (LEVELS.index(msg_lev) >= LEVELS.index(log_level)))
 
+        # TODO
         # lines = self.debug_log_params['lines']
         # no_tail = self.debug_log_params['no_tail']
 

--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -448,7 +448,7 @@ class Connection:
         write_or_not = True
 
         entity = result['tag']
-        lev = result['sev']
+        msg_lev = result['sev']
         mod = result['mod']
         msg = result['msg']
 
@@ -464,14 +464,22 @@ class Connection:
             (only_these_modules == [] or mod in only_these_modules) and \
             (included_entities == [] or entity in included_entities)
 
-        # level = self.debug_log_params['level']
+        LEVELS = ['TRACE', 'DEBUG', 'INFO', 'WARNING', 'ERROR']
+        log_level = self.debug_log_params['level']
+
+        if log_level != "" and log_level not in LEVELS:
+            log.warning("Debug Logger: level should be one of %s, given %s" % (LEVELS, log_level))
+        else:
+            write_or_not = write_or_not and \
+                (log_level == "" or (LEVELS.index(msg_lev) >= LEVELS.index(log_level)))
+
         # lines = self.debug_log_params['lines']
         # no_tail = self.debug_log_params['no_tail']
 
         if write_or_not:
             ts = parse(result['ts'])
 
-            self.debug_log_target.write("%s %02d:%02d:%02d %s %s %s\n" % (entity, ts.hour, ts.minute, ts.second, lev, mod, msg))
+            self.debug_log_target.write("%s %02d:%02d:%02d %s %s %s\n" % (entity, ts.hour, ts.minute, ts.second, msg_lev, mod, msg))
             return 1
         else:
             return 0

--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -416,11 +416,9 @@ class Connection:
         if self._receiver_task:
             self._receiver_task.cancel()
             self._receiver_task = None
-        if self._debug_log_task and not to_reconnect:
-            #  Don't need to cancel the _debug_log_task for reconnects
+        if self._debug_log_task:
             self._debug_log_task.cancel()
             self._debug_log_task = None
-            self._close_debug_log_target()
         #  Allow a second for tasks to be cancelled
         await jasyncio.sleep(1)
 
@@ -438,10 +436,6 @@ class Connection:
             return await self.messages.get(request_id)
         except GeneratorExit:
             return {}
-
-    def _close_debug_log_target(self):
-        if self.debug_log_target is not sys.stdout:
-            self.debug_log_target.close()
 
     def debug_log_filter_write(self, result):
 
@@ -748,7 +742,7 @@ class Connection:
                 if not self.endpoints else
                 self.endpoints
             )
-            if connector is self._connect_with_login:
+            if not self.is_debug_log_connection:
                 self._build_facades(res.get('facades', {}))
                 if not self._pinger_task:
                     self._pinger_task = jasyncio.create_task(self._pinger())

--- a/juju/model.py
+++ b/juju/model.py
@@ -1490,9 +1490,9 @@ class Model:
         raise NotImplementedError()
 
     async def debug_log(
-            self, target=sys.stdout, no_tail=False, exclude_module=None,
-            include_module=None, include=None, level=None, limit=0, lines=10,
-            replay=False, exclude=None):
+            self, target=sys.stdout, no_tail=False, exclude_module=[],
+            include_module=[], include=[], level=None, limit=0, lines=10,
+            exclude=[]):
         """Get log messages for this model.
 
         :param bool no_tail: Stop after returning existing log messages
@@ -1507,7 +1507,6 @@ class Model:
             filtered) lines are shown
         :param int lines: Yield this many of the most recent lines, and keep
             yielding
-        :param bool replay: Yield the entire log, and keep yielding
         :param list exclude: Do not show log messages for these entities
 
         """
@@ -1522,7 +1521,6 @@ class Model:
             'level': level,
             'limit': limit,
             'lines': lines,
-            'replay': replay,
             'exclude': exclude,
         }
         await self.connect(debug_log_conn=target, debug_log_params=params)

--- a/juju/model.py
+++ b/juju/model.py
@@ -1514,7 +1514,18 @@ class Model:
         if not self.is_connected():
             await self.connect()
 
-        await self.connect(debug_log_conn=target)
+        params = {
+            'no_tail': no_tail,
+            'exclude_module': exclude_module,
+            'include_module': include_module,
+            'include': include,
+            'level': level,
+            'limit': limit,
+            'lines': lines,
+            'replay': replay,
+            'exclude': exclude,
+        }
+        await self.connect(debug_log_conn=target, debug_log_params=params)
 
     def _get_series(self, entity_url, entity):
         # try to get the series from the provided charm URL

--- a/juju/model.py
+++ b/juju/model.py
@@ -1491,8 +1491,8 @@ class Model:
 
     async def debug_log(
             self, target=sys.stdout, no_tail=False, exclude_module=[],
-            include_module=[], include=[], level=None, limit=0, lines=10,
-            exclude=[]):
+            include_module=[], include=[], level="", limit=sys.maxsize,
+            lines=10, exclude=[]):
         """Get log messages for this model.
 
         :param bool no_tail: Stop after returning existing log messages


### PR DESCRIPTION
#### Description

This introduces the filtering parameters and some fixes for `model.debug_log` on pylibjuju.

Fixes #587 

#### QA Steps

```sh
python3 examples/debug-log.py
```

#### Notes & Discussion

The `--no-tail` and the `--lines` parameters are not included yet. I'm not sure how much we care about completeness. However, I need to understand better the semantics of the `--lines`, and I'm not sure yet how to implement `--no-tail` with the `_debug_log_task` mechanism.