### PR TITLE
[JUJU-1172] Visiting the pylibjuju CI

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -1858,7 +1858,7 @@ class Model:
                 'description': '',
                 'fingerprint': '',
                 'name': name,
-                'path': path,
+                'path': Path(path).name,
                 'revision': 0,
                 'size': 0,
                 'type_': resource_type,

--- a/tests/bundle/mini-bundle.yaml
+++ b/tests/bundle/mini-bundle.yaml
@@ -1,4 +1,3 @@
-series: xenial
 applications:
   ghost:
     charm: "ghost"
@@ -6,7 +5,7 @@ applications:
     num_units: 1
   mysql:
     charm: "mysql"
-    channel: stable
+    channel: candidate
     num_units: 1
 relations:
   - ["ghost", "mysql"]

--- a/tests/integration/bundle-file-resource.yaml
+++ b/tests/integration/bundle-file-resource.yaml
@@ -1,0 +1,6 @@
+applications:
+  file-resource-charm:
+    charm: ./file-resource-charm
+    num_units: 1
+    resources:
+      file-res: ./file-resource-charm/test.file

--- a/tests/integration/bundle/bundle-include-file.yaml
+++ b/tests/integration/bundle/bundle-include-file.yaml
@@ -1,4 +1,3 @@
-series: xenial
 applications:
   ghost:
     charm: "ghost"
@@ -8,7 +7,7 @@ applications:
       config: include-file://config1.yaml
   mysql:
     charm: "mysql"
-    channel: stable
+    channel: candidate
     num_units: 1
   test:
     charm: "../charm"

--- a/tests/integration/bundle/test-overlays/bundle-with-overlay-multi.yaml
+++ b/tests/integration/bundle/test-overlays/bundle-with-overlay-multi.yaml
@@ -1,4 +1,3 @@
-series: xenial
 applications:
   ghost:
     charm: "ghost"
@@ -6,7 +5,7 @@ applications:
     num_units: 1
   mysql:
     charm: "mysql"
-    channel: stable
+    channel: candidate
     num_units: 1
 relations:
   - ["ghost", "mysql"]    

--- a/tests/integration/bundle/test-overlays/test-multi-overlay.yaml
+++ b/tests/integration/bundle/test-overlays/test-multi-overlay.yaml
@@ -11,5 +11,5 @@ applications:
   memcached:
   mysql:
     charm: "mysql"
-    channel: stable
+    channel: candidate
     num_units: 1

--- a/tests/integration/bundle/test-overlays/test-overlay.yaml
+++ b/tests/integration/bundle/test-overlays/test-overlay.yaml
@@ -7,7 +7,7 @@ applications:
     num_units: 1
   mysql:
     charm: "mysql"
-    channel: stable
+    channel: candidate
     num_units: 1  
 relations:
   - ["ghost", "mysql"]

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -23,8 +23,8 @@ from .. import base
 MB = 1
 GB = 1024
 SSH_KEY = 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsYMJGNGG74HAJha3n2CFmWYsOOaORnJK6VqNy86pj0MIpvRXBzFzVy09uPQ66GOQhTEoJHEqE77VMui7+62AcMXT+GG7cFHcnU8XVQsGM6UirCcNyWNysfiEMoAdZScJf/GvoY87tMEszhZIUV37z8PUBx6twIqMdr31W1J0IaPa+sV6FEDadeLaNTvancDcHK1zuKsL39jzAg7+LYjKJfEfrsQP+lj/EQcjtKqlhVS5kzsJVfx8ZEd0xhW5G7N6bCdKNalS8mKCMaBXJpijNQ82AiyqCIDCRrre2To0/i7pTjRiL0U9f9mV3S4NJaQaokR050w/ZLySFf6F7joJT mathijs@Qrama-Mathijs'  # noqa
-HERE_DIR = Path(__file__).absolute().parent
-TESTS_DIR = HERE_DIR.parent
+HERE_DIR = Path(__file__).absolute().parent  # tests/integration
+TESTS_DIR = HERE_DIR.parent  # tests/
 OVERLAYS_DIR = HERE_DIR / 'bundle' / 'test-overlays'
 
 
@@ -58,6 +58,20 @@ async def test_deploy_local_bundle_file(event_loop):
         assert ghost and mysql
         await model.block_until(lambda: (len(ghost.units) == 1 and
                                 len(mysql.units) == 1),
+                                timeout=60 * 4)
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_deploy_bundle_local_resource_relative_path(event_loop):
+    bundle_file_path = HERE_DIR / 'bundle-file-resource.yaml'
+
+    async with base.CleanModel() as model:
+        await model.deploy(str(bundle_file_path))
+
+        app = model.applications.get('file-resource-charm')
+        assert app
+        await model.block_until(lambda: (len(app.units) == 1),
                                 timeout=60 * 4)
 
 

--- a/tests/integration/test_unit.py
+++ b/tests/integration/test_unit.py
@@ -213,7 +213,7 @@ async def test_resolve_local(event_loop):
         )
 
         try:
-            await model.wait_for_idle(raise_on_error=False, idle_period=3)
+            await model.wait_for_idle(raise_on_error=False, idle_period=1)
             assert app.units[0].workload_status == 'error'
 
             await app.units[0].resolved()

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -347,7 +347,7 @@ class TestAddApplicationChangeRun:
         model._deploy.assert_called_once()
         model._deploy.assert_called_with(charm_url="cs:charm1",
                                          application="application",
-                                         series="kubernetes",
+                                         series=None,
                                          config="options",
                                          constraints="constraints",
                                          endpoint_bindings="endpoint_bindings",


### PR DESCRIPTION
#### Description

Looks like a unit test has slipped when we were landing #679 . This PR fixes that, along with other CI problems in pylibjuju.

#### QA Steps

CI tests should pass.

#### Notes & Discussion

This PR will act as a set of changes required to fix up the libjuju CI. There seems to be some configuration issues in juju-qa-jenkins too. 

~~This shouldn't land until we see all green in the CI.~~ We have some intermittent failures about internal event handling that will be addressed later.


- [x] So the time out we see in the integration tests are caused by the ephemeral node configurations on aws, the jobs spawn machines that are not powerful enough to run the tests within 120 mins (global timeout). https://github.com/juju/juju-qa-jenkins/pull/24 will fix that.

- [x] The `check-merge` job will be fixed when the [detect-merge-go-version](https://github.com/juju/juju-qa-jenkins/blob/0e87aff16e6e83908926292709b88cf6a153dd5f/jobs/github/github-check-merge.yml#L143) builder is excluded from the python-libjuju jobs.

