### PR TITLE
[JUJU-1664] Add force, no-wait, destroy-storage params to app.destroy

### DIFF
--- a/juju/application.py
+++ b/juju/application.py
@@ -227,8 +227,7 @@ class Application(model.ModelEntity):
         """
 
         if no_wait and not force:
-            log.warning("Invalid parameters. Automatically setting the --force parameter to True.")
-            force = True
+            raise JujuError("--no-wait without --force is not valid")
 
         app_facade = self._facade()
 

--- a/juju/model.py
+++ b/juju/model.py
@@ -1005,10 +1005,13 @@ class Model:
         if ret.results[0].error:
             raise JujuError(ret.results[0].error.message)
 
-    async def remove_application(self, app_name, block_until_done=False):
+    async def remove_application(self, app_name, block_until_done=False, force=False, destroy_storage=False, no_wait=False):
         """Removes the given application from the model.
 
         :param str app_name: Name of the application
+        :param bool force: Completely remove an application and all its dependencies. (=false)
+        :param bool destroy_storage: Destroy storage attached to application unit. (=false)
+        :param bool no_wait: Rush through application removal without waiting for each individual step to complete (=false)
         :param bool block_until_done: Ensure the app is removed from the
         model when returned
         """
@@ -1016,7 +1019,10 @@ class Model:
             raise JujuError("Given application doesn't seem to appear in the\
              model: %s\nCurrent applications are: %s" %
                             (app_name, self.applications))
-        await self.applications[app_name].remove()
+        await self.applications[app_name].remove(destroy_storage=destroy_storage,
+                                                 force=force,
+                                                 no_wait=no_wait,
+                                                 )
         if block_until_done:
             await self.block_until(lambda: app_name not in self.applications)
 

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -249,7 +249,10 @@ async def test_app_destroy(event_loop):
         await model.wait_for_idle(status="active")
         assert a_name in model.applications
         await app.destroy(destroy_storage=True, force=True, no_wait=True)
-        await jasyncio.sleep(10)
+        await model.block_until(
+            lambda: a_name not in model.applications,
+            timeout=60,
+        )
         assert a_name not in model.applications
 
 

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -242,6 +242,19 @@ async def test_trusted(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+async def test_app_destroy(event_loop):
+    async with base.CleanModel() as model:
+        app = await model.deploy('ubuntu')
+        a_name = app.name  # accessing name is impossible after the app is destroyed
+        await model.wait_for_idle(status="active")
+        assert a_name in model.applications
+        await app.destroy(destroy_storage=True, force=True, no_wait=True)
+        await jasyncio.sleep(10)
+        assert a_name not in model.applications
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
 async def test_app_remove_wait_flag(event_loop):
     async with base.CleanModel() as model:
         app = await model.deploy('ubuntu')


### PR DESCRIPTION
#### Description

This PR adds the parameters `force`, `no_wait` and `destroy_storage` parameters to `Application.destroy()`.

Fixes #645

#### QA Steps

```
tox -e integration -- tests/integration/test_application.py::test_app_destroy
```

```
tox -e integration -- tests/integration/test_application.py::test_app_remove_wait_flag
```


#### Notes & Discussion

