### PR TITLE
[JUJU-1528] Add storage implementation

### DIFF
--- a/juju/application.py
+++ b/juju/application.py
@@ -126,10 +126,12 @@ class Application(model.ModelEntity):
 
         return await self.model.relate(local_relation, remote_relation)
 
-    async def add_unit(self, count=1, to=None):
+    async def add_unit(self, count=1, to=None, attach_storage=[]):
         """Add one or more units to this application.
 
         :param int count: Number of units to add
+        :param [str] attach_storage: Existing storage to attach to the deployed unit
+        (not available on k8s models)
         :param str to: Placement directive, e.g.::
             '23' - machine 23
             'lxc:7' - new lxc container on machine 7
@@ -153,6 +155,7 @@ class Application(model.ModelEntity):
             application=self.name,
             placement=parse_placement(to) if to else None,
             num_units=count,
+            attach_storage=attach_storage,
         )
 
         return await jasyncio.gather(*[

--- a/juju/model.py
+++ b/juju/model.py
@@ -985,7 +985,7 @@ class Model:
             raise JujuError(err.message)
         return [p.serialize() for p in res.results[0].storage_pools]
 
-    async def remove_storage(self,  *storage_ids, force=False, destroy_storage=False):
+    async def remove_storage(self, *storage_ids, force=False, destroy_storage=False):
         """Removes storage from the model.
 
         :param bool force: Remove storage even if it is currently attached

--- a/juju/model.py
+++ b/juju/model.py
@@ -951,6 +951,19 @@ class Model:
             res = await storage_facade.ListStorageDetails(filters=[])
         return res.results
 
+    async def show_storage_details(self, *storage_ids):
+        """Shows storage instance information.
+
+        :param []str storage_ids:
+        :return:
+        """
+        if not storage_ids:
+            raise JujuError("Expected at least one storage ID")
+
+        storage_facade = client.StorageFacade.from_connection(self.connection)
+        res = await storage_facade.StorageDetails(entities=[client.Entity(tag.storage(s)) for s in storage_ids])
+        return res.results
+
     async def list_storage_pools(self):
         """List storage pools.
 

--- a/juju/model.py
+++ b/juju/model.py
@@ -907,6 +907,24 @@ class Model:
             attrs=dict(_attrs)
         )])
 
+    async def remove_storage(self, force=False, destroy_storage=False, *storage_ids):
+        """Removes storage from the model.
+
+        :param force: Remove storage even if it is currently attached
+        :param destroy_storage: Remove the storage and destroy it
+        :param storage_ids:
+        :return:
+        """
+        if not storage_ids:
+            raise JujuError("Expected at least one storage ID")
+
+        storage_facade = client.StorageFacade.from_connection(self.connection)
+        return await storage_facade.Remove(storage=[client.RemoveStorageInstance(
+            destroy_storage=destroy_storage,
+            force=False,
+            tag=tag.storage(s)
+        ) for s in storage_ids])
+
     async def remove_application(self, app_name, block_until_done=False):
         """Removes the given application from the model.
 

--- a/juju/model.py
+++ b/juju/model.py
@@ -914,7 +914,7 @@ class Model:
         :return:
         """
         storage_facade = client.StorageFacade.from_connection(self.connection())
-        return await storage_facade.RemovePool(pools=[name])
+        return await storage_facade.RemovePool(pools=[client.StoragePoolDeleteArg(name)])
 
     async def update_storage_pool(self, name, attributes=""):
         """ Update storage pool attributes.

--- a/juju/model.py
+++ b/juju/model.py
@@ -907,12 +907,21 @@ class Model:
             attrs=dict(_attrs)
         )])
 
