### PR TITLE
[JUJU-289] Use provided series in deploy if supported

### DIFF
--- a/juju/bundle.py
+++ b/juju/bundle.py
@@ -356,7 +356,7 @@ class BundleHandler:
                                             architecture=architecture,
                                             risk=risk,
                                             track=track)
-                charm_url, charm_origin = await self.model._resolve_charm(charm_url, origin)
+                charm_url, charm_origin, _ = await self.model._resolve_charm(charm_url, origin)
 
                 spec['charm'] = str(charm_url)
             else:
@@ -716,7 +716,7 @@ class AddCharmChange(ChangeInfo):
                                         architecture=arch,
                                         risk=ch.risk,
                                         track=ch.track)
-            identifier, origin = await context.model._resolve_charm(url, origin)
+            identifier, origin, _ = await context.model._resolve_charm(url, origin)
 
         if identifier is None:
             raise JujuError('unknown charm {}'.format(self.charm))

--- a/tests/integration/test_crossmodel.py
+++ b/tests/integration/test_crossmodel.py
@@ -98,7 +98,7 @@ async def test_add_relation_with_offer(event_loop):
         application = await model_1.deploy(
             'ch:mysql',
             application_name='mysql',
-            series='focal',
+            series='xenial',
             channel='stable',
         )
         assert 'mysql' in model_1.applications
@@ -115,7 +115,7 @@ async def test_add_relation_with_offer(event_loop):
             await model_2.deploy(
                 'ch:mediawiki',
                 application_name='mediawiki',
-                series='focal',
+                series='trusty',
                 channel='stable',
             )
             await model_2.block_until(

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -279,6 +279,29 @@ async def test_deploy_channels_revs(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+async def test_deploy_from_ch_with_series(event_loop):
+    charm = 'ch:ubuntu'
+    for series in ['xenial', 'bionic', 'focal']:
+        async with base.CleanModel() as model:
+            app_name = "ubuntu-{}".format(series)
+            await model.deploy(charm, application_name=app_name, series=series)
+            assert (await model.get_status())["applications"][app_name]["series"] == series
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_deploy_from_ch_with_invalid_series(event_loop):
+    async with base.CleanModel() as model:
+        charm = 'ch:ubuntu'
+        try:
+            await model.deploy(charm, series='invalid')
+            assert False, 'Invalid deployment should raise JujuError'
+        except JujuError:
+            pass
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
 async def test_add_machine(event_loop):
     from juju.machine import Machine
 


### PR DESCRIPTION
Previously any provided series was ignored and the default provided by
CharmStore API was always used. Now, if a provided series is supported,
use that instead