### PR TITLE
[JUJU-2027] Local refresh with resoruces

### DIFF
--- a/juju/application.py
+++ b/juju/application.py
@@ -637,14 +637,11 @@ class Application(model.ModelEntity):
         :param str switch: Crossgrade charm url
 
         """
-        if resources is not None:
-            raise NotImplementedError("resources option is not implemented")
 
         if switch is not None and revision is not None:
             raise ValueError("switch and revision are mutually exclusive")
 
         app_facade = self._facade()
-        resources_facade = client.ResourcesFacade.from_connection(self.connection)
         charms_facade = client.CharmsFacade.from_connection(self.connection)
 
         # 1 - Figure out the destination origin and destination charm_url
@@ -663,6 +660,9 @@ class Application(model.ModelEntity):
             await self.local_refresh(origin, force, force_series,
                                      force_units, path, resources)
             return
+
+        if resources is not None:
+            raise NotImplementedError("resources option is not implemented")
 
         parsed_url = URL.parse(charm_url)
         charm_name = parsed_url.name
@@ -731,6 +731,7 @@ class Application(model.ModelEntity):
         # Already prepped the charm_resources
         # Now get the existing resources from the ResourcesFacade
         request_data = [client.Entity(self.tag)]
+        resources_facade = client.ResourcesFacade.from_connection(self.connection)
         response = await resources_facade.ListResources(entities=request_data)
         existing_resources = {
             resource.name: resource

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -266,6 +266,26 @@ async def test_upgrade_local_charm(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+async def test_upgrade_local_charm_resource(event_loop):
+    async with base.CleanModel() as model:
+        tests_dir = Path(__file__).absolute().parent
+        charm_path = tests_dir / 'file-resource-charm'
+        resources = {"file-res": "test.file"}
+
+        app = await model.deploy(str(charm_path), resources=resources)
+        assert 'file-resource-charm' in model.applications
+        await model.wait_for_idle()
+        assert app.units[0].agent_status == 'idle'
+
+        await app.upgrade_charm(path=charm_path, resources=resources)
+        await model.wait_for_idle()
+        ress = await app.get_resources()
+        assert 'file-res' in ress
+        assert ress['file-res']
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
 @pytest.mark.skip('Update charm')
 async def test_upgrade_switch_charmstore_to_charmhub(event_loop):
     async with base.CleanModel() as model:


### PR DESCRIPTION
#### Description

This fixes the regression where we don't accept local refresh (`upgrade-charm`) with resources.

Fixes #756 

#### QA Steps

Added an additional test to catch this in the future:

```
tox -e integration -- tests/integration/test_application.py::test_upgrade_local_charm_resource
```