### PR TITLE
[JUJU-1155] Avoid incorrectly setting `series: kubernetes` for sidecar charms in k8s bundles

### DIFF
--- a/examples/deploy_local_big_k8s_bundle.py
+++ b/examples/deploy_local_big_k8s_bundle.py
@@ -1,0 +1,33 @@
+"""
+This example:
+
+1. Connects to the current model
+2. Deploy a bundle and waits until it reports itself active
+3. Destroys the units and applications
+
+"""
+from juju import jasyncio
+from juju.model import Model
+
+
+async def main():
+    model = Model()
+    print('Connecting to model')
+    # Connect to current model with current user, per Juju CLI
+    await model.connect()
+
+    try:
+        print('Deploying bundle')
+        await model.deploy(
+            './examples/k8s-local-bundle/big-k8s-bundle.yaml',
+            channel='edge',
+            trust=True,
+        )
+    finally:
+        print('Disconnecting from model')
+        await model.disconnect()
+        print("Success")
+
+
+if __name__ == '__main__':
+    jasyncio.run(main())

--- a/examples/k8s-local-bundle/big-k8s-bundle.yaml
+++ b/examples/k8s-local-bundle/big-k8s-bundle.yaml
@@ -1,0 +1,12 @@
+bundle: kubernetes
+name: magma-orc8r
+description: |
+  Orchestrator is a Magma service that provides a simple and consistent way to 
+  configure and monitor the wireless network securely. The metrics acquired through the platform 
+  allows you to see the analytics and traffic flows of the wireless users through the Magma web UI.
+applications:
+  nms-magmalte:
+    charm: magma-nms-magmalte
+    channel: edge
+    scale: 1
+    trust: true

--- a/juju/bundle.py
+++ b/juju/bundle.py
@@ -257,6 +257,7 @@ class BundleHandler:
                     self.overlay_removed_charms.add(charm_name)
 
         self.bundle = await self._validate_bundle(self.bundle)
+
         if is_local:
             self.bundle = await self._handle_local_charms(self.bundle, bundle_dir)
 
@@ -316,6 +317,7 @@ class BundleHandler:
         deployed = dict()
 
         specs = self.applications_specs
+
         for name in self.applications:
             spec = specs[name]
             app = self.model.applications.get(name, None)
@@ -593,8 +595,7 @@ class AddApplicationChange(ChangeInfo):
             raise JujuError("expected origin to be valid for application {} and charm {} with channel {}".format(self.application, str(url), str(channel)))
 
         if self.series is None or self.series == "":
-            self.series = context.bundle.get("bundle",
-                                             context.bundle.get("series", None))
+            self.series = context.bundle.get("series", None)
 
         if Schema.CHARM_STORE.matches(url.schema):
             resources = await context.model._add_store_resources(


### PR DESCRIPTION
#### Description

This is a remnant of a cleanup we did when we removed the `series: kubernetes` from k8s bundles a while ago (we cleaned up a bunch of lines like this on libjuju as well, apparently forgot this one).  So turns out when we have a `bundle: kubernetes` in a k8s bundle, the `AddApplicationChange` (which is  what carries out the deploy really) incorrectly sets the series to `kubernetes`, which results in pods trying to get the image with the tag `jujusolutions/charm-base:kubernetes-kubernetes`. 

With this change, the series is not set incorrectly, and the images are pulled with the correct tag `jujusolutions/charm-base:ubuntu-20.04`, therefore we don't see any `ImagePullBackOff` errors on the pods.

Fixes #677 

#### QA Steps

Bootstrap and make sure you have a k8s model to work with.

There are two ways to QA this:

##### Long version:

Run the following and wait for all the units to initialize and get into active status.
```sh
  $ python examples/deploy_local_big_k8s_bundle.py
```

##### Short version:

Write this into a file named `test.yaml`:

```yaml
bundle: kubernetes
name: magma-orc8r
description: |
  Orchestrator is a Magma service that provides a simple and consistent way to 
  configure and monitor the wireless network securely. The metrics acquired through the platform 
  allows you to see the analytics and traffic flows of the wireless users through the Magma web UI.
applications:
  nms-magmalte:
    charm: magma-nms-magmalte
    channel: edge
    scale: 1
    trust: true
```

Deploy it with `pylibjuju`, i.e. run something like:

```python
async def main():
    model = Model()
    await model.connect()

    await model.deploy(
        'test.yaml',
        channel='edge',
        trust=True,
    )
    await model.disconnect()
```

Then run the following and make sure the STATUS of the `nms-magmalte` pod is `Running` and not `ImagePullBackOff`:

`microk8s kubectl get pods --all-namespaces`

