### PR TITLE
Fix conditional

### DIFF
--- a/juju/client/facade.py
+++ b/juju/client/facade.py
@@ -676,7 +676,7 @@ class Type:
             # assumes are in the form of a list
             d = {}
             for entry in data:
-                if '>' or '>=' in entry:
+                if '>' in entry or '>=' in entry:
                     # something like juju >= 2.9.31
                     i = entry.index('>')
                     key = entry[:i].strip()


### PR DESCRIPTION
This PR fixes a conditional (#685) that is [causing](https://github.com/canonical/prometheus-k8s-operator/runs/7582604302?check_suite_focus=true#step:4:1258) the following error:

```
  File "/home/runner/work/prometheus-k8s-operator/prometheus-k8s-operator/.tox/integration/lib/python3.8/site-packages/juju/client/facade.py", line 683, in from_json
    i = entry.index('>')
ValueError: substring not found
```