### PR TITLE
[JUJU-367] Improve `get_charm_series` to check the model for series for a local charm

### DIFF
--- a/examples/upgrade_local_charm_k8s.py
+++ b/examples/upgrade_local_charm_k8s.py
@@ -3,7 +3,8 @@ This example:
 
 1. Connects to the current model
 2. Deploy a bundle and waits until it reports itself active
-3. Destroys the units and applications
+3. Upgrades the charm with a local path
+4. Destroys the units and applications
 
 """
 from juju import jasyncio
@@ -26,7 +27,9 @@ async def main():
         await model.wait_for_idle(status='active')
         print("Successfully deployed!")
 
-        await applications[0].upgrade_charm(path='./examples/charms/onos.charm')
+        local_path = './examples/charms/onos.charm'
+        print('Upgrading charm with %s' % local_path)
+        await applications[0].upgrade_charm(path=local_path)
 
         await model.wait_for_idle(status='active')
 

--- a/examples/upgrade_local_charm_k8s.py
+++ b/examples/upgrade_local_charm_k8s.py
@@ -1,0 +1,43 @@
+"""
+This example:
+
+1. Connects to the current model
+2. Deploy a bundle and waits until it reports itself active
+3. Destroys the units and applications
+
+"""
+from juju import jasyncio
+from juju.model import Model
+
+
+async def main():
+    model = Model()
+    print('Connecting to model')
+    # Connect to current model with current user, per Juju CLI
+    await model.connect()
+
+    try:
+        print('Deploying bundle')
+        applications = await model.deploy(
+            './examples/k8s-local-bundle/bundle.yaml',
+        )
+
+        print('Waiting for active')
+        await model.wait_for_idle(status='active')
+        print("Successfully deployed!")
+
+        await applications[0].upgrade_charm(path='./examples/charms/onos.charm')
+
+        await model.wait_for_idle(status='active')
+
+        print('Removing bundle')
+        for application in applications:
+            await application.remove()
+    finally:
+        print('Disconnecting from model')
+        await model.disconnect()
+        print("Success")
+
+
+if __name__ == '__main__':
+    jasyncio.run(main())

--- a/juju/application.py
+++ b/juju/application.py
@@ -755,7 +755,7 @@ class Application(model.ModelEntity):
         charm_dir = path.expanduser().resolve()
         model_config = await self.get_config()
 
-        series = get_charm_series(charm_dir)
+        series = await get_charm_series(charm_dir, self.model)
         if not series:
             model_config = await self.get_config()
             default_series = model_config.get("default-series")

--- a/juju/bundle.py
+++ b/juju/bundle.py
@@ -434,10 +434,13 @@ async def get_charm_series(path, model):
     series = _series[0] if _series else None
 
     if series is None:
+        # get the ConfigValue for the 'default-series' from the model
         model_config = await model.get_config()
-        default_series = model_config.get("default-series")
-        if default_series:
-            series = default_series.value
+        _default_series = model_config.get("default-series")
+
+        if _default_series is not None:
+            # then update the series with its value
+            series = _default_series.value
 
     return series
 

--- a/juju/model.py
+++ b/juju/model.py
@@ -1655,7 +1655,7 @@ class Model:
                 metadata = utils.get_local_charm_metadata(charm_dir)
                 if not application_name:
                     application_name = metadata['name']
-                series = series or get_charm_series(charm_dir, self)
+                series = series or await get_charm_series(charm_dir, self)
                 if not series:
                     model_config = await self.get_config()
                     default_series = model_config.get("default-series")

--- a/juju/model.py
+++ b/juju/model.py
@@ -1655,7 +1655,7 @@ class Model:
                 metadata = utils.get_local_charm_metadata(charm_dir)
                 if not application_name:
                     application_name = metadata['name']
-                series = series or get_charm_series(charm_dir)
+                series = series or get_charm_series(charm_dir, self)
                 if not series:
                     model_config = await self.get_config()
                     default_series = model_config.get("default-series")


### PR DESCRIPTION
#### Description

`get_charm_series` method for a local charm extracts the `series` information for a local charm. It's often called from the `_handle_local_charms` from within the bundle.py when deploying local charms, which handles the case where no series information found by also checking the model config data.

The `get_charm_series` is also called from `application.py` in `refresh (upgrade_charm)` method, which doesn't handle the "no series" case.

This PR moves that logic (of also checking the model for series info) into the `get_charm_series` by adding an additional model parameter. So, whichever entity that's calling the `get_charm_series` also provides the associated model and need to do nothing else.

Fixes #606 

#### QA Steps

```sh
juju bootstrap microk8s test && python examples/upgrade_local_charm_k8s.py
```
Also related:
```sh
tox -e integration -- tests/integration/test_application.py::test_upgrade_local_charm
```
This one :point_up: is using machine charms and was already passing before this PR too.

#### Notes & Discussion

