### PR TITLE
[JUJU-1979] Backport upgrade-charm fixes onto `2.9`

### DIFF
--- a/juju/application.py
+++ b/juju/application.py
@@ -625,38 +625,15 @@ class Application(model.ModelEntity):
 
         app_facade = self._facade()
 
-        charmstore = self.model.charmstore
-        charmstore_entity = None
-
-        if switch is not None:
-            charm_url = switch
-            if not charm_url.startswith('cs:'):
-                charm_url = 'cs:' + charm_url
-        else:
-            charm_url = self.data['charm-url']
-            charm_url = charm_url.rpartition('-')[0]
-            if revision is not None:
-                charm_url = "%s-%d" % (charm_url, revision)
-            else:
-                charmstore_entity = await charmstore.entity(charm_url,
-                                                            channel=channel)
-                charm_url = charmstore_entity['Id']
-
-        if charm_url == self.data['charm-url']:
-            raise JujuError('already running charm "%s"' % charm_url)
-
-        # Update charm
-        await client_facade.AddCharm(
-            url=charm_url,
-            force=force,
-            channel=channel
-        )
-        charm_url = self.data['charm-url']
-        parsed_url = URL.parse(charm_url)
+        url = switch or self.data['charm-url']
+        parsed_url = URL.parse(url)
         charm_name = parsed_url.name
 
         # First we need to make sure we have the resources for the charm that's
         # coming
+
+        if parsed_url.schema is None:
+            raise JujuError(f'A ch: or cs: schema is required for application refresh, given : {str(parsed_url)}')
 
         # Get the list of resources needed to deploy this charm
         if Schema.CHARM_HUB.matches(parsed_url.schema):
@@ -664,13 +641,14 @@ class Application(model.ModelEntity):
             charmhub = self.model.charmhub
             charm_resources = await charmhub.list_resources(charm_name)
 
-            charm_url_origin_result = await app_facade.GetCharmURLOrigin(application=charm_name)
+            charm_url_origin_result = await app_facade.GetCharmURLOrigin(application=self.name)
 
             if charm_url_origin_result.error is not None:
                 err = charm_url_origin_result.error
                 raise JujuError(f'{err.code} : {err.message}')
-            charm_url = charm_url_origin_result.url
+            charm_url = switch or charm_url_origin_result.url
             origin = charm_url_origin_result.charm_origin
+            origin.source = 'charm-hub'
 
             if channel:
                 ch = Channel.parse(channel).normalize()
@@ -680,7 +658,7 @@ class Application(model.ModelEntity):
             charms_facade = client.CharmsFacade.from_connection(self.connection)
             resolved_charm_with_channel_results = await charms_facade.ResolveCharms(resolve=[client.ResolveCharmWithChannel(
                 charm_origin=origin,
-                switch_charm=False,
+                switch_charm=True if switch else False,  # rpc expects boolean type
                 reference=charm_url,
             )])
             resolved_charm = resolved_charm_with_channel_results.results[0]

--- a/juju/application.py
+++ b/juju/application.py
@@ -18,7 +18,7 @@ import logging
 import pathlib
 
 from . import model, tag, utils, jasyncio
-from .url import URL
+from .url import URL, Schema
 from .status import derive_status
 from .annotationhelper import _get_annotations, _set_annotations
 from .client import client
@@ -620,8 +620,7 @@ class Application(model.ModelEntity):
         if switch is not None and revision is not None:
             raise ValueError("switch and revision are mutually exclusive")
 
-        resources_facade = client.ResourcesFacade.from_connection(
-            self.connection)
+        resources_facade = client.ResourcesFacade.from_connection(self.connection)
         app_facade = self._facade()
 
         charmstore = self.model.charmstore
@@ -651,11 +650,47 @@ class Application(model.ModelEntity):
             channel=channel
         )
         charm_url = self.data['charm-url']
