### PR TITLE
Use public-address key instead of public_address

### DIFF
--- a/juju/unit.py
+++ b/juju/unit.py
@@ -118,7 +118,7 @@ class Unit(model.ModelEntity):
         defResult = await app_facade.UnitsInfo(entities=[client.Entity(self.tag)])
         if defResult is not None and len(defResult.results) > 1:
             raise JujuAPIError("expected one result")
-        return defResult.results[0].result.get('public_address', None)
+        return defResult.results[0].result.get('public-address', None)
 
     def get_resources(self, details=False):
         """Return resources for this unit.


### PR DESCRIPTION
PR #600 updated the get_public_address method for units to look up the
public address in the ApplicationFacade's UnitsInfo object. However,
the change used the get(str) method of the Type class which performs a
lookup in the json dictionary using the hyphenated key rather than the
underscore key, thus always returns None since this key is not in the
JSON dictionary. Changing it to return the lookup of 'public-address'
instead of 'public_address' results in the unit's public address being
returned.

Fixes #551 

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>