### PR TITLE
[JUJU-1706] Allow waiting for `wait_for_exact_units=0`

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -2532,7 +2532,7 @@ class Model:
 
     async def wait_for_idle(self, apps=None, raise_on_error=True, raise_on_blocked=False,
                             wait_for_active=False, timeout=10 * 60, idle_period=15, check_freq=0.5,
-                            status=None, wait_for_units=1, wait_for_exact_units=-1):
+                            status=None, wait_for_units=1, wait_for_exact_units=None):
         """Wait for applications in the model to settle into an idle state.
 
         :param apps (list[str]): Optional list of specific app names to wait on.
@@ -2574,8 +2574,7 @@ class Model:
 
         :param wait_for_exact_units (int): The exact number of units to be expected before
             going into the idle state. (e.g. useful for scaling down).
-            The default is -1 unit.
-            When positive, takes precedence over the `wait_for_units` parameter.
+            When set, takes precedence over the `wait_for_units` parameter.
         """
         if wait_for_active:
             warnings.warn("wait_for_active is deprecated; use status", DeprecationWarning)
@@ -2606,6 +2605,10 @@ class Model:
                     ", ".join(errored),
                 ))
 
+        if wait_for_exact_units is not None:
+            assert type(wait_for_exact_units) == int and wait_for_exact_units >= 0, \
+                f'Invalid value for wait_for_exact_units {wait_for_exact_units}'
+
         while True:
             busy = []
             errors = {}
@@ -2619,7 +2622,7 @@ class Model:
                     errors.setdefault("App", []).append(app.name)
                 if raise_on_blocked and app.status == "blocked":
                     blocks.setdefault("App", []).append(app.name)
-                if wait_for_exact_units > 0:
+                if wait_for_exact_units is not None:
                     if len(app.units) != wait_for_exact_units:
                         busy.append(app.name + " (waiting for exactly %s units, current : %s)" %
                                     (wait_for_exact_units, len(app.units)))

--- a/juju/model.py
+++ b/juju/model.py
@@ -2607,7 +2607,7 @@ class Model:
 
         if wait_for_exact_units is not None:
             assert type(wait_for_exact_units) == int and wait_for_exact_units >= 0, \
-                f'Invalid value for wait_for_exact_units {wait_for_exact_units}'
+                'Invalid value for wait_for_exact_units : %s' % wait_for_exact_units
 
         while True:
             busy = []

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -835,11 +835,40 @@ async def test_wait_for_idle_with_exact_units_scale_down(event_loop):
         await app.destroy_units(*two_units_to_remove)
 
         # assert that the following wait is not returning instantaneously
-        starttime = time.time()
+        start_time = time.time()
         await model.wait_for_idle(timeout=5 * 60, wait_for_exact_units=1)
-        endtime = time.time()
+        end_time = time.time()
         # checking if waited more than 10ms
-        assert (endtime - starttime) > 0.001
+        assert (end_time - start_time) > 0.001
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_wait_for_idle_with_exact_units_scale_down_zero(event_loop):
+    """Deploys 3 units, waits for them to be idle, then removes 3 of them,
+    then waits for exactly 0 unit to be left.
+
+    """
+    async with base.CleanModel() as model:
+        app = await model.deploy(
+            'ubuntu',
+            application_name='ubuntu',
+            series='bionic',
+            channel='stable',
+            num_units=3,
+        )
+        await model.wait_for_idle(timeout=5 * 60, wait_for_exact_units=3)
+
+        units_to_remove = [u.name for u in app.units]
+        # Remove all the units
+        await app.destroy_units(*units_to_remove)
+
+        # assert that the following wait is not returning instantaneously
+        start_time = time.time()
+        await model.wait_for_idle(timeout=5 * 60, wait_for_exact_units=0)
+        end_time = time.time()
+        # checking if waited more than 10ms
+        assert (end_time - start_time) > 0.001
 
 
 @base.bootstrapped

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -457,8 +457,8 @@ async def add_manual_machine_ssh(event_loop, is_root=False):
 
         def wait_for_network(container, timeout=30):
             """Wait for eth0 to have an ipv4 address."""
-            starttime = time.time()
-            while time.time() < starttime + timeout:
+            starttime = time.perf_counter()
+            while time.perf_counter() < starttime + timeout:
                 time.sleep(1)
                 if 'eth0' in container.state().network:
                     addresses = container.state().network['eth0']['addresses']
@@ -835,9 +835,9 @@ async def test_wait_for_idle_with_exact_units_scale_down(event_loop):
         await app.destroy_units(*two_units_to_remove)
 
         # assert that the following wait is not returning instantaneously
-        start_time = time.time()
+        start_time = time.perf_counter()
         await model.wait_for_idle(timeout=5 * 60, wait_for_exact_units=1)
-        end_time = time.time()
+        end_time = time.perf_counter()
         # checking if waited more than 10ms
         assert (end_time - start_time) > 0.001
 
@@ -864,9 +864,9 @@ async def test_wait_for_idle_with_exact_units_scale_down_zero(event_loop):
         await app.destroy_units(*units_to_remove)
 
         # assert that the following wait is not returning instantaneously
-        start_time = time.time()
+        start_time = time.perf_counter()
         await model.wait_for_idle(timeout=5 * 60, wait_for_exact_units=0)
-        end_time = time.time()
+        end_time = time.perf_counter()
         # checking if waited more than 10ms
         assert (end_time - start_time) > 0.001
 


### PR DESCRIPTION
#### Description

This adds logic to wait for `wait_for_exact_units=0` option for `model.wait_for_idle()`.

Fixes: #721 


#### QA Steps

```
tox -e integration -- tests/integration/test_model.py::test_wait_for_idle_with_exact_units_scale_down_zero
```