-        charm_name = URL.parse(charm_url).name
+        parsed_url = URL.parse(charm_url)
+        charm_name = parsed_url.name
+
+        # First we need to make sure we have the resources for the charm that's
+        # coming
+
+        # Get the listof resources needed to deploy this charm
+        if Schema.CHARM_HUB.matches(parsed_url.schema):
+            # Charmhub charms
+            charmhub = self.model.charmhub
+            charm_resources = await charmhub.list_resources(charm_name)
+        else:
+            charms_facade = client.CharmsFacade.from_connection(self.connection)
+            charmstore = self.model.charmstore
+            charmstore_entity = None
+            if switch is not None:
+                charm_url = switch
+                if not charm_url.startswith('cs:'):
+                    charm_url = 'cs:' + charm_url
+            else:
+                charm_url = self.data['charm-url']
+                charm_url = charm_url.rpartition('-')[0]
+                if revision is not None:
+                    charm_url = "%s-%d" % (charm_url, revision)
+                else:
+                    charmstore_entity = await charmstore.entity(charm_url, channel=channel)
+                    charm_url = charmstore_entity['Id']
+
+            if charm_url == self.data['charm-url']:
+                raise JujuError('already running charm "%s"' % charm_url)
+
+            origin = client.CharmOrigin(source="charm-store", risk=channel)
+            # Update charm
+            await charms_facade.AddCharm(url=charm_url,
+                                         force=force,
+                                         charm_origin=origin)
+            if not charmstore_entity:
+                charmstore_entity = await charmstore.entity(charm_url, channel=channel)
+            charm_resources = charmstore_entity['Meta']['resources']
 
         # Update resources
-        charmhub = self.model.charmhub
-        charmhub_resources = await charmhub.list_resources(charm_name)
 
         request_data = [client.Entity(self.tag)]
         response = await resources_facade.ListResources(entities=request_data)
@@ -665,7 +700,7 @@ class Application(model.ModelEntity):
         }
 
         resources_to_update = [
-            resource for resource in charmhub_resources
+            resource for resource in charm_resources
             if resource['Name'] not in existing_resources or
             existing_resources[resource['Name']].origin != 'upload'
         ]

--- a/juju/application.py
+++ b/juju/application.py
@@ -621,79 +621,72 @@ class Application(model.ModelEntity):
         if switch is not None and revision is not None:
             raise ValueError("switch and revision are mutually exclusive")
 
-        resources_facade = client.ResourcesFacade.from_connection(self.connection)
-
         app_facade = self._facade()
+        resources_facade = client.ResourcesFacade.from_connection(self.connection)
+        charms_facade = client.CharmsFacade.from_connection(self.connection)
 
-        url = switch or self.data['charm-url']
-        parsed_url = URL.parse(url)
+        # Get the charm URL and charm origin of the given application is running at present.
+        charm_url_origin_result = await app_facade.GetCharmURLOrigin(application=self.name)
+        if charm_url_origin_result.error is not None:
+            err = charm_url_origin_result.error
+            raise JujuError(f'{err.code} : {err.message}')
+        charm_url = switch or charm_url_origin_result.url
+        origin = charm_url_origin_result.charm_origin
+
+        parsed_url = URL.parse(charm_url)
         charm_name = parsed_url.name
-
-        # First we need to make sure we have the resources for the charm that's
-        # coming
 
         if parsed_url.schema is None:
             raise JujuError(f'A ch: or cs: schema is required for application refresh, given : {str(parsed_url)}')
 
-        # Get the list of resources needed to deploy this charm
+        if revision is not None:
+            origin.revision = revision
+
         if Schema.CHARM_HUB.matches(parsed_url.schema):
-            # Charmhub charms
-            charmhub = self.model.charmhub
-            charm_resources = await charmhub.list_resources(charm_name)
-
-            charm_url_origin_result = await app_facade.GetCharmURLOrigin(application=self.name)
-
-            if charm_url_origin_result.error is not None:
-                err = charm_url_origin_result.error
-                raise JujuError(f'{err.code} : {err.message}')
-            charm_url = switch or charm_url_origin_result.url
-            origin = charm_url_origin_result.charm_origin
             origin.source = 'charm-hub'
