### PR TITLE
[JUJU-704] Remove non-implemented (stuıb) functions

### DIFF
--- a/juju/application.py
+++ b/juju/application.py
@@ -175,21 +175,6 @@ class Application(model.ModelEntity):
                                           scale_change=scale_change)
         ])
 
-    def attach(self, resource_name, file_path):
-        """Upload a file as a resource for this application.
-
-        :param str resource: Name of the resource
-        :param str file_path: Path to the file to upload
-
-        """
-        raise NotImplementedError()
-
-    def collect_metrics(self):
-        """Collect metrics on this application.
-
-        """
-        raise NotImplementedError()
-
     async def destroy_relation(self, local_relation, remote_relation):
         """Remove a relation to another application.
 
@@ -581,31 +566,6 @@ class Application(model.ModelEntity):
             'Setting constraints for %s: %s', self.name, constraints)
 
         return await app_facade.SetConstraints(application=self.name, constraints=constraints)
-
-    def set_meter_status(self, status, info=None):
-        """Set the meter status on this status.
-
-        :param str status: Meter status, e.g. 'RED', 'AMBER'
-        :param str info: Extra info message
-
-        """
-        raise NotImplementedError()
-
-    def set_plan(self, plan_name):
-        """Set the plan for this application, effective immediately.
-
-        :param str plan_name: Name of plan
-
-        """
-        raise NotImplementedError()
-
-    def update_allocation(self, allocation):
-        """Update existing allocation for this application.
-
-        :param int allocation: The allocation to set
-
-        """
-        raise NotImplementedError()
 
     async def refresh(
             self, channel=None, force=False, force_series=False, force_units=False,

--- a/juju/client/jujudata.py
+++ b/juju/client/jujudata.py
@@ -18,68 +18,6 @@ class NoModelException(Exception):
 class JujuData:
     __metaclass__ = abc.ABCMeta
 
-    @abc.abstractmethod
-    def current_controller(self):
-        '''Return the current controller name'''
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def controllers(self):
-        '''Return all the currently known controllers as a dict
-        mapping controller name to a dict containing the
-        following string keys:
-        uuid: The UUID of the controller
-        api-endpoints: A list of host:port addresses for the controller.
-        ca-cert: the PEM-encoded CA cert of the controller (optional)
-
-        This is compatible with the "controllers" entry in the YAML-unmarshaled data
-        stored in ~/.local/share/juju/controllers.yaml.
-        '''
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def models(self):
-        '''Return all the currently known models as a dict
-        containing a key for each known controller,
-        each holding a dict value containing an optional "current-model"
-        key (the name of the current model for that controller,
-        if there is one), and a dict mapping fully-qualified
-        model names to a dict containing a "uuid" key with the
-        key for that model.
-        This is compatible with the YAML-unmarshaled data
-        stored in ~/.local/share/juju/models.yaml.
-        '''
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def accounts(self):
-        '''Return the currently known accounts, as a dict
-        containing a key for each known controller, with
-        each value holding a dict with the following keys:
-
-        user: The username to use when logging into the controller (str)
-        password: The password to use when logging into the controller (str, optional)
-        '''
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def cookies_for_controller(self, controller_name):
-        '''Return the cookie jar to use when connecting to the
-        controller with the given name.
-        :return http.cookiejar.CookieJar
-        '''
-        raise NotImplementedError()
-
-    @abc.abstractmethod
-    def current_model(self, controller_name=None, model_only=False):
-        '''Return the current model, qualified by its controller name.
-        If controller_name is specified, the current model for
-        that controller will be returned.
-        If model_only is true, only the model name, not qualified by
-        its controller name, will be returned.
-        '''
-        raise NotImplementedError()
-
     def parse_model(self, model):
         """Split the given model_name into controller and model parts.
         If the controller part is empty, the current controller will be used.

--- a/juju/client/proxy/proxy.py
+++ b/juju/client/proxy/proxy.py
@@ -1,5 +1,7 @@
 from abc import abstractmethod
 
+from juju.errors import AbstractMethodError
+
 
 class ProxyNotConnectedError(Exception):
     pass
@@ -12,12 +14,12 @@ class Proxy():
 
     @abstractmethod
     def connect(self):
