### PR TITLE
Add destroy units

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -2014,7 +2014,13 @@ class Model:
             'max-wait': max_wait,
             'dry-run': dry_run,
         }])
-    destroy_units = destroy_unit
+
+    async def destroy_units(self, *unit_names, destroy_storage=False, dry_run=False, force=False, max_wait=None):
+        """Destroy several units at once.
+
+        """
+        for u in unit_names:
+            await self.destroy_unit(u, destroy_storage, dry_run, force, max_wait)
 
     def download_backup(self, archive_id, target_filename=None):
         """Download a backup archive file.

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -884,6 +884,23 @@ async def test_wait_for_idle_with_exact_units_scale_down_zero(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+async def test_destroy_units(event_loop):
+    async with base.CleanModel() as model:
+        app = await model.deploy(
+            'ubuntu',
+            application_name='ubuntu',
+            series='jammy',
+            channel='stable',
+            num_units=3,
+        )
+        await model.wait_for_idle(status='active')
+        await model.destroy_units(*[u.name for u in app.units])
+        await model.wait_for_idle(timeout=5 * 60, wait_for_exact_units=0)
+        assert app.units == []
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
 async def test_watcher_reconnect(event_loop):
     async with base.CleanModel() as model:
         await model.connection().close()


### PR DESCRIPTION
#### Description

This brings back the separate `model.destroy_units(*units)` as a quality of life feature. 

Fixes #811 

#### QA Steps

All the regular tests should pass. Additionally, this also adds a separate integration test for `destroy_units`, so the following should be passing (I tried it on juju 3.1).

```
tox -e integration -- tests/integration/test_model.py::test_destroy_units
```
#### Notes & Discussion

As a future reference, this was changed in #791.