### PR TITLE
add support for ipv6

### DIFF
--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -678,7 +678,9 @@ class Connection:
 
         """
         endpoint = self.endpoint
-        host, remainder = endpoint.split(':', 1)
+        # Support IPv6 by right splitting on : and removing [] around IP address for host
+        host, remainder = endpoint.rsplit(':', 1)
+        host = host.strip("[]")
         port = remainder
         if '/' in remainder:
             port, _ = remainder.split('/', 1)


### PR DESCRIPTION
#### Description

For machine charms, every now and then during testing libjuju will pick an IPv6 address to communicate with the machine. This results in problems with the part of the code changed because it just splits the endpoint to a host and port on the first `:` character which, for an IPv6 address, does not separate the host and port since an IPv6 address has many `:` characters in it. After applying this patch locally, libjuju is able to communicate with the machine again.

*\<Fixes: add support for ipv6 connections\>*


#### QA Steps

*\<Commands / tests / steps to run to verify that the change works: I ran tests for a charm that ocassionaly used ipv6 with these changes and they worked\>*

```
tox -e py3 -- tests/unit/...
```

```
tox -e integration -- tests/integration/...
```

All CI tests need to pass.

*\<Please note that most likely an additional test will be required by the reviewers for any change that's not a one liner to land.\>*

#### Notes & Discussion

*\<Additional notes for the reviewers if needed. Please delete section if not applicable.\>*