### PR TITLE
[JUJU-1970] Revise local refresh

### DIFF
--- a/juju/application.py
+++ b/juju/application.py
@@ -633,10 +633,6 @@ class Application(model.ModelEntity):
         :param str switch: Crossgrade charm url
 
         """
-        if path is not None:
-            await self.local_refresh(channel, force, force_series, force_units,
-                                     path, resources)
-            return
         if resources is not None:
             raise NotImplementedError("resources option is not implemented")
 
@@ -658,6 +654,11 @@ class Application(model.ModelEntity):
             raise JujuError(f'{err.code} : {err.message}')
         charm_url = switch or charm_url_origin_result.url
         origin = charm_url_origin_result.charm_origin
+
+        if path is not None:
+            await self.local_refresh(origin, force, force_series,
+                                     force_units, path, resources)
+            return
 
         parsed_url = URL.parse(charm_url)
         charm_name = parsed_url.name
@@ -788,7 +789,8 @@ class Application(model.ModelEntity):
     upgrade_charm = refresh
 
     async def local_refresh(
-            self, channel=None, force=False, force_series=False, force_units=False,
+            self, charm_origin=None, force=False, force_series=False,
+            force_units=False,
             path=None, resources=None):
         """Refresh the charm for this application with a local charm.
 
@@ -831,7 +833,7 @@ class Application(model.ModelEntity):
         # Update application
         await app_facade.SetCharm(
             application=self.entity_id,
-            channel=channel,
+            charm_origin=charm_origin,
             charm_url=charm_url,
             config_settings=None,
             config_settings_yaml=None,

--- a/tests/charm-folder-symlink/metadata.yaml
+++ b/tests/charm-folder-symlink/metadata.yaml
@@ -1,4 +1,5 @@
 name: simple
 summary: A simple example charm with the new operator framework
+series: ["focal"]
 description: |
     Simple is an example charm

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -247,9 +247,10 @@ async def test_upgrade_local_charm(event_loop):
     async with base.CleanModel() as model:
         tests_dir = Path(__file__).absolute().parent
         charm_path = tests_dir / 'upgrade-charm'
-        app = await model.deploy('cs:ubuntu', series='focal')
+        app = await model.deploy('ch:ubuntu', series='focal')
         await model.wait_for_idle(status="active")
-        assert app.data['charm-url'].startswith('cs:ubuntu')
+        assert app.data['charm-url'].startswith('ch:') and 'ubuntu' in \
+               app.data['charm-url']
         await app.upgrade_charm(path=charm_path)
         await model.wait_for_idle(status="waiting")
         assert app.data['charm-url'] == 'local:focal/ubuntu-0'


### PR DESCRIPTION
#### Description

This change revises the `local_refresh()` (i.e. `application.upgrade_charm()` with a local charm) to use the `app_facade.GetCharmURLOrigin()` to get the origin of the currently running application charm, instead of trying to pass `channel` to the `SetCharm` like before.

We already implemented this when revising `upgrade_charm` in #729, but the upgrade local was missed (we talked about it but I forgot to include it).

This should fix the `tests/integration/test_application.py::test_upgrade_local_charm` that's currently failing in the CI runs.

#### QA Steps

The integration test mentioned above is revised a little bit, so it should pass. QA with different types and shapes of local charms would be appreciated.

```
tox -e integration -- tests/integration/test_application.py::test_upgrade_local_charm
```