### PR TITLE
Provide extra metadata with charmstore.entity(...) 

### DIFF
--- a/juju/charmstore.py
+++ b/juju/charmstore.py
@@ -4,7 +4,6 @@ import theblues.charmstore
 import theblues.errors
 
 from urllib.parse import urlencode
-from urllib.error import HTTPError
 
 
 from . import jasyncio
@@ -37,11 +36,6 @@ class CharmStore:
 
         try:
             data = self._cs._get(url)
-        except HTTPError as err:
-            if err.code == 404:
-                return {}
-            else:
-                raise
         except theblues.charmstore.EntityNotFound:
             return {}
         return data.json()

--- a/juju/charmstore.py
+++ b/juju/charmstore.py
@@ -2,6 +2,7 @@ from functools import partial
 
 import theblues.charmstore
 import theblues.errors
+from urllib.parse import urlencode
 
 from . import jasyncio
 
@@ -10,15 +11,65 @@ class CharmStore:
     """
     Async wrapper around theblues.charmstore.CharmStore
     """
+    DEFAULT_INCLUDES = theblues.charmstore.DEFAULT_INCLUDES
+    _get_path = theblues.charmstore._get_path
+
     def __init__(self, cs_timeout=20):
         self._cs = theblues.charmstore.CharmStore(timeout=cs_timeout)
+
+    def _resources(self, entity_id, channel=None):
+        '''
+        Retrieve metadata about the resources of an entity in the charmstore.
+        This data was previously available in the charmstore API but is no longer included
+        with charmhub compatibility.  However, another API to retrieve the same
+        information is available.
+
+        @param entity_id The ID either a reference or a string of the entity
+               to get.
+        '''
+        url = '{}/{}/meta/resources'.format(self._cs.url,
+                                            CharmStore._get_path(entity_id))
+        if isinstance(channel, str):
+            url += '?channel={}'.format(urlencode(channel))
+
+        data = self._cs._get(url)
+        return data.json()
+
+    def _entity(self, *args, **kwargs):
+        '''
+        Overloads the method from theblues.charmstore.CharmStore
+        by fetching entity information and additional resources listings
+        in the event other application level code expected to continue
+        fetching this information.
+
+        Get the default data for any entity (e.g. bundle or charm).
+
+        @param entity_id The entity's id either as a reference or a string
+        @param get_files Whether to fetch the files for the charm or not.
+        @param channel Optional channel name.
+        @param include_stats Optionally disable stats collection.
+        @param includes An optional list of meta info to include, as a
+               sequence of strings. If None, the default include list is used.
+        '''
+        includes = kwargs.get('includes')
+        if not includes:
+            includes = kwargs["includes"] = CharmStore.DEFAULT_INCLUDES + ["id"]
+
+        result = self._cs.entity(*args, **kwargs)
+        if "resources" in includes:
+            resources = self._resources(result["Id"], channel=kwargs.get("channel"))
+            result['Meta']['resources'] = resources
+        return result
 
     def __getattr__(self, name):
         """
         Wrap method calls in coroutines that use run_in_executor to make them
         async.
         """
-        attr = getattr(self._cs, name)
+        if name == "entity":
+            attr = self._entity
+        else:
+            attr = getattr(self._cs, name)
         if not callable(attr):
             wrapper = partial(getattr, self._cs, name)
             setattr(self, name, wrapper)

--- a/juju/model.py
+++ b/juju/model.py
@@ -495,6 +495,11 @@ class CharmStoreDeployType:
         self.charmstore = charmstore
         self.get_series = get_series
 
+    @staticmethod
+    def _default_app_name(meta):
+        suggested_name = meta.get('charm-metadata', {}).get('Name')
+        return suggested_name or meta.get('id', {}).get('Name')
+
     async def resolve(self, url, architecture, app_name=None, channel=None, series=None, entity_url=None):
         """resolve attempts to resolve charmstore charms or bundles. A request
         to the charmstore is required to get more information about the
@@ -510,7 +515,7 @@ class CharmStoreDeployType:
             series = self.get_series(entity_url, result)
 
         if app_name is None and not is_bundle:
-            app_name = result['Meta']['charm-metadata']['Name']
+            app_name = self._default_app_name(result['Meta'])
 
         origin = client.CharmOrigin(source="charm-store",
                                     architecture=architecture,


### PR DESCRIPTION
some API's responses were lost during the transition to charmhub api responses.  To restore the api of python-libjuju wrap those API responses in a new method


* specifically the `charm-metadata` response is no longer available from charmhub -- so i've replaced that with the `Meta.id` field
* secondly, the `resources` response is no longer available from charmhub when fetching `/meta/any` URL
    * this wraps the `charmstore.entity(...)` call to provide `/meta/resources` in its response output
