### PR TITLE
[JUJU-366] Utility for connecting directly to existing connection

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -742,6 +742,10 @@ class Model:
         """
         return await self.connect()
 
+    async def connect_to(self, connection):
+        conn_params = connection.connect_params()
+        await self._connect_direct(**conn_params)
+
     async def _connect_direct(self, **kwargs):
         await self.disconnect()
         await self._connector.connect(**kwargs)

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -933,6 +933,29 @@ async def test_backups(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+async def test_connect_to_connection(event_loop):
+    async with base.CleanModel() as test_model:
+        # get the connection from test_model
+        conn = test_model.connection()
+
+        # make a new Model obj
+        m = Model()
+
+        # it's not connected yet
+        assert not m.is_connected()
+
+        # connect it directly to the connection
+        await m.connect_to(conn)
+
+        # it is connected
+        assert m.is_connected()
+
+        # cleanup
+        await m.disconnect()
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
 async def test_model_cache_update(event_loop):
     """Connecting to a new model shouldn't fail because the cache is not
     updated yet


### PR DESCRIPTION
#### Description

This adds a small utility function `connect_to` that accepts an existing connection and bind the Model directly to it.

Fixes #81 

#### QA Steps

```sh
tox -e integration -- tests/integration/test_model.py::test_connect_to_connection
```

#### Notes & Discussion

