### PR TITLE
[JUJU-771] Auto switch to scale from add_unit on container based models

### DIFF
--- a/examples/charmhub_deploy_k8s.py
+++ b/examples/charmhub_deploy_k8s.py
@@ -24,9 +24,12 @@ async def main():
         )
 
         print('Waiting for active')
-        await model.block_until(
-            lambda: all(unit.workload_status == 'active'
-                        for unit in application.units))
+        await model.wait_for_idle(status="active")
+
+        # when run on a container based model it should auto-switch to
+        # scale instead of failing with JujuError
+        await application.add_unit(count=2)
+        await application.destroy()
 
     finally:
         print('Disconnecting from model')

--- a/juju/application.py
+++ b/juju/application.py
@@ -131,6 +131,11 @@ class Application(model.ModelEntity):
             If None, a new machine is provisioned.
 
         """
+
+        if self.model.info.type_ == 'caas':
+            log.warning('adding units to a container-based model not supported, auto-switching to scale')
+            return await self.scale(scale_change=count)
+
         app_facade = self._facade()
 
         log.debug(

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -623,7 +623,7 @@ async def test_local_oci_image_resource_charm(event_loop):
             lambda: (
                 len(charm.units) > 0 and
                 charm.units[0].workload_status in terminal_statuses),
-            timeout=60 * 4,
+            timeout=60 * 10,
         )
         assert charm.units[0].workload_status == 'active'
 


### PR DESCRIPTION
#### Description

This is a quality of life feature that automatically uses `scale` function when `add_unit` is used on a container based model (instead of failing with `JujuError` as it's current behavior).

Fixes #651 

#### QA Steps

For this you're gonna need a container based model, like:

```sh
juju bootstrap microk8s test
juju add-model test-model
```

Then:
```sh
python examples/charmhub_deploy_k8s.py
```
should complete wihtout an error.

#### Notes & Discussion