+    async def remove_storage_pool(self, name):
+        """Remove an existing storage pool.
+
+        :param str name:
+        :return:
+        """
+        storage_facade = client.StorageFacade.from_connection(self.connection)
+        return await storage_facade.RemovePool(pools=[name])
+
     async def remove_storage(self, force=False, destroy_storage=False, *storage_ids):
         """Removes storage from the model.
 
-        :param force: Remove storage even if it is currently attached
-        :param destroy_storage: Remove the storage and destroy it
-        :param storage_ids:
+        :param bool force: Remove storage even if it is currently attached
+        :param bool destroy_storage: Remove the storage and destroy it
+        :param []str storage_ids:
         :return:
         """
         if not storage_ids:

--- a/juju/model.py
+++ b/juju/model.py
@@ -970,7 +970,7 @@ class Model:
 
         storage_facade = client.StorageFacade.from_connection(self.connection())
         res = await storage_facade.StorageDetails(entities=[client.Entity(tag.storage(s)) for s in storage_ids])
-        return res.results
+        return [s.result.serialize() for s in res.results]
 
     async def list_storage_pools(self):
         """List storage pools.

--- a/juju/model.py
+++ b/juju/model.py
@@ -916,6 +916,23 @@ class Model:
         storage_facade = client.StorageFacade.from_connection(self.connection)
         return await storage_facade.RemovePool(pools=[name])
 
+    async def update_storage_pool(self, name, attributes=""):
+        """ Update storage pool attributes.
+
+        :param name:
+        :param attributes: "key=value key=value ..."
+        :return:
+        """
+        _attrs = dict([splt.split("=") for splt in attributes.split()])
+        if len(_attrs) == 0:
+            raise JujuError("Expected at least one attribute to update")
+
+        storage_facade = client.StorageFacade.from_connection(self.connection)
+        return await storage_facade.UpdatePool(pools=[client.StoragePool(
+            name=name,
+            attrs=_attrs,
+        )])
+
     async def remove_storage(self, force=False, destroy_storage=False, *storage_ids):
         """Removes storage from the model.
 

--- a/juju/model.py
+++ b/juju/model.py
@@ -933,6 +933,16 @@ class Model:
             attrs=_attrs,
         )])
 
+    async def list_storage_pools(self):
+        """List storage pools.
+
+        :return:
+        """
+        # TODO (cderici): Filter on pool type, name.
+        storage_facade = client.StorageFacade.from_connection(self.connection)
+        res = await storage_facade.ListPools(filters=[])
+        return res.results
+
     async def remove_storage(self, force=False, destroy_storage=False, *storage_ids):
         """Removes storage from the model.
 

--- a/juju/model.py
+++ b/juju/model.py
@@ -933,6 +933,24 @@ class Model:
             attrs=_attrs,
         )])
 
+    async def list_storage(self, filesystem=False, volume=False):
+        """Lists storage details.
+
+        :param bool filesystem: List filesystem storage
+        :param bool volume: List volume storage
+        :return:
+        """
+        storage_facade = client.StorageFacade.from_connection(self.connection)
+        if filesystem and volume:
+            raise JujuError("--filesystem and --volume can not be used together")
+        if filesystem:
+            res = await storage_facade.ListFilesystems(filters=[])
+        elif volume:
+            res = await storage_facade.ListVolumes(filters=[])
+        else:
+            res = await storage_facade.ListStorageDetails(filters=[])
+        return res.results
+
     async def list_storage_pools(self):
         """List storage pools.
 

--- a/juju/model.py
+++ b/juju/model.py
@@ -888,6 +888,25 @@ class Model:
             lambda: len(self.machines) == 0
         )
 
