### PR TITLE
Add wait_for_app flag to wait_for_idle

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -2530,7 +2530,7 @@ class Model:
 
     async def wait_for_idle(self, apps=None, raise_on_error=True, raise_on_blocked=False,
                             wait_for_active=False, timeout=10 * 60, idle_period=15, check_freq=0.5,
-                            status=None, wait_for_units=1, wait_for_exact_units=None):
+                            status=None, wait_for_units=1, wait_for_exact_units=None, wait_for_app_status=False):
         """Wait for applications in the model to settle into an idle state.
 
         :param apps (list[str]): Optional list of specific app names to wait on.
@@ -2573,6 +2573,9 @@ class Model:
         :param wait_for_exact_units (int): The exact number of units to be expected before
             going into the idle state. (e.g. useful for scaling down).
             When set, takes precedence over the `wait_for_units` parameter.
+
+        :param wait_for_app_status (bool): Wait for the application status to become active.
+            The default is False.
         """
         if wait_for_active:
             warnings.warn("wait_for_active is deprecated; use status", DeprecationWarning)
@@ -2620,6 +2623,9 @@ class Model:
                     errors.setdefault("App", []).append(app.name)
                 if raise_on_blocked and app.status == "blocked":
                     blocks.setdefault("App", []).append(app.name)
+                if wait_for_app_status and app.status != "active":
+                    busy.append("Application {app_name}: {app.status}")
+                    continue
                 if wait_for_exact_units is not None:
                     if len(app.units) != wait_for_exact_units:
                         busy.append(app.name + " (waiting for exactly %s units, current : %s)" %

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -347,7 +347,7 @@ class TestModelWaitForIdle(asynctest.TestCase):
             m = Model()
 
             # pass "active" via `status` (str)
-            await m.wait_for_idle(apps=["dummy_app"], wait_for_app=True)
+            await m.wait_for_idle(apps=["dummy_app"], wait_for_app_status=True)
 
         mock_apps.assert_called_with()
 
@@ -373,6 +373,6 @@ class TestModelWaitForIdle(asynctest.TestCase):
             await m.wait_for_idle(apps=["dummy_app"])
             # pass "active" via `status` (str)
             with pytest.raises(jasyncio.TimeoutError):
-                await m.wait_for_idle(apps=["dummy_app"], wait_for_app=True)
+                await m.wait_for_idle(apps=["dummy_app"], wait_for_app_status=True)
 
         mock_apps.assert_called_with()


### PR DESCRIPTION

#### Description

The wait_for_idle function wasn't waiting for the application status to become active. This meant that after it returned the units would be in an `active` state while the application could be still in `waiting`. 

I added a flag to make this inactive by default, in case it breaks something. Not sure if that's needed.

#### QA steps

To run the unit tests:
```
tox -e unit -- -k test_wait_for_idle_wait_for_app_status
```