-
             if channel:
                 ch = Channel.parse(channel).normalize()
                 origin.risk = ch.risk
                 origin.track = ch.track
 
-            charms_facade = client.CharmsFacade.from_connection(self.connection)
-            resolved_charm_with_channel_results = await charms_facade.ResolveCharms(resolve=[client.ResolveCharmWithChannel(
-                charm_origin=origin,
-                switch_charm=True if switch else False,  # rpc expects boolean type
-                reference=charm_url,
-            )])
-            resolved_charm = resolved_charm_with_channel_results.results[0]
-
-            if resolved_charm.error is not None:
-                err = resolved_charm.error
-                raise JujuError(f'{err.code} : {err.message}')
-            dest_origin = resolved_charm.charm_origin
-            charm_url = resolved_charm.url
-
+            charmhub = self.model.charmhub
+            charm_resources = await charmhub.list_resources(charm_name)
         else:
-            charms_facade = client.CharmsFacade.from_connection(self.connection)
             charmstore = self.model.charmstore
-            charmstore_entity = None
-            if switch is not None:
-                charm_url = switch
-                if not charm_url.startswith('cs:'):
-                    charm_url = 'cs:' + charm_url
-            else:
-                charm_url = self.data['charm-url']
+            charmstore_entity = await charmstore.entity(charm_url, channel=channel)
+
+            if switch is None:
                 charm_url = charm_url.rpartition('-')[0]
                 if revision is not None:
                     charm_url = "%s-%d" % (charm_url, revision)
                 else:
-                    charmstore_entity = await charmstore.entity(charm_url, channel=channel)
                     charm_url = charmstore_entity['Id']
+            origin.source = 'charm-store'
+            if channel:
+                origin.risk = channel
 
-            if charm_url == self.data['charm-url']:
-                raise JujuError('already running charm "%s"' % charm_url)
-
-            dest_origin = client.CharmOrigin(source="charm-store", risk=channel)
-
-            if not charmstore_entity:
-                charmstore_entity = await charmstore.entity(charm_url, channel=channel)
             charm_resources = charmstore_entity['Meta']['resources']