+    async def create_storage_pool(self, name, provider_type, attributes=""):
+        """Create or define a storage pool.
+
+        :param str name: a pool name
+        :param str provider_type: provider type (defaults to "kubernetes" for
+        Kubernetes models)
+        :param str attributes: attributes for configuration as space-separated pairs,
+        e.g. tags, size, path, etc.
+        :return:
+        """
+        _attrs = [splt.split("=") for splt in attributes.split()]
+
+        storage_facade = client.StorageFacade.from_connection(self.connection)
+        return await storage_facade.CreatePool(pools=[client.StoragePool(
+            name=name,
+            provider=provider_type,
+            attrs=dict(_attrs)
+        )])
+
     async def remove_application(self, app_name, block_until_done=False):
         """Removes the given application from the model.
 

--- a/juju/model.py
+++ b/juju/model.py
@@ -985,7 +985,7 @@ class Model:
             raise JujuError(err.message)
         return [p.serialize() for p in res.results[0].storage_pools]
 
-    async def remove_storage(self, force=False, destroy_storage=False, *storage_ids):
+    async def remove_storage(self,  *storage_ids, force=False, destroy_storage=False):
         """Removes storage from the model.
 
         :param bool force: Remove storage even if it is currently attached
@@ -997,11 +997,13 @@ class Model:
             raise JujuError("Expected at least one storage ID")
 
         storage_facade = client.StorageFacade.from_connection(self.connection())
