### PR TITLE
Revert "Avoid ignoring asyncio exceptions in coroutines"

### DIFF
--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -512,7 +512,7 @@ class Connection:
             # be cancelled by the reconnect and we don't want the reconnect
             # to be aborted half-way through
             jasyncio.ensure_future(self.reconnect())
-            raise
+            return
         except Exception as e:
             log.exception("Error in debug logger : %s" % e)
             jasyncio.create_task(self.close())
@@ -539,7 +539,7 @@ class Connection:
             # be cancelled by the reconnect and we don't want the reconnect
             # to be aborted half-way through
             jasyncio.ensure_future(self.reconnect())
-            raise
+            return
         except Exception as e:
             log.exception("Error in receiver")
             # make pending listeners aware of the error
@@ -576,7 +576,7 @@ class Connection:
             # The connection has closed - we can't do anything
             # more until the connection is restarted.
             log.debug('ping failed because of closed connection')
-            raise
+            pass
 
     async def rpc(self, msg, encoder=None):
         '''Make an RPC to the API. The message is encoded as JSON

--- a/juju/jasyncio.py
+++ b/juju/jasyncio.py
@@ -65,9 +65,9 @@ def create_task_with_handler(coro, task_name, logger=ROOT_LOGGER):
         try:
             task.result()
         except CancelledError:
-            raise
+            pass
         except websockets.exceptions.ConnectionClosed:
-            raise
+            return
         except Exception as e:
             # This really is an arbitrary exception we need to catch
             #
@@ -76,7 +76,6 @@ def create_task_with_handler(coro, task_name, logger=ROOT_LOGGER):
             # event_handler, which won't do anything but yell 'Task
             # exception was never retrieved' anyways.
             logger.exception("Task %s raised an exception: %s" % (task_name, e))
-            raise
 
     task = create_task(coro)
     task.add_done_callback(functools.partial(_task_result_exp_handler, task_name=task_name, logger=logger))


### PR DESCRIPTION
This reverts commit f7552bea44447d1e22eff473c9730e43b8d88d91. The suggested fix did not really solve the issue it was supposed to solve as it instead fails with `[Errno 9] Bad File Descriptor` crashing most of our tests.