-        raise NotImplementedError()
+        raise AbstractMethodError()
 
     @abstractmethod
     def close(self):
-        raise NotImplementedError()
+        raise AbstractMethodError()
 
     @abstractmethod
     def socket(self):
-        raise NotImplementedError()
+        raise AbstractMethodError()

--- a/juju/controller.py
+++ b/juju/controller.py
@@ -479,13 +479,6 @@ class Controller:
         entity = client.Entity(tag.user(username))
         return await user_facade.EnableUser(entities=[entity])
 
-    def kill(self):
-        """Forcibly terminate all machines and other associated resources for
-        this controller.
-
-        """
-        raise NotImplementedError()
-
     async def cloud(self, name=None):
         """Get Cloud
 
@@ -575,39 +568,6 @@ class Controller:
         """
         uuids = await self.model_uuids(username, all)
         return sorted(uuids.keys())
-
-    def get_payloads(self, *patterns):
-        """Return list of known payloads.
-
-        :param str *patterns: Patterns to match against
-
-        Each pattern will be checked against the following info in Juju::
-
-            - unit name
-            - machine id
-            - payload type
-            - payload class
-            - payload id
-            - payload tag
-            - payload status
-
-        """
-        raise NotImplementedError()
-
-    def login(self):
-        """Log in to this controller.
-
-        """
-        raise NotImplementedError()
-
-    def logout(self, force=False):
-        """Log out of this controller.
-
-        :param bool force: Don't fail even if user not previously logged in
-            with a password
-
-        """
-        raise NotImplementedError()
 
     async def get_current_user(self, secret_key=None):
         """Returns the user object associated with the current connection.

--- a/juju/errors.py
+++ b/juju/errors.py
@@ -103,3 +103,7 @@ class JujuApplicationConfigError(JujuConfigError):
 
 class JujuModelConfigError(JujuConfigError):
     pass
+
+
+class AbstractMethodError(Exception):
+    pass

--- a/juju/juju.py
+++ b/juju/juju.py
@@ -8,73 +8,11 @@ class Juju(object):
     def __init__(self, jujudata=None):
         self.jujudata = jujudata or FileJujuData()
 
-    def add_cloud(self, name, definition, replace=False):
-        """Add a user-defined cloud to Juju from among known cloud types.
-
-        :param str name: Name of cloud
-        :param dict definition: Cloud definition
-
-        Example cloud definition, as yaml::
-
-            type: openstack
-            auth-types: [ userpass ]
-            regions:
-              london:
-                endpoint: https://london.mycloud.com:35574/v3.0/
-
-        """
-        raise NotImplementedError()
-
-    def agree(self, *terms):
-        """Agree to the terms of a charm.
-
-        :param str *terms: Terms to agree to
-
-        """
-        raise NotImplementedError()
-
-    def autoload_credentials(self):
-        """Finds cloud credentials and caches them for use by Juju when
-        bootstrapping.
-
-        """
-        raise NotImplementedError()
-
-    def get_clouds(self):
-        """Return list of all available clouds.
-
-        """
-        raise NotImplementedError()
-
     def get_controllers(self):
         """Return list of all available controllers.
 
         """
         return self.jujudata.controllers()
-
-    def get_plans(self, charm_url):
-        """Return list of plans available for the specified charm.
-
-        :param str charm_url: Charm url
-
-        """
-        raise NotImplementedError()
-
-    def register(self, registration_string):
-        """Register a user to a controller.
-
-        :param str registration_string: The registration string
-
-        """
-        raise NotImplementedError()
-
-    def get_cloud(self, name):
-        """Get a cloud by name.
-
-        :param str name: Name of cloud
-
-        """
-        raise NotImplementedError()
 
     async def get_controller(self, name, include_passwords=False):
         """Get a controller by name.
@@ -96,15 +34,3 @@ class Juju(object):
         controller = Controller()
         await controller.connect(name)
         return controller
-
-    def update_clouds(self):
-        """Update public cloud info available to Juju.
-
-        """
-        raise NotImplementedError()
-
-    def version(self):
-        """Return the Juju version.
-
-        """
-        raise NotImplementedError()

--- a/juju/machine.py
+++ b/juju/machine.py
@@ -32,15 +32,6 @@ class Machine(model.ModelEntity):
             'machine', self.id, 'remove')
     remove = destroy
 
