### PR TITLE
[JUJU-981] Get series from deployed app instead of metadata when charm upgrade

### DIFF
--- a/tests/charm-folder-symlink/metadata.yaml
+++ b/tests/charm-folder-symlink/metadata.yaml
@@ -2,6 +2,3 @@ name: simple
 summary: A simple example charm with the new operator framework
 description: |
     Simple is an example charm
-series:
-- xenial
-- bionic

--- a/tests/integration/bundle/cmr-bundle.yaml
+++ b/tests/integration/bundle/cmr-bundle.yaml
@@ -1,12 +1,11 @@
-series: bionic
 saas:
-  mysql:
-    url: admin/{}.mysql
+  influxdb:
+    url: admin/{}.influxdb
 applications:
-  wordpress:
-    charm: wordpress
+  grafana:
+    charm: grafana
     channel: stable
     num_units: 1
 relations:
-- - wordpress:db
-  - mysql:db
+- - grafana:grafana-source
+  - influxdb:grafana-source

--- a/tests/integration/test_crossmodel.py
+++ b/tests/integration/test_crossmodel.py
@@ -165,20 +165,19 @@ async def test_add_bundle(event_loop):
                 raise
 
             await model_1.deploy(
-                'mysql',
-                application_name='mysql',
-                series='xenial',
+                'influxdb',
+                application_name='influxdb',
                 channel='stable',
             )
-            assert 'mysql' in model_1.applications
+            assert 'influxdb' in model_1.applications
             await model_1.wait_for_idle(status="active")
 
-            await model_1.create_offer("mysql:db")
+            await model_1.create_offer("influxdb:grafana-source")
 
             offers = await model_1.list_offers()
 
             await model_1.block_until(
-                lambda: all(offer.application_name == 'mysql'
+                lambda: all(offer.application_name == 'influxdb'
                             for offer in offers.results),
                 timeout=60 * wait_for_min)
 
@@ -187,4 +186,4 @@ async def test_add_bundle(event_loop):
                 await model_2.deploy('local:{}'.format(tmp_path))
                 await model_2.wait_for_idle(status="active")
 
-            await model_1.remove_offer("admin/{}.mysql".format(model_1.info.name), force=True)
+            await model_1.remove_offer("admin/{}.influxdb".format(model_1.info.name), force=True)

--- a/tests/integration/upgrade-charm/metadata.yaml
+++ b/tests/integration/upgrade-charm/metadata.yaml
@@ -1,5 +1,5 @@
 name: ubuntu
-series: ["focal"]
+series: ["bionic", "focal"]
 summary: "test"
 description: "test"
 maintainers: ["test"]


### PR DESCRIPTION
#### Description

Charmhub is modeling the charm data separately from where the charm is deployed, therefore the series is not a part of the metadata anymore. So instead of getting the series from the metadata we now get it from the deployed application first, then we try the model config, if everything fails then we look at the metadata as a last resort (mostly to keep backwards ompatibility).

Fixes #668 

#### QA Steps

The charm used for the integration test `test_upgrade_local_charm` has been updated to simulate what's happening in #668 (now it has multiple series where the first one is not the one that the charm was initially deployed on), so along with the rest of the CI tests, the following should pass with this change (which fails without the change):

```sh
tox -e integration -- tests/integration/test_application.py::test_upgrade_local_charm
```

#### Notes & Discussion

I initially thought that this would be a breaking change (needs a version bump), however, we're still keeping the old way of getting the series in case the new ways fail, so this shouldn't break anything.
