### PR TITLE
[JUJU-1534] Fix `model.connect_current()`

### DIFF
--- a/examples/config.py
+++ b/examples/config.py
@@ -37,12 +37,12 @@ async def main():
     # update and check app config
     await ubuntu_app.set_config({'tuning-level': 'fast'})
     config = await ubuntu_app.get_config()
-    assert(config['tuning-level']['value'] == 'fast')
+    assert (config['tuning-level']['value'] == 'fast')
 
     # update and check app constraints
     await ubuntu_app.set_constraints({'mem': 512 * MB})
     constraints = await ubuntu_app.get_constraints()
-    assert(constraints['mem'] == 512 * MB)
+    assert (constraints['mem'] == 512 * MB)
 
     await model.disconnect()
 

--- a/examples/relate.py
+++ b/examples/relate.py
@@ -17,14 +17,14 @@ from juju import jasyncio
 class MyRemoveObserver(ModelObserver):
     async def on_change(self, delta, old, new, model):
         if delta.type == 'remove':
-            assert(new.latest() == new)
-            assert(new.next() is None)
-            assert(new.dead)
-            assert(new.current)
-            assert(new.connected)
-            assert(new.previous().dead)
-            assert(not new.previous().current)
-            assert(not new.previous().connected)
+            assert (new.latest() == new)
+            assert (new.next() is None)
+            assert (new.dead)
+            assert (new.current)
+            assert (new.connected)
+            assert (new.previous().dead)
+            assert (not new.previous().current)
+            assert (not new.previous().connected)
 
 
 class MyModelObserver(ModelObserver):

--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -595,7 +595,7 @@ class Connection:
         '''
         self.__request_id__ += 1
         msg['request-id'] = self.__request_id__
-        if'params' not in msg:
+        if 'params' not in msg:
             msg['params'] = {}
         if "version" not in msg:
             msg['version'] = self.facades[msg['type']]

--- a/juju/controller.py
+++ b/juju/controller.py
@@ -499,7 +499,10 @@ class Controller:
         facade = client.ModelManagerFacade.from_connection(self.connection())
         if model_uuid is None:
             uuids = await self.model_uuids()
-            model_uuid = uuids[model_name]
+            try:
+                model_uuid = uuids[model_name]
+            except KeyError:
+                raise errors.JujuError("{} is not among the models in the controller : {}".format(model_name, uuids))
         entity = client.Entity(tag.model(model_uuid))
         _model_info_results = await facade.ModelInfo(entities=[entity])
         return _model_info_results.results[0].result

--- a/juju/model.py
+++ b/juju/model.py
@@ -690,14 +690,16 @@ class Model:
             await self.disconnect()
         model_name = model_uuid = None
         if 'endpoint' not in kwargs and len(args) < 2:
+            # Then we're using the model_name to pick the model
             if args and 'model_name' in kwargs:
                 raise TypeError('connect() got multiple values for model_name')
             elif args:
                 model_name = args[0]
             else:
                 model_name = kwargs.pop('model_name', None)
-            await self._connector.connect_model(model_name, **kwargs)
+            _, model_uuid = await self._connector.connect_model(model_name, **kwargs)
         else:
+            # Then we're using the endpoint to pick the model
             if 'model_name' in kwargs:
                 raise TypeError('connect() got values for both '
                                 'model_name and endpoint')

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -445,7 +445,7 @@ async def add_manual_machine_ssh(event_loop, is_root=False):
         def wait_for_network(container, timeout=30):
             """Wait for eth0 to have an ipv4 address."""
             starttime = time.time()
-            while(time.time() < starttime + timeout):
+            while time.time() < starttime + timeout:
                 time.sleep(1)
                 if 'eth0' in container.state().network:
                     addresses = container.state().network['eth0']['addresses']

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -1014,6 +1014,14 @@ async def test_connect_to_connection(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+async def test_connect_current(event_loop):
+    m = Model()
+    await m.connect_current()
+    assert m.is_connected()
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
 async def test_model_cache_update(event_loop):
     """Connecting to a new model shouldn't fail because the cache is not
     updated yet

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -170,6 +170,7 @@ class TestModelConnect(asynctest.TestCase):
     @pytest.mark.asyncio
     async def test_no_args(self, mock_connect_model, _):
         m = Model()
+        mock_connect_model.side_effect = [("_", "uuid")]
         await m.connect()
         mock_connect_model.assert_called_once_with(None)
 
@@ -177,6 +178,7 @@ class TestModelConnect(asynctest.TestCase):
     @pytest.mark.asyncio
     async def test_with_model_name(self, mock_connect_model, _):
         m = Model()
+        mock_connect_model.side_effect = [("_", "uuid")]
         await m.connect(model_name='foo')
         mock_connect_model.assert_called_once_with('foo')
 
@@ -184,6 +186,7 @@ class TestModelConnect(asynctest.TestCase):
     @pytest.mark.asyncio
     async def test_with_endpoint_but_no_uuid(self, mock_connect_model, _):
         m = Model()
+        mock_connect_model.side_effect = [("_", "uuid")]
         with self.assertRaises(TypeError):
             await m.connect(endpoint='0.1.2.3:4566')
         self.assertEqual(mock_connect_model.call_count, 0)
@@ -251,6 +254,7 @@ class TestModelConnect(asynctest.TestCase):
     @asynctest.patch('juju.client.connector.Connector.connect')
     async def test_with_posargs(self, mock_connect, mock_connect_model, _):
         m = Model()
+        mock_connect_model.side_effect = [("_", "uuid")]
         await m.connect('foo')
         mock_connect_model.assert_called_once_with('foo')
         with self.assertRaises(TypeError):


### PR DESCRIPTION
#### Description

This PR fixes the `model.connect_current()` call which currently fails at the after_connect where we pull up the model info. The reason of the failure is that we neither have a `model_name`, nor a `model_uuid` for the controller to pull up the info. To solve it, this change gets the `model_uuid` from the connector during connect (if we don't use the endpoints, in which case we don't have a problem to begin with).

#### QA Steps

This change also introduces an integration test, namely, `test_connect_current`, so the following should pass.

```
tox -e integration -- tests/integration/test_model.py::test_connect_current
```

#### Notes & Discussion



