### PR TITLE
[JUJU-1671] Charmhub url from model config

### DIFF
--- a/juju/bundle.py
+++ b/juju/bundle.py
@@ -619,7 +619,7 @@ class AddApplicationChange(ChangeInfo):
                 self.application, charm, overrides=self.resources)
         elif Schema.CHARM_HUB.matches(url.schema):
             c_hub = charmhub.CharmHub(context.model)
-            id_, _ = c_hub.get_charm_id(url.name)
+            id_, _ = await c_hub.get_charm_id(url.name)
             origin.id_ = id_
             resources = await context.model._add_charmhub_resources(
                 self.application, charm, origin, overrides=self.resources)

--- a/juju/charmhub.py
+++ b/juju/charmhub.py
@@ -18,18 +18,22 @@ class CharmHub:
             jasyncio.sleep(5)
         raise JujuError("Got {} from {}".format(_response.status_code, url))
 
-    def get_charm_id(self, charm_name):
+    async def get_charm_id(self, charm_name):
         conn, headers, path_prefix = self.model.connection().https_connection()
 
-        url = "https://api.snapcraft.io/v2/charms/info/{}".format(charm_name)
+        model_conf = await self.model.get_config()
+        charmhub_url = model_conf['charmhub-url']
+        url = "{}/v2/charms/info/{}".format(charmhub_url.value, charm_name)
         _response = self.request_charmhub_with_retry(url, 5)
         response = json.loads(_response.text)
         return response['id'], response['name']
 
-    def is_subordinate(self, charm_name):
+    async def is_subordinate(self, charm_name):
         conn, headers, path_prefix = self.model.connection().https_connection()
 
-        url = "https://api.snapcraft.io/v2/charms/info/{}?fields=default-release.revision.subordinate".format(charm_name)
+        model_conf = await self.model.get_config()
+        charmhub_url = model_conf['charmhub-url']
+        url = "{}/v2/charms/info/{}?fields=default-release.revision.subordinate".format(charmhub_url.value, charm_name)
         _response = self.request_charmhub_with_retry(url, 5)
         response = json.loads(_response.text)
         return 'subordinate' in response['default-release']['revision']

--- a/juju/model.py
+++ b/juju/model.py
@@ -1774,7 +1774,8 @@ class Model:
                     resources = await self._add_charmhub_resources(res.app_name,
                                                                    identifier,
                                                                    add_charm_res.charm_origin)
-                    if self.charmhub.is_subordinate(url.name):
+                    is_sub = await self.charmhub.is_subordinate(url.name)
+                    if is_sub:
                         if num_units > 1:
                             raise JujuError("cannot use num_units with subordinate application")
                         num_units = 0

--- a/tests/integration/test_charmhub.py
+++ b/tests/integration/test_charmhub.py
@@ -9,7 +9,7 @@ from juju import jasyncio
 @pytest.mark.asyncio
 async def test_info(event_loop):
     async with base.CleanModel() as model:
-        _, name = model.charmhub.get_charm_id("hello-juju")
+        _, name = await model.charmhub.get_charm_id("hello-juju")
         assert name == "hello-juju"
 
 

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -307,7 +307,7 @@ class TestAddApplicationChangeRun:
         context.trusted = False
         context.model = model
 
-        info_func = mock.AsyncMock(return_value=["12345", "name"])
+        info_func = base.AsyncMock(return_value=["12345", "name"])
 
         with patch.object(charmhub.CharmHub, 'get_charm_id', info_func):
             result = await change.run(context)
@@ -356,7 +356,7 @@ class TestAddApplicationChangeRun:
         context.trusted = False
         context.model = model
 
-        info_func = mock.AsyncMock(return_value=["12345", "name"])
+        info_func = base.AsyncMock(return_value=["12345", "name"])
 
         with patch.object(charmhub.CharmHub, 'get_charm_id', info_func):
             result = await change.run(context)

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -307,7 +307,7 @@ class TestAddApplicationChangeRun:
         context.trusted = False
         context.model = model
 
-        info_func = mock.Mock(return_value=["12345", "name"])
+        info_func = mock.AsyncMock(return_value=["12345", "name"])
 
         with patch.object(charmhub.CharmHub, 'get_charm_id', info_func):
             result = await change.run(context)
@@ -356,7 +356,7 @@ class TestAddApplicationChangeRun:
         context.trusted = False
         context.model = model
 
-        info_func = mock.Mock(return_value=["12345", "name"])
+        info_func = mock.AsyncMock(return_value=["12345", "name"])
 
         with patch.object(charmhub.CharmHub, 'get_charm_id', info_func):
             result = await change.run(context)


### PR DESCRIPTION
#### Description

Before this change, the api host address for the charmhub was hard-coded. This change allows fetching the api address from the model config.


#### QA Steps

```
tox -e integration -- tests/integration/test_charmhub.py
```
