### PR TITLE
[JUJU-2391] Fix wrong bases analysis.

### DIFF
--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -11,8 +11,8 @@ Documentation: https://pythonlibjuju.readthedocs.io/en/latest/
 Requirements
 ------------
 
-* Python 3.6+
-* Juju 2.0+
+* Python 3.8/3.9/3.10
+* Tested using Juju 3.0.2
 
 
 Design Notes

--- a/juju/utils.py
+++ b/juju/utils.py
@@ -385,9 +385,9 @@ def get_local_charm_base(series, channel_from_arg, charm_metadata,
         else:
             # Also check the charmcraft.yaml
             charmcraft_yaml = get_local_charm_charmcraft_yaml(charm_path)
-        if 'bases' in charmcraft_yaml:
-            channel_for_base = charmcraft_yaml['bases'][0]['run-on'][0]['channel']
-            os_name_for_base = charmcraft_yaml['bases'][0]['run-on'][0]['name']
+            if 'bases' in charmcraft_yaml:
+                channel_for_base = charmcraft_yaml['bases'][0]['run-on'][0]['channel']
+                os_name_for_base = charmcraft_yaml['bases'][0]['run-on'][0]['name']
 
     if channel_for_base == '':
         raise errors.JujuError("Unable to determine base for charm : %s" %

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,11 @@ passenv =
     TEST_AGENTS
     LXD_DIR
 deps =
+    macaroonbakery
+    theblues
+    toposort
+    typing-inspect
+    paramiko
     asynctest
     ipdb
     mock


### PR DESCRIPTION
#### Description

This should fix a base recognition for local charms as described [here](https://bugs.launchpad.net/juju/+bug/1992833).

#### QA Steps
Using a 3.0 controller run:
```
juju download parca-k8s --channel=edge
python3 -m asyncio
>>> from juju.model import Model
>>> model = Model()
>>> await model.connect_current()
>>> await model.deploy("./parca-k8s_9258025.charm")
```

#### Notes & Discussion

This has to be ported to the 2.9 branch.