-    def run(self, command, timeout=None):
-        """Run command on this machine.
-
-        :param str command: The command to run
-        :param int timeout: Time to wait before command is considered failed
-
-        """
-        raise NotImplementedError()
-
     async def get_annotations(self):
         """Get annotations on this machine.
 
@@ -170,15 +161,6 @@ class Machine(model.ModelEntity):
             raise JujuError("command failed: %s with %s" % (cmd, stderr.decode()))
         # stdout is a bytes-like object, returning a string might be more useful
         return stdout.decode()
-
-    def status_history(self, num=20, utc=False):
-        """Get status history for this machine.
-
-        :param int num: Size of history backlog
-        :param bool utc: Display time as UTC in RFC3339 format
-
-        """
-        raise NotImplementedError()
 
     @property
     def agent_status(self):

--- a/juju/model.py
+++ b/juju/model.py
@@ -1426,16 +1426,6 @@ class Model:
         return await key_facade.AddKeys(ssh_keys=[key], user=user)
     add_ssh_keys = add_ssh_key
 
-    def add_subnet(self, cidr_or_id, space, *zones):
-        """Add an existing subnet to this model.
-
-        :param str cidr_or_id: CIDR or provider ID of the existing subnet
-        :param str space: Network space with which to associate
-        :param str *zones: Zone(s) in which the subnet resides
-
-        """
-        raise NotImplementedError()
-
     async def get_backups(self):
         """Retrieve metadata for backups in this model.
 
@@ -1447,31 +1437,6 @@ class Model:
         if 'list' not in backups_metadata:
             raise JujuAPIError("Unexpected response metadata : %s" % backups_metadata)
         return backups_metadata['list']
-
-    def block(self, *commands):
-        """Add a new block to this model.
-
-        :param str *commands: The commands to block. Valid values are
-            'all-changes', 'destroy-model', 'remove-object'
-
-        """
-        raise NotImplementedError()
-
-    def get_blocks(self):
-        """List blocks for this model.
-
-        """
-        raise NotImplementedError()
-
-    def get_cached_images(self, arch=None, kind=None, series=None):
-        """Return a list of cached OS images.
-
-        :param str arch: Filter by image architecture
-        :param str kind: Filter by image kind, e.g. 'lxd'
-        :param str series: Filter by image series, e.g. 'xenial'
-
-        """
-        raise NotImplementedError()
 
     async def create_backup(self, notes=None):
         """Create a backup of this model.
@@ -1498,16 +1463,6 @@ class Model:
         file_name = self.download_backup(backup_id)
 
         return file_name, backup_metadata
-
-    def create_storage_pool(self, name, provider_type, **pool_config):
-        """Create or define a storage pool.
-
-        :param str name: Name to give the storage pool
-        :param str provider_type: Pool provider type
-        :param **pool_config: key/value pool configuration pairs
-
-        """
-        raise NotImplementedError()
 
     async def debug_log(
             self, target=sys.stdout, no_tail=False, exclude_module=[],
@@ -1957,12 +1912,6 @@ class Model:
             raise JujuError('\n'.join(errors))
         return await self._wait_for_new('application', application)
 
-    async def destroy(self):
-        """Terminate all machines and resources for this model.
-            Is already implemented in controller.py.
-        """
-        raise NotImplementedError()
-
     async def destroy_unit(self, *unit_names):
         """Destroy units by name.
 
@@ -2016,25 +1965,6 @@ class Model:
         log.info("Backup archive downloaded in : %s" % file_name)
         return file_name
 
