### PR TITLE
[JUJU-1542] Fix run actions on units

### DIFF
--- a/juju/action.py
+++ b/juju/action.py
@@ -7,4 +7,4 @@ class Action(model.ModelEntity):
         return self.data['status']
 
     async def wait(self):
-        return await self.model.wait_for_action(self.id)
+        return await self.model.get_action_output(self.id)

--- a/juju/unit.py
+++ b/juju/unit.py
@@ -164,19 +164,19 @@ class Unit(model.ModelEntity):
 
         log.debug('Starting action `%s` on %s', action_name, self.name)
 
-        res = await action_facade.Enqueue(actions=[client.Action(
+        res = await action_facade.EnqueueOperation(actions=[client.Action(
             name=action_name,
             parameters=params,
             receiver=self.tag,
         )])
-        action = res.results[0].action
-        error = res.results[0].error
+        action = res.actions[0].result
+        error = res.actions[0].error
         if error and error.code == 'not found':
             raise ValueError('Action `%s` not found on %s' % (action_name,
                                                               self.name))
         elif error:
             raise Exception('Unknown action error: %s' % error.serialize())
-        action_id = action.tag[len('action-'):]
+        action_id = action[len('action-'):]
         log.debug('Action started as %s', action_id)
         # we mustn't use wait_for_action because that blocks until the
         # action is complete, rather than just being in the model


### PR DESCRIPTION
#### Description

This changes the function that's used for running an action on a unit from `Action.Enqueue` to `Action.EnqueueOperation`, because it's the most up to date one and also the former one is deprecated in `Action v7` facade.

- [ ] Should be merged after #697 has landed.

#### QA Steps

The qa steps I followed were with a k8s model. So get a controller on a k8s cloud. 
The following then should work fine.

```python
async def _get_password():
    model = Model()
    await model.connect()
    await model.deploy('zinc-k8s')
    await model.wait_for_idle(status="active")

    unit = model.applications['zinc-k8s'].units[0]
    action = await unit.run_action("get-admin-password")
    results = await action.wait()
    print(results["admin-password"])
    await model.disconnect()
```

#### Notes & Discussion

* Maybe we should also add an integration test with an example action to make sure we won't regress from this in the future.
