### PR TITLE
Additional checks in print status.

### DIFF
--- a/examples/status.py
+++ b/examples/status.py
@@ -8,6 +8,7 @@ import logging
 import sys
 from logging import getLogger
 from juju.model import Model
+from juju.status import formatted_status
 
 LOG = getLogger(__name__)
 logging.basicConfig(stream=sys.stdout, level=logging.INFO)
@@ -31,7 +32,8 @@ async def main():
             # By setting raw to True, the returned
             # entry contains a FullStatus object with
             # all the available status data.
-            status = await model.status(raw=True)
+            # status = await model.status(raw=True)
+            status = await formatted_status(model)
             print(status)
         except Exception as e:
             print(e)

--- a/juju/status.py
+++ b/juju/status.py
@@ -112,10 +112,14 @@ def _print_status_apps(result_status):
         # like in ch:amd64/trusty/mediawiki-28
         charm_name = app.charm.split('/')[-1]
         charm_name = charm_name.split('-')[0]
+        work_ver = 'NA' if app.workload_version is None else app.workload_version
+        charm_channel = 'NA' if app.charm_channel is None else app.charm_channel
+        app_units = 'NA' if app.units is None else len(app.units)
+        app_status = 'NA' if app.status.status is None else app.status.status
         result_str += '\n'
         result_str += limits.format(
-            name, app.workload_version, app.status.status, len(app.units), charm_name,
-            app.charm_channel)
+            name, work_ver, app_status, app_units, charm_name,
+            charm_channel)
     result_str += '\n'
     return result_str
 


### PR DESCRIPTION
As mentioned in #621 the `formatted_status` function fails during the deployment of local charms. This PR sets additional checks and rewrites the `status.py` in the example folder. In order to check use charmcraft to deploy a local charm and mimic the erroneous situation.

```bash
charmcraft init
charmcraft build
juju deploy ./test_ubuntu-20.04-amd64.charm
```
Now you can run the status from the example folder to get an idea of what is going on.

```bash
tox -e eample -- examples/status.py
Model                     Cloud/Region              Version         SLA             Timestamp                      Notes                         
default                   localhost/localhost       2.9.22          unsupported     2022-01-31T10:21:19.350699526Z                               

App                       Version    Status     Scale Charm                Channel 
test                                 unknown    1     test                 NA      

Unit            Workload        Agent                Machine    Public address  Ports      Message                       
test/0          unknown         idle                 2          10.73.25.117                                             

Machine         State           DNS             Inst id              Series          Message                       
2               started         10.73.25.117    juju-35dc34-2        focal                                         
```