### PR TITLE
[JUJU-2026] Improve resolve charm

### DIFF
--- a/juju/origin.py
+++ b/juju/origin.py
@@ -1,6 +1,8 @@
 from enum import Enum
 from .errors import JujuError
 
+from . import utils
+
 
 class Source(Enum):
     """Source defines a origin source. Providing a hint to the controller about
@@ -111,6 +113,19 @@ class Channel:
         if self.track != "":
             path = "{}/{}".format(self.track, path)
         return path
+
+    def compute_base_channel(self, series=None):
+        """Determines the channel for a client.Base
+        A base channel is a track/risk/branch
+
+        """
+        _ch = [self.risk]
+        tr = self.track
+        if series:
+            tr = utils.get_series_version(series)
+        if tr:
+            _ch = [tr] + _ch
+        return "/".join(_ch)
 
 
 class Platform:

--- a/tests/integration/test_unit.py
+++ b/tests/integration/test_unit.py
@@ -239,3 +239,17 @@ async def test_resolve_local(event_loop):
             # Errored units won't get cleaned up unless we force them.
             await asyncio.gather(*(machine.destroy(force=True)
                                    for machine in model.machines.values()))
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_unit_introspect(event_loop):
+    async with base.CleanModel() as model:
+        await model.deploy('ubuntu', series='jammy')
+        await model.wait_for_idle(status="active")
+
+        await model.deploy('juju-introspect',
+                           channel='edge',
+                           series='jammy',
+                           to='0',
+                           )


### PR DESCRIPTION
#### Description

This fixes the latest issues related to the `series` information for both local and charmhub charms.

Fixes #758, #759 


#### QA Steps

To QA the #758, I downloaded the `hello-kubecon` and tried it with that, so following should work:

```python
await model.deploy('./hello-kubecon_ubuntu-20.04-amd64.charm', series='focal', trust=True)
```

And for the #759, I added that specific case as an integration test, so the following should work:

```
tox -e integration -- tests/integration/test_unit.py::test_unit_introspect
```

For everything else the current tests in the CI should pass.