### PR TITLE
Fallback to 'local-fan'

### DIFF
--- a/juju/machine.py
+++ b/juju/machine.py
@@ -239,6 +239,8 @@ class Machine(model.ModelEntity):
             scope = address['scope']
             if scope == 'public' or scope == 'local-cloud':
                 return address['value']
+            if scope == 'local-fan':
+                return address['value']
         return None
 
     @property

--- a/juju/machine.py
+++ b/juju/machine.py
@@ -234,11 +234,17 @@ class Machine(model.ModelEntity):
 
         May return None if no suitable address is found.
         """
-        return_addresses = []
         addresses = self.safe_data['addresses'] or []
-        for address in addresses:
+        return_addresses = []
+        ordered_addresses = []
+        ordered_scopes = ['public', 'local-cloud', 'local-fan']
+        for scope in ordered_scopes:
+            for address in addresses:
+                if scope == address['scope']:
+                    ordered_addresses.append(address)
+        for address in ordered_addresses:
             scope = address['scope']
-            for check_scope in ['public', 'local-cloud', 'local-fan']:
+            for check_scope in ordered_scopes:
                 if scope == check_scope:
                     return_addresses.append(address['value'])
         if return_addresses:

--- a/juju/machine.py
+++ b/juju/machine.py
@@ -234,13 +234,15 @@ class Machine(model.ModelEntity):
 
         May return None if no suitable address is found.
         """
+        return_addresses = []
         addresses = self.safe_data['addresses'] or []
         for address in addresses:
             scope = address['scope']
-            if scope == 'public' or scope == 'local-cloud':
-                return address['value']
-            if scope == 'local-fan':
-                return address['value']
+            for check_scope in ['public', 'local-cloud', 'local-fan']:
+                if scope == check_scope:
+                    return_addresses.append(address['value'])
+        if return_addresses:
+            return return_addresses[0]
         return None
 
     @property

--- a/juju/machine.py
+++ b/juju/machine.py
@@ -235,7 +235,6 @@ class Machine(model.ModelEntity):
         May return None if no suitable address is found.
         """
         addresses = self.safe_data['addresses'] or []
-        return_addresses = []
         ordered_addresses = []
         ordered_scopes = ['public', 'local-cloud', 'local-fan']
         for scope in ordered_scopes:
@@ -246,9 +245,7 @@ class Machine(model.ModelEntity):
             scope = address['scope']
             for check_scope in ordered_scopes:
                 if scope == check_scope:
-                    return_addresses.append(address['value'])
-        if return_addresses:
-            return return_addresses[0]
+                    return address['value']
         return None
 
     @property


### PR DESCRIPTION
If 'public' or 'local-cloud' are missing from the unit data, fallback to
'local-fan', in case of containers using solely fan networking and no
provider network.

Fixes juju#611