### PR TITLE
[JUJU-566] `safe_data` checks the connection before access in ModelEntity

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -363,11 +363,12 @@ class ModelEntity:
     def safe_data(self):
         """The data dictionary for this entity.
 
-        If this `ModelEntity` points to the dead state, it will
-        raise `DeadEntityException`.
+        If this `ModelEntity` points to the dead state, or the model
+        is not connected anymore, it will raise `DeadEntityException`.
 
         """
-        if self.data is None:
+
+        if self.data is None or not self.model.is_connected():
             raise DeadEntityException(
                 "Entity {}:{} is dead - its attributes can no longer be "
                 "accessed. Use the .previous() method on this object to get "

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -1062,5 +1062,5 @@ async def test_disconnect_clears_safe_data(event_loop):
 
             with pytest.raises(DeadEntityException):
                 await u.get_public_address()
-        except Exception: # Intentional generic exception
+        except Exception:  # Intentional generic exception
             await controller.destroy_model(model_name)

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -1062,5 +1062,7 @@ async def test_disconnect_clears_safe_data(event_loop):
 
             with pytest.raises(DeadEntityException):
                 await u.get_public_address()
+
+            await controller.destroy_model(model_name)
         except Exception:  # Intentional generic exception
             await controller.destroy_model(model_name)


### PR DESCRIPTION
#### Description

`safe_data` is a property access method on `ModelEntity` objects (such as `Unit`s). This PR makes every model entity to check their model's connection before allowing access to the underlying data. If the model is disconnected, any access to data in the associated model entities will raise a `DeadEntityException`.

Fixes #627 

#### QA Steps

```sh
tox -e integration -- tests/integration/test_model.py::test_disconnect_clears_safe_data
```

#### Notes & Discussion




