### PR TITLE
[JUJU-1893] Revisit `charmhub.info()`

### DIFF
--- a/juju/charmhub.py
+++ b/juju/charmhub.py
@@ -74,7 +74,8 @@ class CharmHub:
             if err_code:
                 raise JujuError(f'charmhub.info - {err_code} : {res.errors.error_list.message}')
             result = res.result
-            result.channel_map = self._channel_map_to_dict(result.channel_map)
+            result.channel_map = CharmHub._channel_map_to_dict(
+                result.channel_map)
             result = result.serialize()
         else:
             charmhub_url = await self._charmhub_url()
@@ -82,9 +83,11 @@ class CharmHub:
                 charmhub_url.value, name)
             _response = self.request_charmhub_with_retry(url, 5)
             result = json.loads(_response.text)
+            result['channel-map'] = CharmHub._channel_list_to_map(result['channel-map'])
         return result
 
-    def _channel_list_to_map(self, channel_list_map):
+    @staticmethod
+    def _channel_list_to_map(channel_list_map):
         """Charmhub API returns the channel map as a list of channel objects
         (with risk, track, revision, download etc). This turns that into a map
         that's keyed with the channel=track/risk for easy
@@ -106,7 +109,8 @@ class CharmHub:
                 = ch
         return channel_map
 
-    def _channel_map_to_dict(self, channel_map):
+    @staticmethod
+    def _channel_map_to_dict(channel_map):
         """Converts the client.definitions.Channel objects into python maps
         inside a channel map (for pylibjuju <3.0)
 

--- a/juju/charmhub.py
+++ b/juju/charmhub.py
@@ -14,12 +14,12 @@ class CharmHub:
         model_conf = await self.model.get_config()
         return model_conf['charmhub-url']
 
-    def request_charmhub_with_retry(self, url, retries):
+    async def request_charmhub_with_retry(self, url, retries):
         for attempt in range(retries):
             _response = requests.get(url)
             if _response.status_code == 200:
                 return _response
-            jasyncio.sleep(5)
+            await jasyncio.sleep(5)
         raise JujuError("Got {} from {}".format(_response.status_code, url))
 
     async def get_charm_id(self, charm_name):
@@ -27,7 +27,7 @@ class CharmHub:
 
         charmhub_url = await self._charmhub_url()
         url = "{}/v2/charms/info/{}".format(charmhub_url.value, charm_name)
-        _response = self.request_charmhub_with_retry(url, 5)
+        _response = await self.request_charmhub_with_retry(url, 5)
         response = json.loads(_response.text)
         return response['id'], response['name']
 
@@ -36,7 +36,7 @@ class CharmHub:
 
         charmhub_url = await self._charmhub_url()
         url = "{}/v2/charms/info/{}?fields=default-release.revision.subordinate".format(charmhub_url.value, charm_name)
-        _response = self.request_charmhub_with_retry(url, 5)
+        _response = await self.request_charmhub_with_retry(url, 5)
         response = json.loads(_response.text)
         return 'subordinate' in response['default-release']['revision']
 
@@ -48,7 +48,7 @@ class CharmHub:
 
         charmhub_url = await self._charmhub_url()
         url = "{}/v2/charms/info/{}?fields=default-release.resources".format(charmhub_url.value, charm_name)
-        _response = self.request_charmhub_with_retry(url, 5)
+        _response = await self.request_charmhub_with_retry(url, 5)
         response = json.loads(_response.text)
         return response['default-release']['resources']
 

--- a/juju/charmhub.py
+++ b/juju/charmhub.py
@@ -84,7 +84,11 @@ class CharmHub:
             charmhub_url = await self._charmhub_url()
             url = "{}/v2/charms/info/{}?fields=channel-map".format(
                 charmhub_url.value, name)
