### PR TITLE
added get_relation_data in Unit

### DIFF
--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -59,7 +59,7 @@ ubuntu charm, then exits:
       model = Model()
 
       # Connect to the currently active Juju model
-      await model.connect_current()
+      await model.connect()
 
       try:
           # Deploy a single unit of the ubuntu charm, using the latest revision
@@ -119,7 +119,7 @@ and then, to connect to the current model and fetch status:
 
   >>> from juju.model import Model
   >>> model = Model()
-  >>> await model.connect_current()
+  >>> await model.connect()
   >>> status = await model.get_status()
 
 


### PR DESCRIPTION
This PR adds to `Unit` a `get_relation_data(endpoint:str, related_endpoint:str, remote:str)` method that returns 'raw' RelationData objects.

Fixes https://github.com/juju/python-libjuju/issues/699
Fixes https://github.com/juju/python-libjuju/issues/644
(somewhat) Fixes https://github.com/charmed-kubernetes/pytest-operator/issues/81

It would be nice, as a next step, to add a shortcut to access this data via the Relation object.

Note: this is untested code. Will finalize after a green light that this is indeed a good addition