### PR TITLE
[JUJU-858] Add quality of life feature ensure application removal at return

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -875,6 +875,21 @@ class Model:
             lambda: len(self.machines) == 0
         )
 
+    async def remove_application(self, app_name, block_until_done=False):
+        """Removes the given application from the model.
+
+        :param str app_name: Name of the application
+        :param bool block_until_done: Ensure the app is removed from the
+        model when returned
+        """
+        if app_name not in self.applications:
+            raise JujuError("Given application doesn't seem to appear in the\
+             model: %s\nCurrent applications are: %s" %
+                            (app_name, self.applications))
+        await self.applications[app_name].remove()
+        if block_until_done:
+            await self.block_until(lambda: app_name not in self.applications)
+
     async def block_until(self, *conditions, timeout=None, wait_period=0.5):
         """Return only after all conditions are true.
 

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -235,3 +235,15 @@ async def test_trusted(event_loop):
         await ubuntu_app.set_trusted(False)
         trusted = await ubuntu_app.get_trusted()
         assert trusted is False
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_app_remove_wait_flag(event_loop):
+    async with base.CleanModel() as model:
+        app = await model.deploy('cs:ubuntu')
+        a_name = app.name
+        await model.wait_for_idle(status="active")
+
+        await model.remove_application(app.name, block_until_done=True)
+        assert a_name not in model.applications


### PR DESCRIPTION
#### Description

This is to make life easier by allowing the following pattern:

```python
    await ops_test.model.applications[related_app.name].remove()
    # Block until it is really gone. Added after an itest failed when tried to redeploy:
    # juju.errors.JujuError: ['cannot add application "related-app": application already exists']
    await ops_test.model.block_until(lambda: related_app.name not in ops_test.model.applications)
```

to be written as:

```python
    await ops_test.model.remove_application(related_app.name, block_until_done=True)
```


Fixes #656 

#### QA Steps

```sh
tox -e integration -- tests/integration/test_application.py::test_app_remove_wait_flag
```

#### Notes & Discussion

Another option would be to do `await ops_test.model.applications[related_app.name].remove(block_until_done=True)`, however, then it gets weird to ask the `app.model` to `block_until` the `app.name` is no longer in `model.applications` while the `app` object is being torn down.