-    def enable_ha(
-            self, num_controllers=0, constraints=None, series=None, to=None):
-        """Ensure sufficient controllers exist to provide redundancy.
-
-        :param int num_controllers: Number of controllers to make available
-        :param constraints: Constraints to apply to the controller machines
-        :type constraints: :class:`juju.Constraints`
-        :param str series: Series of the controller machines
-        :param list to: Placement directives for controller machines, e.g.::
-
-            '23' - machine 23
-            'lxc:7' - new lxc container on machine 7
-            '24/lxc/3' - lxc container 3 or machine 24
-
-            If None, a new machine is provisioned.
-
-        """
-        raise NotImplementedError()
-
     async def get_config(self):
         """Return the configuration settings for this model.
 
@@ -2075,26 +2005,11 @@ class Model:
                                                       constraint)
         return constraints
 
-    def import_ssh_key(self, identity):
-        """Add a public SSH key from a trusted indentity source to this model.
-
-        :param str identity: User identity in the form <lp|gh>:<username>
-
-        """
-        raise NotImplementedError()
-    import_ssh_keys = import_ssh_key
-
     async def get_machines(self):
         """Return list of machines in this model.
 
         """
         return list(self.state.machines.keys())
-
-    def get_shares(self):
-        """Return list of all users with access to this model.
-
-        """
-        raise NotImplementedError()
 
     async def get_spaces(self):
         """Return list of all known spaces, including associated subnets.
@@ -2117,39 +2032,6 @@ class Model:
         return await key_facade.ListKeys(entities=entities, mode=raw_ssh)
     get_ssh_keys = get_ssh_key
 
-    def get_storage(self, filesystem=False, volume=False):
-        """Return details of storage instances.
-
-        :param bool filesystem: Include filesystem storage
-        :param bool volume: Include volume storage
-
-        """
-        raise NotImplementedError()
-
-    def get_storage_pools(self, names=None, providers=None):
-        """Return list of storage pools.
-
-        :param list names: Only include pools with these names
-        :param list providers: Only include pools for these providers
-
-        """
-        raise NotImplementedError()
-
-    def get_subnets(self, space=None, zone=None):
-        """Return list of known subnets.
-
-        :param str space: Only include subnets in this space
-        :param str zone: Only include subnets in this zone
-
-        """
-        raise NotImplementedError()
-
-    def remove_blocks(self):
-        """Remove all blocks from this model.
-
-        """
-        raise NotImplementedError()
-
     async def remove_backup(self, backup_id):
         """Delete a backup.
 
@@ -2167,25 +2049,6 @@ class Model:
         """
         backups_facade = client.BackupsFacade.from_connection(self.connection())
         return await backups_facade.Remove(backup_ids)
-
-    def remove_cached_images(self, arch=None, kind=None, series=None):
-        """Remove cached OS images.
-
-        :param str arch: Architecture of the images to remove
-        :param str kind: Image kind to remove, e.g. 'lxd'
-        :param str series: Image series to remove, e.g. 'xenial'
-
-        """
-        raise NotImplementedError()
-
-    def remove_machine(self, *machine_ids):
-        """Remove a machine from this model.
-
-        :param str *machine_ids: Ids of the machines to remove
-
-        """
-        raise NotImplementedError()
-    remove_machines = remove_machine
 
     async def remove_ssh_key(self, user, key):
         """Remove a public SSH key(s) from this model.
@@ -2215,21 +2078,6 @@ class Model:
 
         """
         raise DeprecationWarning("juju restore-backup is deprecated in favor of the stand-alone 'juju-restore' tool: https://github.com/juju/juju-restore")
-
-    def retry_provisioning(self):
-        """Retry provisioning for failed machines.
-
-        """
-        raise NotImplementedError()
-
-    def run(self, command, timeout=None):
-        """Run command on all machines in this model.
-
-        :param str command: The command to run
-        :param int timeout: Time to wait before command is considered failed
-
-        """
-        raise NotImplementedError()
 
     async def set_config(self, config):
         """Set configuration keys on this model.
@@ -2335,69 +2183,6 @@ class Model:
         """
         client_facade = client.ClientFacade.from_connection(self.connection())
         return await client_facade.FullStatus(patterns=filters)