+
+        # resolve the given charm URLs with an optionally specified preferred channel.
+        # Channel provided via CharmOrigin.
+        resolved_charm_with_channel_results = await charms_facade.ResolveCharms(
+            resolve=[client.ResolveCharmWithChannel(
+                charm_origin=origin,
+                switch_charm=True if switch else False,  # rpc expects boolean type
+                reference=charm_url,
+            )])
+        resolved_charm = resolved_charm_with_channel_results.results[0]
+
+        # Get the destination origin and destination charm_url
+        # from the resolved charm
+        if resolved_charm.error is not None:
+            err = resolved_charm.error
+            raise JujuError(f'{err.code} : {err.message}')
+        dest_origin = resolved_charm.charm_origin
+        charm_url = resolved_charm.url
+
+        # Then we need to take care of the resources:
+        # Get the list of resources needed to deploy this charm
 
         # Add the charm with the new origin
         charm_origin_result = await charms_facade.AddCharm(url=charm_url,

--- a/juju/application.py
+++ b/juju/application.py
@@ -629,7 +629,7 @@ class Application(model.ModelEntity):
         charm_url_origin_result = await app_facade.GetCharmURLOrigin(application=self.name)
         if charm_url_origin_result.error is not None:
             err = charm_url_origin_result.error
-            raise JujuError(f'{err.code} : {err.message}')
+            raise JujuError("%s : %s" % (err.code, err.message))
         charm_url = switch or charm_url_origin_result.url
         origin = charm_url_origin_result.charm_origin
 
@@ -642,7 +642,8 @@ class Application(model.ModelEntity):
         charm_name = parsed_url.name
 
         if parsed_url.schema is None:
-            raise JujuError(f'A ch: or cs: schema is required for application refresh, given : {str(parsed_url)}')
+            raise JujuError("A ch: or cs: schema is required for application "
+                            "refresh, given : %s " % str(parsed_url))
 
         if revision is not None:
             origin.revision = revision

--- a/juju/application.py
+++ b/juju/application.py
@@ -611,10 +611,6 @@ class Application(model.ModelEntity):
         :param str switch: Crossgrade charm url
 
         """
-        if path is not None:
-            await self.local_refresh(channel, force, force_series, force_units,
-                                     path, resources)
-            return
         if resources is not None:
             raise NotImplementedError("resources option is not implemented")
 
@@ -636,6 +632,11 @@ class Application(model.ModelEntity):
             raise JujuError(f'{err.code} : {err.message}')
         charm_url = switch or charm_url_origin_result.url
         origin = charm_url_origin_result.charm_origin
+
+        if path is not None:
+            await self.local_refresh(origin, force, force_series,
+                                     force_units, path, resources)
+            return
 
         parsed_url = URL.parse(charm_url)
         charm_name = parsed_url.name
@@ -766,7 +767,8 @@ class Application(model.ModelEntity):
     upgrade_charm = refresh
 
     async def local_refresh(
-            self, channel=None, force=False, force_series=False, force_units=False,
+            self, charm_origin=None, force=False, force_series=False,
+            force_units=False,
             path=None, resources=None):
         """Refresh the charm for this application with a local charm.
 
@@ -809,7 +811,7 @@ class Application(model.ModelEntity):
         # Update application
         await app_facade.SetCharm(
             application=self.entity_id,
-            channel=channel,
+            charm_origin=charm_origin,
             charm_url=charm_url,
             config_settings=None,
             config_settings_yaml=None,

--- a/juju/application.py
+++ b/juju/application.py
@@ -658,13 +658,16 @@ class Application(model.ModelEntity):
         # First we need to make sure we have the resources for the charm that's
         # coming
 
-        # Get the listof resources needed to deploy this charm
+        # Get the list of resources needed to deploy this charm
         if Schema.CHARM_HUB.matches(parsed_url.schema):
             # Charmhub charms
             charmhub = self.model.charmhub
             charm_resources = await charmhub.list_resources(charm_name)
 
             res = await app_facade.GetCharmURLOrigin(application=charm_name)
+
+            if res.error is not None:
+                raise JujuError(f'{res.code} : {res.message}')
             charm_url = res.url
             origin = res.charm_origin
 
@@ -674,14 +677,17 @@ class Application(model.ModelEntity):
                 origin.track = ch.track
 
             charms_facade = client.CharmsFacade.from_connection(self.connection)
-            resolved_charm = await charms_facade.ResolveCharms(resolve=[client.ResolveCharmWithChannel(
+            resolved_charm_with_channel_results = await charms_facade.ResolveCharms(resolve=[client.ResolveCharmWithChannel(
                 charm_origin=origin,
                 switch_charm=False,
                 reference=charm_url,
             )])
-            # TODO: error check here
-            dest_origin = resolved_charm.results[0].charm_origin
-            charm_url = resolved_charm.results[0].url
+            resolved_charm = resolved_charm_with_channel_results.results[0]
+
+            if resolved_charm.error is not None:
+                raise JujuError(f'{res.code} : {res.message}')
+            dest_origin = resolved_charm.charm_origin
+            charm_url = resolved_charm.url
 
             await charms_facade.AddCharm(url=charm_url,
                                          force=force,

--- a/juju/application.py
+++ b/juju/application.py
@@ -707,11 +707,11 @@ class Application(model.ModelEntity):
             if charm_url == self.data['charm-url']:
                 raise JujuError('already running charm "%s"' % charm_url)
 
-            origin = client.CharmOrigin(source="charm-store", risk=channel)
+            dest_origin = client.CharmOrigin(source="charm-store", risk=channel)
             # Update charm
             await charms_facade.AddCharm(url=charm_url,
                                          force=force,
-                                         charm_origin=origin)
+                                         charm_origin=dest_origin)
             if not charmstore_entity:
                 charmstore_entity = await charmstore.entity(charm_url, channel=channel)
             charm_resources = charmstore_entity['Meta']['resources']

--- a/juju/application.py
+++ b/juju/application.py
@@ -689,7 +689,7 @@ class Application(model.ModelEntity):
         # Get the destination origin and destination charm_url from the resolved charm
         if resolved_charm.error is not None:
             err = resolved_charm.error
-            raise JujuError(f'{err.code} : {err.message}')
+            raise JujuError("%s : %s" % (err.code, err.message))
         dest_origin = resolved_charm.charm_origin
         charm_url = resolved_charm.url
 
@@ -699,7 +699,7 @@ class Application(model.ModelEntity):
                                                            charm_origin=dest_origin)
         if charm_origin_result.error is not None:
             err = charm_origin_result.error
-            raise JujuError(f'{err.code} : {err.message}')
+            raise JujuError("%s : %s" % (err.code, err.message))
 
         # Now take care of the resources:
 

--- a/juju/charmhub.py
+++ b/juju/charmhub.py
@@ -1,5 +1,9 @@
 from .client import client
 from .errors import JujuError
+from juju import jasyncio
+
+import requests
+import json
 
 
 class CharmHub:

--- a/juju/charmhub.py
+++ b/juju/charmhub.py
@@ -6,6 +6,47 @@ class CharmHub:
     def __init__(self, model):
         self.model = model
 
+    def request_charmhub_with_retry(self, url, retries):
+        for attempt in range(retries):
+            _response = requests.get(url)
+            if _response.status_code == 200:
+                return _response
+            jasyncio.sleep(5)
+        raise JujuError("Got {} from {}".format(_response.status_code, url))
+
+    async def get_charm_id(self, charm_name):
+        conn, headers, path_prefix = self.model.connection().https_connection()
+
+        model_conf = await self.model.get_config()
+        charmhub_url = model_conf['charmhub-url']
+        url = "{}/v2/charms/info/{}".format(charmhub_url.value, charm_name)
+        _response = self.request_charmhub_with_retry(url, 5)
+        response = json.loads(_response.text)
+        return response['id'], response['name']
+
+    async def is_subordinate(self, charm_name):
+        conn, headers, path_prefix = self.model.connection().https_connection()
+
+        model_conf = await self.model.get_config()
+        charmhub_url = model_conf['charmhub-url']
+        url = "{}/v2/charms/info/{}?fields=default-release.revision.subordinate".format(charmhub_url.value, charm_name)
+        _response = self.request_charmhub_with_retry(url, 5)
+        response = json.loads(_response.text)
+        return 'subordinate' in response['default-release']['revision']
+
+    # TODO (caner) : we should be able to recreate the channel-map through the
+    #  api call without needing the CharmHub facade
+
+    async def list_resources(self, charm_name):
+        conn, headers, path_prefix = self.model.connection().https_connection()
+
+        model_conf = await self.model.get_config()
+        charmhub_url = model_conf['charmhub-url']
+        url = "{}/v2/charms/info/{}?fields=default-release.resources".format(charmhub_url.value, charm_name)
+        _response = self.request_charmhub_with_retry(url, 5)
+        response = json.loads(_response.text)
+        return response['default-release']['resources']
+
     async def info(self, name, channel=None):
         """info displays detailed information about a CharmHub charm. The charm
         can be specified by the exact name.

--- a/tests/charm-folder-symlink/metadata.yaml
+++ b/tests/charm-folder-symlink/metadata.yaml
@@ -1,4 +1,5 @@
 name: simple
 summary: A simple example charm with the new operator framework
+series: ["focal"]
 description: |
     Simple is an example charm

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -4,7 +4,7 @@ import pytest
 import logging
 
 from .. import base
-from juju import jasyncio, errors
+from juju import errors
 from juju.url import URL, Schema
 
 MB = 1

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -191,7 +191,7 @@ async def test_upgrade_charm_switch_channel(event_loop):
             still76 = True
         except AssertionError:
             logger.warning("Charm used in test_upgrade_charm_switch_channel "
-                           "seems to have been updated, revise the test")
+                           "seems to have been updated, the test needs to be revised")
 
         await app.upgrade_charm(channel='candidate')
         await model.wait_for_idle(status='active')
@@ -200,8 +200,15 @@ async def test_upgrade_charm_switch_channel(event_loop):
             try:
                 assert charm_url.revision == 75
             except AssertionError:
-                raise errors.JujuError("Either the upgrade has failed, or the charm used moved "
-                                       "the candidate channel to stable, so no upgrade took place")
+                raise errors.JujuError("Either the upgrade has failed, or the used charm moved "
+                                       "the candidate channel to stable, so no upgrade took place, "
+                                       "the test needs to be revised.")
+
+        # Try with another charm too, just in case, no need to check revisions etc
+        app = await model.deploy('ubuntu', channel='stable')
+        await model.wait_for_idle(status='active')
+        await app.upgrade_charm(channel='candidate')
+        await model.wait_for_idle(status='active')
 
 
 @base.bootstrapped

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -1,10 +1,15 @@
 from pathlib import Path
 
 import pytest
+import logging
 
 from .. import base
+from juju import jasyncio, errors
+from juju.url import URL, Schema
 
 MB = 1
+
+logger = logging.getLogger(__name__)
 
 
 @base.bootstrapped
@@ -162,6 +167,41 @@ async def test_upgrade_charm_channel(event_loop):
         await app.upgrade_charm(channel='stable')
         assert app.data['charm-url'].startswith('cs:ubuntu-')
         assert app.data['charm-url'] != 'cs:ubuntu-0'
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_upgrade_charm_switch_channel(event_loop):
+    # Note for future:
+    # This test requires a charm that has different
+    # revisions in channels 'stable' and 'candidate'.
+    # Currently, we use mongodb, but eventually
+    # (when the 'candidate' moves to 'stable') this test
+    # will be testing nothing (if not failing).
+
+    async with base.CleanModel() as model:
+        app = await model.deploy('mongodb', channel='stable')
+        await model.wait_for_idle(status='active')
+
+        charm_url = URL.parse(app.data['charm-url'])
+        assert Schema.CHARM_HUB.matches(charm_url.schema)
+        still76 = False
+        try:
+            assert charm_url.revision == 76
+            still76 = True
+        except AssertionError:
+            logger.warning("Charm used in test_upgrade_charm_switch_channel "
+                           "seems to have been updated, revise the test")
+
+        await app.upgrade_charm(channel='candidate')
+        await model.wait_for_idle(status='active')
+
+        if still76:
+            try:
+                assert charm_url.revision == 75
+            except AssertionError:
+                raise errors.JujuError("Either the upgrade has failed, or the charm used moved "
+                                       "the candidate channel to stable, so no upgrade took place")
 
 
 @base.bootstrapped

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -174,10 +174,11 @@ async def test_upgrade_charm_channel(event_loop):
 async def test_upgrade_charm_switch_channel(event_loop):
     # Note for future:
     # This test requires a charm that has different
-    # revisions in channels 'stable' and 'candidate'.
-    # Currently, we use mongodb, but eventually
-    # (when the 'candidate' moves to 'stable') this test
+    # revisions for different channels/risks.
+    # Currently, we use juju-qa-test, but eventually
+    # (when the 'edge' moves to 'stable') this test
     # will be testing nothing (if not failing).
+    # So checks are in place for that.
 
     async with base.CleanModel() as model:
         app = await model.deploy('juju-qa-test', channel='2.0/stable')
@@ -187,7 +188,7 @@ async def test_upgrade_charm_switch_channel(event_loop):
         assert Schema.CHARM_HUB.matches(charm_url.schema)
         still22 = False
         try:
-            assert charm_url.revision == 76
+            assert charm_url.revision == 22
             still22 = True
         except AssertionError:
             logger.warning("Charm used in test_upgrade_charm_switch_channel "
@@ -198,6 +199,7 @@ async def test_upgrade_charm_switch_channel(event_loop):
 
         if still22:
             try:
+                charm_url = URL.parse(app.data['charm-url'])
                 assert charm_url.revision == 23
             except AssertionError:
                 raise errors.JujuError("Either the upgrade has failed, or the used charm moved "

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -180,25 +180,25 @@ async def test_upgrade_charm_switch_channel(event_loop):
     # will be testing nothing (if not failing).
 
     async with base.CleanModel() as model:
-        app = await model.deploy('mongodb', channel='stable')
+        app = await model.deploy('juju-qa-test', channel='2.0/stable')
         await model.wait_for_idle(status='active')
 
         charm_url = URL.parse(app.data['charm-url'])
         assert Schema.CHARM_HUB.matches(charm_url.schema)
-        still76 = False
+        still22 = False
         try:
             assert charm_url.revision == 76
-            still76 = True
+            still22 = True
         except AssertionError:
             logger.warning("Charm used in test_upgrade_charm_switch_channel "
                            "seems to have been updated, the test needs to be revised")
 
-        await app.upgrade_charm(channel='candidate')
+        await app.upgrade_charm(channel='2.0/edge')
         await model.wait_for_idle(status='active')
 
-        if still76:
+        if still22:
             try:
-                assert charm_url.revision == 75
+                assert charm_url.revision == 23
             except AssertionError:
                 raise errors.JujuError("Either the upgrade has failed, or the used charm moved "
                                        "the candidate channel to stable, so no upgrade took place, "

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -245,9 +245,10 @@ async def test_upgrade_local_charm(event_loop):
     async with base.CleanModel() as model:
         tests_dir = Path(__file__).absolute().parent
         charm_path = tests_dir / 'upgrade-charm'
-        app = await model.deploy('cs:ubuntu', series='focal')
+        app = await model.deploy('ch:ubuntu', series='focal')
         await model.wait_for_idle(status="active")
-        assert app.data['charm-url'].startswith('cs:ubuntu')
+        assert app.data['charm-url'].startswith('ch:') and 'ubuntu' in \
+               app.data['charm-url']
         await app.upgrade_charm(path=charm_path)
         await model.wait_for_idle(status="waiting")
         assert app.data['charm-url'] == 'local:focal/ubuntu-0'

--- a/tests/integration/test_charmhub.py
+++ b/tests/integration/test_charmhub.py
@@ -97,3 +97,11 @@ async def test_subordinate_charm_zero_units(event_loop):
         app2 = await model.deploy('rsyslog-forwarder-ha', num_units=1)
         await jasyncio.sleep(5)
         assert len(app2.units) == 0
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_list_resources(event_loop):
+    async with base.CleanModel() as model:
+        resources = await model.charmhub.list_resources('postgresql')
+        assert type(resources) == list and len(resources) > 0


### PR DESCRIPTION
#### Description

This cherry-picks the `upgrade-charm` fixes from #729 and #742 to bring them onto `2.9` branch. 

Includes the fix for the `juju.errors.JujuAPIError: missing base name or channel not valid` error when upgrading local charms.

#### QA Steps

Same QA Steps for #729 and #742 should work here.

```
tox -e integration -- tests/integration/test_application.py::test_upgrade_local_charm
```
```
tox -e integration -- tests/integration/test_charmhub.py::test_list_resources
```
```
tox -e integration -- tests/integration/test_application.py::test_upgrade_charm_switch_channel
```