### PR TITLE
[JUJU-378] Utility for block_until-ing with a custom coroutine

### DIFF
--- a/juju/utils.py
+++ b/juju/utils.py
@@ -130,7 +130,7 @@ async def block_until_with_coroutine(condition_coroutine, timeout=None, wait_per
     async def _block():
         while not await condition_coroutine():
             await jasyncio.sleep(wait_period)
-    await jasyncio.wait_for(_block(), timeout)
+    await jasyncio.wait_for(_block(), timeout=timeout)
 
 
 async def wait_for_bundle(model, bundle, **kwargs):

--- a/juju/utils.py
+++ b/juju/utils.py
@@ -123,6 +123,16 @@ async def block_until(*conditions, timeout=None, wait_period=0.5):
     await jasyncio.wait_for(_block(), timeout)
 
 
+async def block_until_with_coroutine(condition_coroutine, timeout=None, wait_period=0.5):
+    """Return only after the given coroutine returns True.
+
+    """
+    async def _block():
+        while not await condition_coroutine():
+            await jasyncio.sleep(wait_period)
+    await jasyncio.wait_for(_block(), timeout)
+
+
 async def wait_for_bundle(model, bundle, **kwargs):
     """Helper to wait for just the apps in a specific bundle.
 

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -419,7 +419,7 @@ async def add_manual_machine_ssh(event_loop, is_root=False):
             'name': test_name,
             'source': {
                 'type': 'image',
-                'alias': 'bionic',
+                'alias': 'focal',
                 'mode': 'pull',
                 'protocol': 'simplestreams',
                 'server': 'https://cloud-images.ubuntu.com/releases',

--- a/tests/integration/test_unit.py
+++ b/tests/integration/test_unit.py
@@ -21,7 +21,12 @@ async def test_block_coroutine(event_loop):
         )
 
         async def is_leader_elected():
-            return any([await u.is_leader_from_status() for u in app.units])
+            # TODO: cleanup/refactor the code below when the py3.5
+            # support is dropped
+            for u in app.units:
+                if await u.is_leader_from_status():
+                    return True
+            return False
 
         await utils.block_until_with_coroutine(is_leader_elected,
                                                timeout=60)

--- a/tests/integration/test_unit.py
+++ b/tests/integration/test_unit.py
@@ -1,10 +1,30 @@
 import asyncio
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-
 import pytest
 
+from juju import utils
+
 from .. import base
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_block_coroutine(event_loop):
+    async with base.CleanModel() as model:
+        app = await model.deploy(
+            'ch:ubuntu',
+            application_name='ubuntu',
+            series='bionic',
+            channel='stable',
+            num_units=3,
+        )
+
+        async def is_leader_elected():
+            return any([await u.is_leader_from_status() for u in app.units])
+
+        await utils.block_until_with_coroutine(is_leader_elected,
+                                               timeout=60)
 
 
 @base.bootstrapped

--- a/tests/integration/test_unit.py
+++ b/tests/integration/test_unit.py
@@ -29,7 +29,7 @@ async def test_block_coroutine(event_loop):
             return False
 
         await utils.block_until_with_coroutine(is_leader_elected,
-                                               timeout=60)
+                                               timeout=480)
 
 
 @base.bootstrapped


### PR DESCRIPTION
#### Description

Normally to `block-until`, one needs to provide some regular Python predicate(s) to block until a True value to be produced.

This PR adds a utility named `block_until_with_coroutine` that allows `block-until`ing with a coroutine.

Fixes #609 

#### QA Steps

```sh
tox -e integration -- tests/integration/test_unit.py::test_block_coroutine
```

#### Notes & Discussion

`tests/integration/test_model.py::test_add_manual_machine_ssh` and `tests/integration/test_model.py::test_add_manual_machine_ssh_root` seemed to be blocking indefinitely in the CI.

 https://github.com/juju/python-libjuju/blob/d67fa18c158a3980a048ee2bbc222ce19f44f1a5/tests/integration/test_model.py#L350

Updating the series used in the tests solved the issue (related to #535).