-
-    def sync_tools(
-            self, all_=False, destination=None, dry_run=False, public=False,
-            source=None, stream=None, version=None):
-        """Copy Juju tools into this model.
-
-        :param bool all_: Copy all versions, not just the latest
-        :param str destination: Path to local destination directory
-        :param bool dry_run: Don't do the actual copy
-        :param bool public: Tools are for a public cloud, so generate mirrors
-            information
-        :param str source: Path to local source directory
-        :param str stream: Simplestreams stream for which to sync metadata
-        :param str version: Copy a specific major.minor version
-
-        """
-        raise NotImplementedError()
-
-    def unblock(self, *commands):
-        """Unblock an operation that would alter this model.
-
-        :param str *commands: The commands to unblock. Valid values are
-            'all-changes', 'destroy-model', 'remove-object'
-
-        """
-        raise NotImplementedError()
-
-    def unset_config(self, *keys):
-        """Unset configuration on this model.
-
-        :param str *keys: The keys to unset
-
-        """
-        raise NotImplementedError()
-
-    def upgrade_gui(self):
-        """Upgrade the Juju GUI for this model.
-
-        """
-        raise NotImplementedError()
-
-    def upgrade_juju(
-            self, dry_run=False, reset_previous_upgrade=False,
-            upload_tools=False, version=None):
-        """Upgrade Juju on all machines in a model.
-
-        :param bool dry_run: Don't do the actual upgrade
-        :param bool reset_previous_upgrade: Clear the previous (incomplete)
-            upgrade status
-        :param bool upload_tools: Upload local version of tools
-        :param str version: Upgrade to a specific version
-
-        """
-        raise NotImplementedError()
-
-    def upload_backup(self, archive_path):
-        """Store a backup archive remotely in Juju.
-
-        :param str archive_path: Path to local archive
-        :return str created backup ID
-
-        """
-        raise NotImplementedError()
 
     async def get_metrics(self, *tags):
         """Retrieve metrics.

--- a/juju/relation.py
+++ b/juju/relation.py
@@ -149,7 +149,3 @@ class Relation(model.ModelEntity):
         All applications involved in this relation.
         """
         return [ep.application for ep in self.endpoints]
-
-    async def destroy(self):
-        raise NotImplementedError()
-        # TODO: destroy a relation

--- a/juju/unit.py
+++ b/juju/unit.py
@@ -77,22 +77,6 @@ class Unit(model.ModelEntity):
     def tag(self):
         return tag.unit(self.name)
 
-    def add_storage(self, name, constraints=None):
-        """Add unit storage dynamically.
-
-        :param str name: Storage name, as specified by the charm
-        :param str constraints: Comma-separated list of constraints in the
-            form 'POOL,COUNT,SIZE'
-
-        """
-        raise NotImplementedError()
-
-    def collect_metrics(self):
-        """Collect metrics on this unit.
-
-        """
-        raise NotImplementedError()
-
     async def destroy(self):
         """Destroy this unit.
 
@@ -119,15 +103,6 @@ class Unit(model.ModelEntity):
         if defResult is not None and len(defResult.results) > 1:
             raise JujuAPIError("expected one result")
         return defResult.results[0].result.get('public-address', None)
-
-    def get_resources(self, details=False):
-        """Return resources for this unit.
-
-        :param bool details: Include detailed info about resources used by each
-            unit
-
-        """
-        raise NotImplementedError()
 
     async def resolved(self, retry=False):
         """Mark unit errors resolved.
@@ -234,12 +209,6 @@ class Unit(model.ModelEntity):
         await self.machine.scp_from(source, destination, user=user,
                                     proxy=proxy, scp_opts=scp_opts)
 
-    def set_meter_status(self):
-        """Set the meter status on this unit.
-
-        """
-        raise NotImplementedError()
-
     async def ssh(
             self, command, user='ubuntu', proxy=False, ssh_opts=None):
         """Execute a command over SSH on this unit.
@@ -251,15 +220,6 @@ class Unit(model.ModelEntity):
 
         """
         return await self.machine.ssh(command, user, proxy, ssh_opts)
-
-    def status_history(self, num=20, utc=False):
-        """Get status history for this unit.
-
-        :param int num: Size of history backlog
-        :param bool utc: Display time as UTC in RFC3339 format
-
-        """
-        raise NotImplementedError()
 
     async def is_leader_from_status(self):
         """


### PR DESCRIPTION
#### Description

This removes the stub functions that just raise `NotImplementedError`. Note that we still use that error for vaious sub-functionalities or corner cases that are yet to be implemented. This only removes the functions that stays in the code as stubs.

#### QA Steps

```sh
CI tests should pass.
```

#### Notes & Discussion

This also introduces `AbstractMethodError` for `@abstractmethod` functions to raise instead of raising the `NotImplementedError`.





