### PR TITLE
[JUJU-1705] Make sure the action status is correctly set

### DIFF
--- a/juju/action.py
+++ b/juju/action.py
@@ -14,8 +14,7 @@ class Action(model.ModelEntity):
 
     async def fetch_output(self):
         completed_action = await self.model._get_completed_action(self.id)
-        self.results = {} if completed_action.output is None else \
-            completed_action.output
+        self.results = completed_action.output or {}
         self._status = completed_action.status
 
     async def wait(self):

--- a/juju/action.py
+++ b/juju/action.py
@@ -6,13 +6,16 @@ class Action(model.ModelEntity):
     def __init__(self, entity_id, model, history_index=-1, connected=True):
         super().__init__(entity_id, model, history_index, connected)
         self.results = {}
+        self._status = self.data['status']
 
     @property
     def status(self):
-        return self.data['status']
+        return self._status
 
     async def fetch_output(self):
-        self.results = await self.model.get_action_output(self.id)
+        completed_action = await self.model._get_completed_action(self.id)
+        self.results = completed_action.output
+        self._status = completed_action.status
 
     async def wait(self):
         self.results or await self.fetch_output()

--- a/juju/action.py
+++ b/juju/action.py
@@ -14,7 +14,8 @@ class Action(model.ModelEntity):
 
     async def fetch_output(self):
         completed_action = await self.model._get_completed_action(self.id)
-        self.results = completed_action.output
+        self.results = {} if completed_action.output is None else \
+            completed_action.output
         self._status = completed_action.status
 
     async def wait(self):


### PR DESCRIPTION
#### Description

This fixes the way we set the status of an action that's ran on a unit. Previously only the `action.output` was being returned and the actual status of the action was being retrieved from the `self.data[]` (as the Action object is a modelEntity), which is not reliable at the moment. This PR changes it to get it directly from the Action object returned by the Juju API when the action completes (with either `completed` or `failed`) status. So it should be completely accurate all the time.

Fixes #719

#### QA Steps

Following should pass %100.

```
tox -e integration -- tests/integration/test_unit.py::test_run
```