### PR TITLE
Add ability to share juju model across integration tests

### DIFF
--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -35,7 +35,7 @@ async def test_model_name(event_loop):
     with pytest.raises(JujuModelError):
         model.name
 
-    async with base.CleanModel() as new_model:
+    async with base.CachedModel() as new_model:
         await model.connect(new_model.name)
         assert model.name == new_model.name
         await model.disconnect()
@@ -46,7 +46,7 @@ async def test_model_name(event_loop):
 async def test_deploy_local_bundle_dir(event_loop):
     bundle_path = TESTS_DIR / 'bundle'
 
-    async with base.CleanModel() as model:
+    async with base.CachedModel() as model:
         await model.deploy(str(bundle_path))
 
         app1 = model.applications.get('grafana')


### PR DESCRIPTION
#### Description

Our integration tests taking very long and timing out. We also add additional tests whenever we develop or fix things, so the test time is getting worse and worse. This proposes an idea where we can save up some time re-using models across test cases wherever possible, possibly saving a lot of time.

Currently the tests use the context manager named `CleanModel`  to initiate and use a new model, by connecting to the current controller, adding a brand new model, connecting to that model and returning it, each time a test uses that context.

This is a prototype change that introduces the `CachedModel` where we initially do the same steps as the CleanModel, however, when we get out of the context we don't destroy the model, we just clean it up for the next test to use it. The purpose is to save up time not creating and destroying models for every single test case.

Note that we have a bunch of tests that I believe this is not going to work, but for those that will, all we need to do is to change the model to the `CachedModel` and it should work as it is. For the other tests that needs a fresh model to work, we can simply left them as they are, i.e. continue using the `CleanModel`.

This is a prototype, so a couple of design decisions need to be made, one being that currently the model we use (I named it `cached-model-for-testing`) is not being destroyed anywhere and it needs to be picked up by whichever process starts this again (currently if we use this model in a separate process --restart the tox test somewhere else-- it fails with "can't create this model, it already exists"). Possible spot for this is the tox where we initialize the testing environment. It might even be plausible to create this model in the tox setup phase before starting to run the tests to begin with (and destroy it there).

#### QA Steps

We need to somehow make sure that no result of any tests are being affected by this change, i.e. make sure that tests are passing for the right reason.