### PR TITLE
[JUJU-843] Attach-resource to check if given binary file

### DIFF
--- a/juju/application.py
+++ b/juju/application.py
@@ -441,7 +441,8 @@ class Application(model.ModelEntity):
 
         headers['Content-Type'] = 'application/octet-stream'
         headers['Content-Length'] = len(data)
-        headers['Content-Sha384'] = hashlib.sha384(bytes(data, 'utf-8')).hexdigest()
+        data_bytes = data if isinstance(data, bytes) else bytes(data, 'utf-8')
+        headers['Content-Sha384'] = hashlib.sha384(data_bytes).hexdigest()
 
         file_name = str(file_name)
         if not file_name.startswith('./'):

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -660,6 +660,9 @@ async def test_attach_resource(event_loop):
         with open(str(charm_path / 'test.file')) as f:
             app.attach_resource('file-res', 'test.file', f)
 
+        with open(str(charm_path / 'test.file'), 'rb') as f:
+            app.attach_resource('file-res', 'test.file', f)
+
 
 @base.bootstrapped
 @pytest.mark.asyncio


### PR DESCRIPTION
#### Description

The `attach-resource` method on pylibjuju assumes the resource read is plain text, so it borks when it gets a binary file as a resource.

Fixes #654 

#### QA Steps

```sh
tox -e integration -- tests/integration/test_model.py::test_attach_resource
```

#### Notes & Discussion






