### PR TITLE
Fix _resolve_charm errors

### DIFF
--- a/juju/bundle.py
+++ b/juju/bundle.py
@@ -358,7 +358,7 @@ class BundleHandler:
                                             architecture=architecture,
                                             risk=risk,
                                             track=track)
-                charm_url, charm_origin, _ = await self.model._resolve_charm(charm_url, origin)
+                charm_url, charm_origin = await self.model._resolve_charm(charm_url, origin)
 
                 spec['charm'] = str(charm_url)
             else:
@@ -731,7 +731,7 @@ class AddCharmChange(ChangeInfo):
                                         architecture=arch,
                                         risk=ch.risk,
                                         track=ch.track)
-            identifier, origin, _ = await context.model._resolve_charm(url, origin)
+            identifier, origin = await context.model._resolve_charm(url, origin)
 
         if identifier is None:
             raise JujuError('unknown charm {}'.format(self.charm))

--- a/juju/model.py
+++ b/juju/model.py
@@ -1713,7 +1713,7 @@ class Model:
         client_facade = client.ClientFacade.from_connection(self.connection())
         return await client_facade.AddCharm(channel=str(origin.risk), url=charm_url, force=False)
 
-    async def _resolve_charm(self, url, origin, force):
+    async def _resolve_charm(self, url, origin, force=False):
         charms_cls = client.CharmsFacade
         if charms_cls.best_facade_version(self.connection()) < 3:
             raise JujuError("resolve charm")
@@ -1753,7 +1753,7 @@ class Model:
             else:
                 raise JujuError("Series {} not supported for {}. Only {}".format(origin.series, result.url, supported_series))
 
-        return charm_url, result.charm_origin
+        return result.url, result.charm_origin
 
     async def _resolve_architecture(self, url):
         if url.architecture:


### PR DESCRIPTION
#### Description

This adds some changes to fix some errors about the `_resolve_charm` method that are accidentally introduced in #825.

* `_resolve_charm` force parameter is made optional
* fixed the `_resolve_charm` calls in the `bundle.py` to have less number of variables to unpack onto


#### QA Steps

The ones that are `FAILED` in [#825's CI run ](https://github.com/juju/python-libjuju/actions/runs/4622441500/jobs/8175154975) need to be passing.

In fact all of the CI tests need to pass. 