### PR TITLE
[JUJU-3750] Fix bug in Type.from_json() parsing simple entries

### DIFF
--- a/juju/client/facade.py
+++ b/juju/client/facade.py
@@ -689,7 +689,7 @@ class Type:
                             cls.splitEntries(v, d)
                 else:
                     # this is a simple entry
-                    cls.splitEntries(v, d)
+                    cls.splitEntries(entry, d)
             return cls(**d)
         return None
 

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -151,6 +151,13 @@ async def test_deploy_local_charm(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+async def test_deploy_charm_assumes(event_loop):
+    async with base.CleanModel() as model:
+        await model.deploy('postgresql', channel='14/edge')
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
 async def test_deploy_local_charm_channel(event_loop):
     charm_path = TESTS_DIR / 'charm'
 


### PR DESCRIPTION
#### Description

This fixes a bug found in the `facade.py` parsing simple entries in the `Type.from_json()` function.

Should fix #850 & #851


#### QA Steps

To go with the same way of #850 and #851 to reproduce this, using juju `2.9.42`, bootstrap a k8s model (I did it on microk8s).

```sh
 $ juju bootstrap microk8s removeme
```

Then get a libjuju console on the toplevel dir:

```sh
 $ python -m asyncio
```

Then the following should work just fine:

```sh
from juju import model;m = model.Model(); await m.connect(); await m.deploy("postgresql", channel="14/edge")
```

Also added an integration test that should work (fails without this change):

```tox
 tox -e integration -- tests/integration/test_model.py::test_deploy_charm_assumes
```

which just runs `await model.deploy('postgresql', channel='14/edge')`

Note that this is not the ideal test because it depends on that the upstream charm having the simple

assumes:
  -juju

expression. However, simulating the bug in the facade.py for parsing such expressions is non-trivial as we need a test to call something like the CharmsFacade.CharmInfo() to trigger parsing the metadata (which is actually where it fails in the reported bug). Creating a local charm wouldn't work because we locally handle the metadata (wihtout going through anything in the facade.py where the bug is located). Maybe we can manually call AddCharm in the test for a local charm and then manually call the CharmInfo with the returned url.

All CI tests need to pass.

#### Notes & Discussion

This will need to be forward ported into the master.