-            _response = self.request_charmhub_with_retry(url, 5)
+            try:
+                _response = await self.request_charmhub_with_retry(url, 5)
+            except JujuError as e:
+                if '404' in e.message:
+                    raise JujuError(f'{name} not found') from e
             result = json.loads(_response.text)
             result['channel-map'] = CharmHub._channel_list_to_map(result['channel-map'],
                                                                   name,

--- a/juju/charmhub.py
+++ b/juju/charmhub.py
@@ -10,6 +10,10 @@ class CharmHub:
     def __init__(self, model):
         self.model = model
 
+    async def _charmhub_url(self):
+        model_conf = await self.model.get_config()
+        return model_conf['charmhub-url']
+
     def request_charmhub_with_retry(self, url, retries):
         for attempt in range(retries):
             _response = requests.get(url)
@@ -21,8 +25,7 @@ class CharmHub:
     async def get_charm_id(self, charm_name):
         conn, headers, path_prefix = self.model.connection().https_connection()
 
-        model_conf = await self.model.get_config()
-        charmhub_url = model_conf['charmhub-url']
+        charmhub_url = await self._charmhub_url()
         url = "{}/v2/charms/info/{}".format(charmhub_url.value, charm_name)
         _response = self.request_charmhub_with_retry(url, 5)
         response = json.loads(_response.text)
@@ -31,8 +34,7 @@ class CharmHub:
     async def is_subordinate(self, charm_name):
         conn, headers, path_prefix = self.model.connection().https_connection()
 
-        model_conf = await self.model.get_config()
-        charmhub_url = model_conf['charmhub-url']
+        charmhub_url = await self._charmhub_url()
         url = "{}/v2/charms/info/{}?fields=default-release.revision.subordinate".format(charmhub_url.value, charm_name)
         _response = self.request_charmhub_with_retry(url, 5)
         response = json.loads(_response.text)
@@ -44,8 +46,7 @@ class CharmHub:
     async def list_resources(self, charm_name):
         conn, headers, path_prefix = self.model.connection().https_connection()
 
-        model_conf = await self.model.get_config()
-        charmhub_url = model_conf['charmhub-url']
+        charmhub_url = await self._charmhub_url()
         url = "{}/v2/charms/info/{}?fields=default-release.resources".format(charmhub_url.value, charm_name)
         _response = self.request_charmhub_with_retry(url, 5)
         response = json.loads(_response.text)

--- a/tests/integration/test_charmhub.py
+++ b/tests/integration/test_charmhub.py
@@ -1,7 +1,7 @@
 import pytest
 
 from .. import base
-from juju.errors import JujuAPIError, JujuError
+from juju.errors import JujuError
 from juju import jasyncio
 
 
@@ -48,15 +48,11 @@ async def test_info_with_channel(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-@pytest.mark.skip('CharmHub facade no longer exists')
 async def test_info_not_found(event_loop):
     async with base.CleanModel() as model:
-        try:
+        with pytest.raises(JujuError) as err:
             await model.charmhub.info("badnameforapp")
-        except JujuAPIError as e:
-            assert e.message == "badnameforapp not found"
-        else:
-            assert False
+            assert "badnameforapp not found" in str(err)
 
 
 @base.bootstrapped

--- a/tests/integration/test_charmhub.py
+++ b/tests/integration/test_charmhub.py
@@ -12,6 +12,20 @@ async def test_info(event_loop):
         _, name = await model.charmhub.get_charm_id("hello-juju")
         assert name == "hello-juju"
 
+        charm_name = 'juju-qa-test'
+        charm_info = await model.charmhub.info(charm_name)
+        assert charm_info['name'] == 'juju-qa-test'
+        assert charm_info['type'] == 'charm'
+        assert charm_info['id'] == 'Hw30RWzpUBnJLGtO71SX8VDWvd3WrjaJ'
+        assert '2.0/stable' in charm_info['channel-map']
+        cm_rev = charm_info['channel-map']['2.0/stable']['revision']
+        if type(cm_rev) == dict:
+            # New client (>= 3.0)
+            assert cm_rev['revision'] == 22
+        else:
+            # Old client (<= 2.9)
+            assert cm_rev == 22
+
 
 @base.bootstrapped
 @pytest.mark.asyncio

--- a/tests/integration/test_charmhub.py
+++ b/tests/integration/test_charmhub.py
@@ -29,13 +29,21 @@ async def test_info(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-@pytest.mark.skip('CharmHub facade no longer exists')
 async def test_info_with_channel(event_loop):
     async with base.CleanModel() as model:
-        result = await model.charmhub.info("hello-juju", "latest/stable")
+        charm_info = await model.charmhub.info("juju-qa-test", "2.0/stable")
+        assert charm_info['name'] == 'juju-qa-test'
+        assert '2.0/stable' in charm_info['channel-map']
+        assert 'latest/stable' not in charm_info['channel-map']
 
-        assert result.result.name == "hello-juju"
-        assert "latest/stable" in result.result.channel_map
+        try:
+            await model.charmhub.info("juju-qa-test", "non-existing-channel")
+        except JujuError as err:
+            assert err.message == 'Charmhub.info : channel ' \
+                                  'non-existing-channel not found for ' \
+                                  'juju-qa-test'
+        else:
+            assert False, "non-existing-channel didn't raise an error"
 
 
 @base.bootstrapped


### PR DESCRIPTION
#### Description

This PR revisits the `info` method in `charmhub.py`, allowing users to get information for a charm (like `juju info juju-qa-test`) in pylibjuju using either old or new clients. For old clients it calls `Info` from the `Charmhub` facade, and for the new clients it directly calls the charmhub api and processes the result. The channel-map representations are different between the `2.9` and `3.0` clients, this change introduces extra effort to get them as close as possible.

Fixes #734 


#### QA Steps

The existing charmhub tests are updated, and the ones that we used to skip (due to charmhub facade not existing anymore) are re-activated since we have the working code now (only the `info` ones). QA should be done for both `2.9` and `3.0` clients. So get yourself `juju 2.9` and `juju 3.0` and bootstrap two controllers and run the relevant tests:

```
tox -e integration -- tests/integration/test_charmhub.py::test_info
```
```
tox -e integration -- tests/integration/test_charmhub.py::test_info_with_channel
```
```
tox -e integration -- tests/integration/test_charmhub.py::test_info_not_found
```

You may also play with the `examples/charmhub_info.py` with different controllers if you wanna be extra pedantic.