### PR TITLE
[JUJU-1992] Fix charmhub series deploy 3.0

### DIFF
--- a/juju/client/overrides.py
+++ b/juju/client/overrides.py
@@ -80,11 +80,12 @@ class ResourcesFacade(Type):
         Returns -> typing.Union[_ForwardRef('ErrorResult'),
                                 typing.Sequence<+T_co>[str]]
         """
+        version = _client.ResourcesFacade.best_facade_version(self.connection)
         # map input types to rpc msg
         _params = dict()
         msg = dict(type='Resources',
                    request='AddPendingResources',
-                   version=2,
+                   version=version,
                    params=_params)
         _params['tag'] = application_tag
         _params['url'] = charm_url

--- a/juju/model.py
+++ b/juju/model.py
@@ -1739,7 +1739,8 @@ class Model:
             raise JujuError('unknown charm or bundle {}'.format(entity_url))
         identifier = res.identifier
 
-        series = res.origin.series or series
+        series = res.origin.series if self.connection().is_using_old_client \
+            else series
         if res.is_bundle:
             handler = BundleHandler(self, trusted=trust, forced=force)
             await handler.fetch_plan(url, res.origin, overlays=overlays)


### PR DESCRIPTION
#### Description

This fixes the issue with `model.deploy` using charmhub, where we're trying to get the `series` field from the origin returned by resolving the charm. However, `CharmOrigin` no longer has the `series` field in Juju 3.0 (it's replaced with the `base` field), so the origin we get as a part of the result of calling the `ResolveCharms` function no longer has the `series` field.

Note that we gotta keep it in place for clients using older controllers (i.e. `2.9`).

This also fixes the issue where we apparently hardcoded the version of the `Resources` interface (to be 2). With this change, we get that info dynamically from the facade version.

#### QA Steps

Following should work with both `2.9` and `3.0/candidate` controllers.

```python
        application = await model.deploy(
            'ch:minio'
        )
```

#### Notes & Discussion

We also need to focus on the `latest-edge` jenkins CI job, which is currently not working (for jenkins infra issues). I suspect that the change in the `CharmOrigin` is fundamental enough that a bunch more things will blow in libjuju. Therefore the CI test against the latest juju becomes critical, as we would've caught this issue way before it's raised if the jenkins job was working correctly.