### PR TITLE
[JUJU-3583] wait_for_idle to not block when enough units are ready

### DIFF
--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -776,6 +776,28 @@ async def test_wait_for_idle_with_not_enough_units(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+async def test_wait_for_idle_more_units_than_needed(event_loop):
+    async with base.CleanModel() as model:
+        charm_path = TESTS_DIR / 'charm'
+
+        # we add 2 units of a local charm that does nothing
+        # (i.e. can't go into active/idle)
+        await model.deploy(str(charm_path), num_units=2)
+
+        # then add 1 unit of ubuntu charm
+        await model.deploy(
+            'ubuntu',
+            application_name='ubuntu',
+            num_units=1,
+        )
+
+        # because the wait_for_units=1, wait_for_idle should return without timing out
+        # even though there are two more units that aren't active/idle
+        await model.wait_for_idle(timeout=5 * 60, wait_for_units=1, status='active')
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
 async def test_wait_for_idle_with_enough_units(event_loop):
     async with base.CleanModel() as model:
         await model.deploy(


### PR DESCRIPTION
#### Description

`wait_for_idle` will keep waiting (until timeout) if there are less number of units available than requested (via the `wait_for_units` flag). This is a correct behavior. However, if there are already a number of units in a desired status ready to go, more than (or equal to) `wait_for_units`, then it shouldn't block until the other not-yet-available units to get into that desired state as well. This is because when we first introduced that flag we respected the former case, however, we did not consider the latter case where the `wait_for_idle` to return when that number of units is reached (without further blocking for whatever reason).

fixes #837 

#### QA Steps

An integration test is added for this particular case. That needs to pass. Also the other `wait_for_idle` related integration tests should be passing too.

```
tox -e integration -- tests/integration/test_model.py::test_wait_for_idle_more_units_than_needed
```