### PR TITLE
[JUJU-573] Fix charm resolution for Juju 2.8.11

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -1612,8 +1612,10 @@ class Model:
         if is_local_charm(entity_url) and not entity_url.startswith("local:"):
             entity_url = "local:{}".format(entity_url)
 
-        assume_charmstore = client.CharmsFacade.best_facade_version(self.connection()) < 3
-        url = URL.parse(str(entity_url), force_v1=assume_charmstore)
+        if client.CharmsFacade.best_facade_version(self.connection()) < 3:
+            url = URL.parse(str(entity_url), default_store=Schema.CHARM_STORE)
+        else:
+            url = URL.parse(str(entity_url))
 
         architecture = await self._resolve_architecture(url)
 

--- a/juju/model.py
+++ b/juju/model.py
@@ -509,6 +509,7 @@ class CharmStoreDeployType:
         result = await self.charmstore.entity(str(url),
                                               channel=channel,
                                               include_stats=False)
+
         identifier = result['Id']
         is_bundle = url.series == "bundle"
         if not series:
@@ -1818,7 +1819,7 @@ class Model:
                 'size': resource['Size'],
                 'type_': resource['Type'],
                 'origin': 'store',
-            } for resource in entity['Meta']['resources']
+            } for resource in entity['Meta'].get('resources', [])
         ]
 
         if overrides:

--- a/juju/url.py
+++ b/juju/url.py
@@ -42,17 +42,11 @@ class URL:
 
         if Schema.LOCAL.matches(u.scheme):
             c = URL(Schema.LOCAL, name=u.path)
+        elif Schema.CHARM_STORE.matches(u.scheme) or \
+             (u.scheme == "" and Schema.CHARM_STORE.matches(default_store)):
+            c = parse_v1_url(Schema.CHARM_STORE, u, s)
         else:
-            cs_match = Schema.CHARM_STORE.matches(u.scheme)
-            default_is_cs = Schema.CHARM_STORE.matches(default_store)
-
-            ch_match = Schema.CHARM_HUB.matches(u.scheme)
-            default_is_ch = Schema.CHARM_HUB.matches(default_store)
-
-            if cs_match or (not ch_match and default_is_cs):
-                c = parse_v1_url(Schema.CHARM_STORE, u, s)
-            elif ch_match or default_is_ch:
-                c = parse_v2_url(u, s)
+            c = parse_v2_url(u, s)
 
         if not c or not c.schema:
             raise JujuError("expected schema for charm or bundle URL {}".format(u))

--- a/juju/url.py
+++ b/juju/url.py
@@ -29,11 +29,12 @@ class URL:
         self.architecture = architecture
 
     @staticmethod
-    def parse(s):
+    def parse(s, force_v1=False):
         """parse parses the provided charm URL string into its respective
             structure.
 
             A missing schema is assumed to be 'ch'.
+            If force_v1 is True, then it is assumed to be 'cs'.
 
         """
         u = urlparse(s)
@@ -42,7 +43,7 @@ class URL:
 
         if Schema.LOCAL.matches(u.scheme):
             c = URL(Schema.LOCAL, name=u.path)
-        elif Schema.CHARM_STORE.matches(u.scheme):
+        elif force_v1 or Schema.CHARM_STORE.matches(u.scheme):
             c = parse_v1_url(Schema.CHARM_STORE, u, s)
         else:
             c = parse_v2_url(u, s)

--- a/juju/url.py
+++ b/juju/url.py
@@ -43,7 +43,7 @@ class URL:
         if Schema.LOCAL.matches(u.scheme):
             c = URL(Schema.LOCAL, name=u.path)
         elif Schema.CHARM_STORE.matches(u.scheme) or \
-             (u.scheme == "" and Schema.CHARM_STORE.matches(default_store)):
+                (u.scheme == "" and Schema.CHARM_STORE.matches(default_store)):
             c = parse_v1_url(Schema.CHARM_STORE, u, s)
         else:
             c = parse_v2_url(u, s)


### PR DESCRIPTION
#### Description

This is in response to some charm deployment issues with `Juju 2.8.11`. It changes two things:

1 - It patches the deployment of `CharmStore` charms
2 - Normally pylibjuju assumes the `CharmHub` when it receives a charm url without a prefix. This change adds an override for the case where the `CharmsFacade` version is too low to resolve the charm.

Fixes #623 

#### QA Steps

You'll need the [juju 2.8.11](https://github.com/juju/juju/archive/refs/tags/juju-2.8.11.tar.gz), and to put the following script in a file (slightly modified version of what is provided in the reporting issue #623):

```python
import sys
import asyncio
import juju.controller

async def controller():
    c = juju.controller.Controller()
    await c.connect_current()
    return c

async def model(controller):
    return await controller.add_model('test')

loop = asyncio.get_event_loop()

try:
    c = loop.run_until_complete(controller())
    m = loop.run_until_complete(model(c))
    loop.run_until_complete(m.deploy(sys.argv[1], channel='stable'))

    loop.run_until_complete(m.disconnect())
    loop.run_until_complete(c.destroy_model('test'))
    loop.run_until_complete(c.disconnect())
    print("success")
except:
    loop.run_until_complete(c.destroy_model('test'))
    loop.run_until_complete(c.disconnect())
    raise

```

Bootstrap with Juju `2.8.11` and run the file containing the script above like `python3 test.py ubuntu`, you should see `success`.

#### Notes & Discussion

`_resolve_charm` method literally has a failing check for this because lower versions (such as Juju 2.8) cannot deploy from the CharmHub in the first place, so it's safe to put in this override and try to get the charm from the CharmStore instead of failing.

