### PR TITLE
action.wait will block until complete/failed -- update to the latest entity

### DIFF
--- a/juju/action.py
+++ b/juju/action.py
@@ -16,4 +16,4 @@ class Action(model.ModelEntity):
 
     async def wait(self):
         self.results or await self.fetch_output()
-        return self
+        return self.latest()


### PR DESCRIPTION
`action.wait()` returns itself with updated `self.results`, but the `self.data` is stale.  

this can result in situations where the results have valid data, but `action.success` may say `pending` or `running` when in reality it's complete or failed.

to address this issue, return `self.latest()` which should return a new Action object that's got a valid `completed` or `failed` action