### PR TITLE
Update websockets library to work with Py3.10

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
     steps:
     - name: Check out code
       uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'pyyaml>=5.1.2,<=6.0',
         'theblues>=0.5.1,<1.0',
         'websockets>=7.0,<8.0 ; python_version<"3.9"',
-        'websockets>=8.0,<9.0 ; python_version>="3.9"',
+        'websockets>=10.1,<11.0 ; python_version>="3.9"',
         'paramiko>=2.4.0,<3.0.0',
         'pyasn1>=0.4.4',
         'toposort>=1.5,<2',

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = lint,py3,py35,py36,py37,py38,py39
+envlist = lint,py3,py35,py36,py37,py38,py39,py310
 skipsdist=True
 
 [pytest]


### PR DESCRIPTION
The current pin for websockets does not work for Python 3.10 due
to the change of the asyncio event loop API.