### PR TITLE
snapcraft.io access should use https requests

### DIFF
--- a/juju/charmhub.py
+++ b/juju/charmhub.py
@@ -21,7 +21,7 @@ class CharmHub:
     def get_charm_id(self, charm_name):
         conn, headers, path_prefix = self.model.connection().https_connection()
 
-        url = "http://api.snapcraft.io/v2/charms/info/{}".format(charm_name)
+        url = "https://api.snapcraft.io/v2/charms/info/{}".format(charm_name)
         _response = self.request_charmhub_with_retry(url, 5)
         response = json.loads(_response.text)
         return response['id'], response['name']
@@ -29,7 +29,7 @@ class CharmHub:
     def is_subordinate(self, charm_name):
         conn, headers, path_prefix = self.model.connection().https_connection()
 
-        url = "http://api.snapcraft.io/v2/charms/info/{}?fields=default-release.revision.subordinate".format(charm_name)
+        url = "https://api.snapcraft.io/v2/charms/info/{}?fields=default-release.revision.subordinate".format(charm_name)
         _response = self.request_charmhub_with_retry(url, 5)
         response = json.loads(_response.text)
         return 'subordinate' in response['default-release']['revision']


### PR DESCRIPTION
#### Description

This PR switches the charmhub api connection from `http` -> `https` to make sure we're not insisting on `http` when calling charmhub and get blocked by firewalls.

#### QA Steps

We have tests in place to test the calls to charmhub, so all the tests in `test_charmhub.py` should be passing:

```
tox -e integration -- tests/integration/test_charmhub.py
```

#### Notes & Discussion

Note that this is only a temporary patch. There's gonna be a another PR that will fetch the host address from the model configuration dynamically. 
