### PR TITLE
[JUJU-1663] Drop Python 3.5 support from python-libjuju

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.5"
           - "3.6"
           - "3.7"
           - "3.8"
@@ -32,7 +31,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.5"
           - "3.6"
           - "3.7"
           - "3.8"

--- a/debian/control
+++ b/debian/control
@@ -33,14 +33,14 @@ Description:
     Requirements
     ------------
     .
-    * Python 3.5+
+    * Python 3.6+
     * Juju 2.0+
     .
     .
     Design Notes
     ------------
     .
-    * Asynchronous - uses asyncio and async/await features of python 3.5
+    * Asynchronous - Uses asyncio and async/await features of Python
     * Websocket-level bindings are programmatically generated (indirectly) from the
     Juju golang code, ensuring full api coverage
     * Provides an OO layer which encapsulates much of the websocket api and

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -11,14 +11,14 @@ Documentation: https://pythonlibjuju.readthedocs.io/en/latest/
 Requirements
 ------------
 
-* Python 3.5+
+* Python 3.6+
 * Juju 2.0+
 
 
 Design Notes
 ------------
 
-* Asynchronous - uses asyncio and async/await features of python 3.5
+* Asynchronous - Uses asyncio and async/await features of Python
 * Websocket-level bindings are programmatically generated (indirectly) from the
   Juju golang code, ensuring full api coverage
 * Provides an OO layer which encapsulates much of the websocket api and

--- a/examples/add_machine.py
+++ b/examples/add_machine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.5
+#!/usr/bin/env python3
 
 """
 This example:

--- a/examples/machine_hostname.py
+++ b/examples/machine_hostname.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.5
+#!/usr/bin/env python3
 
 """
 This example:

--- a/juju/model.py
+++ b/juju/model.py
@@ -2009,10 +2009,7 @@ class Model:
 
                 data = yaml.dump(docker_image_details)
 
-                if sys.version_info[0:2] == (3, 5):
-                    hash_alg = hashlib.sha384
-                else:
-                    hash_alg = hashlib.sha3_384
+                hash_alg = hashlib.sha3_384
 
                 charmresource['fingerprint'] = hash_alg(bytes(data, 'utf-8')).digest()
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
         "Intended Audience :: Developers",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tests/integration/test_connection.py
+++ b/tests/integration/test_connection.py
@@ -147,12 +147,6 @@ class RedirectServer:
         if hasattr(ssl, 'PROTOCOL_TLS_SERVER'):
             # python 3.6+
             protocol = ssl.PROTOCOL_TLS_SERVER
-        elif hasattr(ssl, 'PROTOCOL_TLS'):
-            # python 3.5.3+
-            protocol = ssl.PROTOCOL_TLS
-        else:
-            # python 3.5.2
-            protocol = ssl.PROTOCOL_TLSv1_2
         self.ssl_context = ssl.SSLContext(protocol)
         crt_file = Path(__file__).with_name('cert.pem')
         key_file = Path(__file__).with_name('key.pem')

--- a/tests/integration/test_unit.py
+++ b/tests/integration/test_unit.py
@@ -21,12 +21,7 @@ async def test_block_coroutine(event_loop):
         )
 
         async def is_leader_elected():
-            # TODO: cleanup/refactor the code below when the py3.5
-            # support is dropped
-            for u in app.units:
-                if await u.is_leader_from_status():
-                    return True
-            return False
+            return any([await u.is_leader_from_status() for u in app.units])
 
         await utils.block_until_with_coroutine(is_leader_elected,
                                                timeout=480)

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -1122,10 +1122,6 @@ class TestBundleHandler:
 
         bundle = await handler._handle_local_charms(bundle, bundle_dir)
 
-        # TODO: for some reason 'assert_has_calls' is failing in
-        # Python3.5, refactor this with 'assert_has_calls' when
-        # Python3.5 support is dropped
-
         m1 = mock.call(
             "oci-image-charm",
             "charm_uri",

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,6 @@ deps =
     websockets
     kubernetes
     # use fork to pick up fix for https://github.com/aaugustin/websockets/pull/528
-    git+https://github.com/johnsca/websockets@bug/client-redirects#egg=websockets ; python_version<'3.6'
 
 [testenv:lint]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = lint,py3,py35,py36,py37,py38,py39,py310
+envlist = lint,py3,py36,py37,py38,py39,py310
 skipsdist=True
 
 [pytest]
@@ -37,14 +37,12 @@ deps =
     kubernetes
     # use fork to pick up fix for https://github.com/aaugustin/websockets/pull/528
     git+https://github.com/johnsca/websockets@bug/client-redirects#egg=websockets ; python_version<'3.6'
-    cffi <= 1.14.6 ; python_version<='3.5'
 
 [testenv:lint]
 commands =
     flake8 {posargs} juju tests examples
 deps =
     flake8
-    cffi <= 1.14.6 ; python_version<='3.5'
 
 [testenv:integration]
 envdir = {toxworkdir}/py3


### PR DESCRIPTION
#### Description

Python-libjuju no longer supports Python 3.5 (:tada:), following the Juju dropping support for xenial.


#### QA Steps

The PR on `juju-qa-jenkins` to remove the `Python3.5` tests is up https://github.com/juju/juju-qa-jenkins/pull/67, and I ran the job builder with the changes, so we shouldn't see any (unit, integration) tests spawn for `Python 3.5`.

Even if they spawn somehow, we can ignore them, but we need to make sure all the other tests are passing for other Python versions. (Modulo, of course we might have some known intermittent bugs that are still under investigation.)
