### PR TITLE
[JUJU-2573] Base argument for model deploy

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -1676,7 +1676,8 @@ class Model:
 
         charm_series = series
         charm_origin = res.origin
-        charm_origin.base = utils.parse_base_arg(base) if base else None
+        if base:
+            charm_origin.base = utils.parse_base_arg(base)
 
         if res.is_bundle:
             handler = BundleHandler(self, trusted=trust, forced=force)

--- a/juju/model.py
+++ b/juju/model.py
@@ -1604,7 +1604,7 @@ class Model:
     async def deploy(
             self, entity_url, application_name=None, bind=None,
             channel=None, config=None, constraints=None, force=False,
-            num_units=1, overlays=[], plan=None, resources=None, series=None,
+            num_units=1, overlays=[], base=None, resources=None, series=None,
             storage=None, to=None, devices=None, trust=False, attach_storage=[]):
         """Deploy a new service or bundle.
 
@@ -1620,9 +1620,9 @@ class Model:
             an unsupported series
         :param int num_units: Number of units to deploy
         :param [] overlays: Bundles to overlay on the primary bundle, applied in order
-        :param str plan: Plan under which to deploy charm
+        :param str base: The base on which to deploy
         :param dict resources: <resource name>:<file path> pairs
-        :param str series: Series on which to deploy
+        :param str series: Series on which to deploy DEPRECATED: use --base (with Juju 3.1)
         :param dict storage: Storage constraints TODO how do these look?
         :param to: Placement directive as a string. For example:
 
@@ -1675,10 +1675,12 @@ class Model:
         identifier = res.identifier
 
         charm_series = series
+        charm_origin = res.origin
+        charm_origin.base = utils.parse_base_arg(base) if base else None
 
         if res.is_bundle:
             handler = BundleHandler(self, trusted=trust, forced=force)
-            await handler.fetch_plan(url, res.origin, overlays=overlays)
+            await handler.fetch_plan(url, charm_origin, overlays=overlays)
             await handler.execute_plan()
             extant_apps = {app for app in self.applications}
             pending_apps = handler.applications - extant_apps
@@ -1698,11 +1700,12 @@ class Model:
             # XXX: we're dropping local resources here, but we don't
             # actually support them yet anyway
             if not res.is_local:
-                add_charm_res = await self._add_charm(identifier, res.origin)
+                add_charm_res = await self._add_charm(identifier, charm_origin)
                 if isinstance(add_charm_res, dict):
                     # This is for backwards compatibility for older
                     # versions where AddCharm returns a dictionary
-                    charm_origin = add_charm_res.get('charm_origin', res.origin)
+                    charm_origin = add_charm_res.get('charm_origin',
+                                                     charm_origin)
                 else:
                     charm_origin = add_charm_res.charm_origin
                 if Schema.CHARM_HUB.matches(url.schema):
@@ -1718,15 +1721,13 @@ class Model:
             else:
                 # We have a local charm dir that needs to be uploaded
                 charm_dir = os.path.abspath(os.path.expanduser(identifier))
-                charm_origin = res.origin
-                base = None
-
                 metadata = utils.get_local_charm_metadata(charm_dir)
                 charm_series = charm_series or await get_charm_series(metadata,
                                                                       self)
-                base = utils.get_local_charm_base(
-                    charm_series, channel, metadata, charm_dir, client.Base)
-                charm_origin.base = base
+                if not base:
+                    charm_origin.base = utils.get_local_charm_base(
+                        charm_series, channel, metadata, charm_dir, client.Base)
+
                 if not application_name:
                     application_name = metadata['name']
                 if not application_name:

--- a/juju/utils.py
+++ b/juju/utils.py
@@ -10,6 +10,7 @@ import yaml
 import zipfile
 
 from . import jasyncio, origin, errors
+from .client import client
 
 
 async def execute_process(*cmd, log=None):
@@ -403,3 +404,15 @@ def base_channel_to_series(channel):
     :return: str series (e.g. focal)
     """
     return get_version_series(origin.Channel.parse(channel).track)
+
+
+def parse_base_arg(base):
+    """Parses a given base into a Client.Base object
+    :param base str : The base to deploy a charm (e.g. ubuntu@22.04)
+    """
+    client.CharmBase()
+    if type(base) != str or "@" not in base:
+        raise errors.JujuError("expected base string to contain os and channel separated by '@'")
+
+    name, channel = base.split('@')
+    return client.Base(name=name, channel=channel)

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -338,6 +338,14 @@ async def test_deploy_from_ch_with_invalid_series(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+async def test_deploy_with_base(event_loop):
+    async with base.CleanModel() as model:
+        await model.deploy("ubuntu", base="ubuntu@22.04")
+        await model.wait_for_idle(status='active')
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
 async def test_add_machine(event_loop):
     from juju.machine import Machine
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -14,6 +14,8 @@ class TestDirResolve(unittest.TestCase):
         assert public.endswith('ssh/juju_id_rsa.pub')
         assert private.endswith('ssh/juju_id_rsa')
 
+
+class TestBaseArgument(unittest.TestCase):
     def test_parse_base_arg(self):
         base = parse_base_arg('ubuntu@22.04')
         assert isinstance(base, client.Base)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,7 @@
 import unittest
 
-from juju.utils import juju_config_dir, juju_ssh_key_paths
+from juju.utils import juju_config_dir, juju_ssh_key_paths, parse_base_arg
+from juju.client import client
 
 
 class TestDirResolve(unittest.TestCase):
@@ -12,3 +13,9 @@ class TestDirResolve(unittest.TestCase):
         public, private = juju_ssh_key_paths()
         assert public.endswith('ssh/juju_id_rsa.pub')
         assert private.endswith('ssh/juju_id_rsa')
+
+    def test_parse_base_arg(self):
+        base = parse_base_arg('ubuntu@22.04')
+        assert isinstance(base, client.Base)
+        assert base.name == 'ubuntu'
+        assert base.channel == '22.04'


### PR DESCRIPTION
#### Description

This adds the `base` argument to the `model.Deploy()`, in accordance with the upcoming Juju `3.1`.

#### QA Steps

Adds a unit test for the new `parse_base_arg` utility and an integration test for deploying with base, so the following tests should be passing:

```
tox -e py3 -- tests/unit/test_utils.py::TestBaseArgument::test_parse_base_arg
```

```
tox -e integration -- tests/integration/test_model.py::test_deploy_with_base
```