-        return await storage_facade.Remove(storage=[client.RemoveStorageInstance(
+        ret = await storage_facade.Remove(storage=[client.RemoveStorageInstance(
             destroy_storage=destroy_storage,
-            force=False,
-            tag=tag.storage(s)
+            force=force,
+            tag=s,
         ) for s in storage_ids])
+        if ret.results[0].error:
+            raise JujuError(ret.results[0].error.message)
 
     async def remove_application(self, app_name, block_until_done=False):
         """Removes the given application from the model.

--- a/juju/tag.py
+++ b/juju/tag.py
@@ -43,8 +43,10 @@ def user(username):
 def application(app_name):
     return _prefix('application-', app_name)
 
+
 def storage(app_name):
     return _prefix('storage-', app_name)
+
 
 def unit(unit_name):
     return _prefix('unit-', unit_name.replace('/', '-'))

--- a/juju/tag.py
+++ b/juju/tag.py
@@ -43,6 +43,8 @@ def user(username):
 def application(app_name):
     return _prefix('application-', app_name)
 
+def storage(app_name):
+    return _prefix('storage-', app_name)
 
 def unit(unit_name):
     return _prefix('unit-', unit_name.replace('/', '-'))

--- a/juju/unit.py
+++ b/juju/unit.py
@@ -160,6 +160,25 @@ class Unit(model.ModelEntity):
             unit_tag=self.tag,
         ) for s_id in storage_ids])
 
+    async def detach_storage(self, force=False, *storage_ids):
+        """Detaches storage from units.
+
+        :param bool force: Forcefully detach storage
+        :param [str] storage_ids:
+        :return:
+        """
+        if not storage_ids:
+            raise JujuError("Expected at least one storage ID")
+
+        storage_facade = client.StorageFacade.from_connection(self.connection)
+        return await storage_facade.DetachStorage(
+            force=force,
+            ids=[client.StorageAttachmentIds(ids=[client.StorageAttachmentId(
+                storage_tag=tag.storage(s),
+                unit_tag=self.tag,
+            ) for s in storage_ids])]
+        )
+
     async def run(self, command, timeout=None):
         """Run command on this unit.
 

--- a/juju/unit.py
+++ b/juju/unit.py
@@ -120,6 +120,26 @@ class Unit(model.ModelEntity):
             retry=retry,
             tags={'entities': [{'tag': self.tag}]})
 
+    async def add_storage(self, storage_name, storage_constraint=""):
+        """Creates a storage and adds it to this unit.
+
+        :param: str storage_name: Name of the storage
+        :param: str storage_constraint: description of how Juju should provision storage instances for the unit.
+        The following three forms are accepted:
+        <storage-pool>[,<count>][,<size>]
+        <count>[,<size>]
+        <size>
+
+        :return:
+        """
+        # TODO (cderici) : storage_constraints
+
+        storage_facade = client.StorageFacade.from_connection(self.connection)
+        return await storage_facade.AddToUnit(storages=[client.StorageAddParams(
+            name=storage_name,
+            unit=tag.unit(self.name),
+        )])
+
     async def run(self, command, timeout=None):
         """Run command on this unit.
 

--- a/juju/unit.py
+++ b/juju/unit.py
@@ -165,7 +165,7 @@ class Unit(model.ModelEntity):
             unit_tag=self.tag,
         ) for s_id in storage_ids])
 
-    async def detach_storage(self, force=False, *storage_ids):
+    async def detach_storage(self, *storage_ids, force=False):
         """Detaches storage from units.
 
         :param bool force: Forcefully detach storage
@@ -176,13 +176,15 @@ class Unit(model.ModelEntity):
             raise JujuError("Expected at least one storage ID")
 
         storage_facade = client.StorageFacade.from_connection(self.connection)
-        return await storage_facade.DetachStorage(
+        ret = await storage_facade.DetachStorage(
             force=force,
-            ids=[client.StorageAttachmentIds(ids=[client.StorageAttachmentId(
+            ids=client.StorageAttachmentIds(ids=[client.StorageAttachmentId(
                 storage_tag=tag.storage(s),
                 unit_tag=self.tag,
-            ) for s in storage_ids])]
+            ) for s in storage_ids])
         )
+        if ret.results[0].error:
+            raise JujuError(ret.results[0].error.message)
 
     async def run(self, command, timeout=None):
         """Run command on this unit.

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -1077,3 +1077,15 @@ async def test_list_storage(event_loop):
         await model.list_storage(volume=True)
 
         assert any([tag.storage("pgdata") in s['storage-tag'] for s in storages])
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_storage_pools(event_loop):
+    async with base.CleanModel() as model:
+        await model.deploy('postgresql')
+        await model.wait_for_idle(status="active")
+
+        await model.create_storage_pool("test-pool", "lxd")
+        pools = await model.list_storage_pools()
+        assert "test-pool" in [p['name'] for p in pools]

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -1079,8 +1079,8 @@ async def test_detach_storage(event_loop):
         storage_details_1 = _storage_details_1[0]
         assert 'unit-postgresql-0' in storage_details_1['attachments']
 
-        await unit.detach_storage(storage_id)
-        await jasyncio.sleep(10)
+        await unit.detach_storage(storage_id, force=True)
+        await jasyncio.sleep(20)
 
         _storage_details_2 = await model.show_storage_details(storage_id)
         storage_details_2 = _storage_details_2[0]
@@ -1088,7 +1088,7 @@ async def test_detach_storage(event_loop):
             storage_details_2['attachments']['unit-postgresql-0'].life == 'dying'
 
         # remove_storage
-        await model.remove_storage(storage_id)
+        await model.remove_storage(storage_id, force=True)
         await jasyncio.sleep(10)
         storages = await model.list_storage()
         assert all([storage_id not in s['storage-tag'] for s in storages])

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -1089,3 +1089,8 @@ async def test_storage_pools(event_loop):
         await model.create_storage_pool("test-pool", "lxd")
         pools = await model.list_storage_pools()
         assert "test-pool" in [p['name'] for p in pools]
+
+        await model.remove_storage_pool("test-pool")
+        await jasyncio.sleep(5)
+        pools = await model.list_storage_pools()
+        assert "test-pool" not in [p['name'] for p in pools]

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -1066,6 +1066,29 @@ async def test_add_storage(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+async def test_detach_storage(event_loop):
+    async with base.CleanModel() as model:
+        app = await model.deploy('postgresql')
+        await model.wait_for_idle(status="active")
+        unit = app.units[0]
+        storage_ids = await unit.add_storage("pgdata")
+        storage_id = storage_ids[0]
+        await jasyncio.sleep(5)
+
+        _storage_details_1 = await model.show_storage_details(storage_id)
+        storage_details_1 = _storage_details_1[0]
+        assert 'unit-postgresql-0' in storage_details_1['attachments']
+
+        await unit.detach_storage(storage_id)
+        await jasyncio.sleep(10)
+
+        _storage_details_2 = await model.show_storage_details(storage_id)
+        storage_details_2 = _storage_details_2[0]
+        assert 'unit-postgresql-0' not in storage_details_2['attachments']
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
 async def test_list_storage(event_loop):
     async with base.CleanModel() as model:
         app = await model.deploy('postgresql')

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -1067,6 +1067,7 @@ async def test_add_storage(event_loop):
 @base.bootstrapped
 @pytest.mark.asyncio
 async def test_detach_storage(event_loop):
+    pytest.skip('detach/attach_storage inconsistent on Juju side, unable to test')
     async with base.CleanModel() as model:
         app = await model.deploy('postgresql')
         await model.wait_for_idle(status="active")

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -1062,3 +1062,18 @@ async def test_add_storage(event_loop):
         unit = app.units[0]
         ret = await unit.add_storage("pgdata")
         assert any([tag.storage("pgdata") in s for s in ret])
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_list_storage(event_loop):
+    async with base.CleanModel() as model:
+        app = await model.deploy('postgresql')
+        await model.wait_for_idle(status="active")
+        unit = app.units[0]
+        await unit.add_storage("pgdata")
+        storages = await model.list_storage()
+        await model.list_storage(filesystem=True)
+        await model.list_storage(volume=True)
+
+        assert any([tag.storage("pgdata") in s['storage-tag'] for s in storages])

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -1084,7 +1084,14 @@ async def test_detach_storage(event_loop):
 
         _storage_details_2 = await model.show_storage_details(storage_id)
         storage_details_2 = _storage_details_2[0]
-        assert 'unit-postgresql-0' not in storage_details_2['attachments']
+        assert ('unit-postgresql-0' not in storage_details_2['attachments']) or \
+            storage_details_2['attachments']['unit-postgresql-0'].life == 'dying'
+
+        # remove_storage
+        await model.remove_storage(storage_id)
+        await jasyncio.sleep(10)
+        storages = await model.list_storage()
+        assert all([storage_id not in s['storage-tag'] for s in storages])
 
 
 @base.bootstrapped

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -12,7 +12,7 @@ import paramiko
 
 import pylxd
 import pytest
-from juju import jasyncio
+from juju import jasyncio, tag
 from juju.client import client
 from juju.errors import JujuError, JujuUnitError, JujuConnectionError
 from juju.model import Model, ModelObserver
@@ -1051,3 +1051,14 @@ async def test_model_cache_update(event_loop):
         await model.disconnect()
         await m.disconnect()
         await controller.destroy_models(model_name)
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_add_storage(event_loop):
+    async with base.CleanModel() as model:
+        app = await model.deploy('postgresql')
+        await model.wait_for_idle(status="active")
+        unit = app.units[0]
+        ret = await unit.add_storage("pgdata")
+        assert any([tag.storage("pgdata") in s for s in ret])


### PR DESCRIPTION
#### Description

This adds the implementation of storage. In particular, it introduces the following functions:

`unit.add_storage()`
`unit.attach_storage()`
`model.create_storage_pool()`
`unit.detach_storage()`
`model.list_storage()`
`model.list_storage_pools()`
`model.remove_storage()`
`model.remove_storage_pool()`
`model.show_storage()`
`model.update_storage_pool()`

Also adds the `--attach-storage` parameter to the `application.add_unit`.

Fixes #694 and #695 

#### QA Steps

A couple of new tests are added to test the main functionality of storages and pools. In particular, all the following should pass:

```
tox -e integration -- tests/integration/test_model.py::test_add_storage
```

```
tox -e integration -- tests/integration/test_model.py::test_list_storage
```

```
tox -e integration -- tests/integration/test_model.py::test_storage_pools
```

#### Notes & Discussion

`attach_storage` & `detach_storage` seem to work inconsistently on Juju's side, we're currently investigating, possibly a launchpad bug is coming, which makes it difficult/impossible to test their behavior here, so we skip the tests for these at the moment.