### PR TITLE
Wait for idle arg type check

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -2581,6 +2581,12 @@ class Model:
         timeout = timedelta(seconds=timeout) if timeout is not None else None
         idle_period = timedelta(seconds=idle_period)
         start_time = datetime.now()
+        # Type check against the common error of passing a str for apps
+        if apps is not None and (not isinstance(apps, list) or
+                                 any(not isinstance(o, str)
+                                     for o in apps)):
+            raise JujuError(f'Expected a List[str] for apps, given {apps}')
+
         apps = apps or self.applications
         idle_times = {}
         last_log_time = None

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -11,7 +11,7 @@ from juju.client.jujudata import FileJujuData
 from juju.model import Model
 from juju.application import Application
 from juju import jasyncio
-from juju.errors import JujuConnectionError
+from juju.errors import JujuConnectionError, JujuError
 
 
 def _make_delta(entity, type_, data=None):
@@ -288,6 +288,21 @@ class TestModelWaitForIdle(asynctest.TestCase):
         with self.assertWarns(DeprecationWarning):
             # no apps so should return right away
             await m.wait_for_idle(wait_for_active=True)
+
+    @pytest.mark.asyncio
+    async def test_apps_no_lst(self):
+        m = Model()
+        with self.assertRaises(JujuError):
+            # apps arg has to be a List[str]
+            await m.wait_for_idle(apps="should-be-list")
+
+        with self.assertRaises(JujuError):
+            # apps arg has to be a List[str]
+            await m.wait_for_idle(apps=3)
+
+        with self.assertRaises(JujuError):
+            # apps arg has to be a List[str]
+            await m.wait_for_idle(apps=[3])
 
     @pytest.mark.asyncio
     async def test_timeout(self):


### PR DESCRIPTION
#### Description

Currently there's no check for the `apps` argument for the `wait_for_idle()` method. So it goes through any iterable that's passed to it, including strings. As a result `wait_for_idle(apps="test")` produces something like the following:

```
INFO     juju.model:model.py:2645 Waiting for model:
  t (missing)
  e (missing)
  s (missing)
  t (missing)
```

This introduces a check for the argument to be a `List[str]`.

Fixes #732 

#### QA Steps

Unit tests are added, should be a simple QA.

```
tox -e py3 -- tests/unit/test_model.py::TestModelWaitForIdle
```