### PR TITLE
Add base.bootstrapped decorator to integration test

### DIFF
--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -341,6 +341,7 @@ async def test_deploy_from_ch_channel_revision_success(event_loop):
         await model.deploy("postgresql", application_name="test2", channel='latest/stable', revision=290)
 
 
+@base.bootstrapped
 @pytest.mark.asyncio
 async def test_deploy_trusted_bundle(event_loop):
     async with base.CleanModel() as model:


### PR DESCRIPTION
#### Description

Looks like we accidentally took out a useful decorator in 5b55b35

The `base.bootstrapped` allows to test to skip (instead of failing) if there's no bootstrapped juju in the environment (which we don't in the merge jobs in jenkins).

#### QA Steps

All CI tests need to pass.

The `github-check-merge-juju-python-libjuju` job fails without this, so that job should be passing.

#### Notes & Discussion

https://github.com/juju/python-libjuju/pull/853 should rebase on `master` after this lands.