### PR TITLE
[JUJU-835] Avoid ignoring asyncio exceptions in coroutines

### DIFF
--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -512,7 +512,7 @@ class Connection:
             # be cancelled by the reconnect and we don't want the reconnect
             # to be aborted half-way through
             jasyncio.ensure_future(self.reconnect())
-            return
+            raise
         except Exception as e:
             log.exception("Error in debug logger : %s" % e)
             jasyncio.create_task(self.close())
@@ -539,7 +539,7 @@ class Connection:
             # be cancelled by the reconnect and we don't want the reconnect
             # to be aborted half-way through
             jasyncio.ensure_future(self.reconnect())
-            return
+            raise
         except Exception as e:
             log.exception("Error in receiver")
             # make pending listeners aware of the error
@@ -576,7 +576,7 @@ class Connection:
             # The connection has closed - we can't do anything
             # more until the connection is restarted.
             log.debug('ping failed because of closed connection')
-            pass
+            raise
 
     async def rpc(self, msg, encoder=None):
         '''Make an RPC to the API. The message is encoded as JSON

--- a/juju/jasyncio.py
+++ b/juju/jasyncio.py
@@ -65,9 +65,9 @@ def create_task_with_handler(coro, task_name, logger=ROOT_LOGGER):
         try:
             task.result()
         except CancelledError:
-            pass
+            raise
         except websockets.exceptions.ConnectionClosed:
-            return
+            raise
         except Exception as e:
             # This really is an arbitrary exception we need to catch
             #
@@ -76,6 +76,7 @@ def create_task_with_handler(coro, task_name, logger=ROOT_LOGGER):
             # event_handler, which won't do anything but yell 'Task
             # exception was never retrieved' anyways.
             logger.exception("Task %s raised an exception: %s" % (task_name, e))
+            raise
 
     task = create_task(coro)
     task.add_done_callback(functools.partial(_task_result_exp_handler, task_name=task_name, logger=logger))


### PR DESCRIPTION
#### Description

Exceptions that happen when a coroutine is being destroyed are
ignored, but they cause backround noise such as "Exception ignored in
coroutine ..." exceptions etc. This change tries to propogate the
exceptions so that the asyncio base handler itself can ignore the
exception as an attempt to get rid of that exception ignored noise in
test outputs etc.

Should fix #657 

#### QA Steps

No such `Exception ignored in coroutine ...` output in tests. QAing this is a little weird, because the background exception (that is ignored by the GC by design) is an intermittent one.

#### Notes & Discussion







