### PR TITLE
[JUJU-3253] add missing force in bundle deployment

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -500,7 +500,7 @@ class CharmStoreDeployType:
         suggested_name = meta.get('charm-metadata', {}).get('Name')
         return suggested_name or meta.get('id', {}).get('Name')
 
-    async def resolve(self, url, architecture, app_name=None, channel=None, series=None, entity_url=None):
+    async def resolve(self, url, architecture, app_name=None, channel=None, series=None, entity_url=None, force=False):
         """resolve attempts to resolve charmstore charms or bundles. A request
         to the charmstore is required to get more information about the
         underlying identifier.

--- a/juju/model.py
+++ b/juju/model.py
@@ -443,7 +443,7 @@ class LocalDeployType:
     """LocalDeployType deals with local only deployments.
     """
 
-    async def resolve(self, url, architecture, app_name=None, channel=None, series=None, entity_url=None):
+    async def resolve(self, url, architecture, app_name=None, channel=None, series=None, entity_url=None, force=False):
         """resolve attempts to resolve a local charm or bundle using the url
         and architecture. If information is missing, it will attempt to backfill
         that information, before sending the result back.


### PR DESCRIPTION
#### Description

Fix #814 

This PR propagates the `force` argument and use it to deploy bundles.


#### QA Steps
Following the example from #814

```python
from juju.model import Model

model = Model()
await model.connect_current()
await model.deploy("weebl", series="jammy")
```
The code above will fail. Nevertheless, if we use `force=True` the deployment will be sucessful.
```
await model.deploy("weebl", series="jammy")
```

#### Notes & Discussion

A similar problem may occur for other use cases. 
This has to be propagated to the master branch.