### PR TITLE
[JUJU-2017] Check subordinate field value instead of existence

### DIFF
--- a/juju/charmhub.py
+++ b/juju/charmhub.py
@@ -38,7 +38,8 @@ class CharmHub:
         url = "{}/v2/charms/info/{}?fields=default-release.revision.subordinate".format(charmhub_url.value, charm_name)
         _response = await self.request_charmhub_with_retry(url, 5)
         response = json.loads(_response.text)
-        return 'subordinate' in response['default-release']['revision']
+        rev_response = response['default-release']['revision']
+        return 'subordinate' in rev_response and rev_response['subordinate']
 
     # TODO (caner) : we should be able to recreate the channel-map through the
     #  api call without needing the CharmHub facade

--- a/tests/integration/test_charmhub.py
+++ b/tests/integration/test_charmhub.py
@@ -123,6 +123,14 @@ async def test_subordinate_charm_zero_units(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+async def test_subordinate_false_field_exists(event_loop):
+    async with base.CleanModel() as model:
+        assert await model.charmhub.is_subordinate("rsyslog-forwarder-ha")
+        assert not await model.charmhub.is_subordinate("mysql-innodb-cluster")
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
 async def test_list_resources(event_loop):
     async with base.CleanModel() as model:
         resources = await model.charmhub.list_resources('postgresql')


### PR DESCRIPTION
#### Description

This checks the `subordinate` field value from `default-release.revision` from charmhub. Previously we were just checking if it exists.

fixes #750


#### QA Steps

```
tox -e integration -- tests/integration/test_charmhub.py::test_subordinate_false_field_exists
```