### PR TITLE
fix: support ipv6 in connection

### DIFF
--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -694,7 +694,7 @@ class Connection:
 
         """
         endpoint = self.endpoint
-        host, remainder = endpoint.split(':', 1)
+        host, remainder = endpoint.rsplit(':', 1)
         port = remainder
         if '/' in remainder:
             port, _ = remainder.split('/', 1)


### PR DESCRIPTION
#### Description

Current connection only supports ipv4 addresses, which throws a ValueError when ipv6 address is passed (`int(port)`).

```
Traceback (most recent call last):
  File "/home/yanks/Documents/canonical/jenkins-k8s-operator/.tox/integration/lib/python3.10/site-packages/pytest_asyncio/plugin.py", line 320, in _async_fixture_wrapper
    return event_loop.run_until_complete(setup())
  File "/usr/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete
    return future.result()
  File "/home/yanks/Documents/canonical/jenkins-k8s-operator/.tox/integration/lib/python3.10/site-packages/pytest_asyncio/plugin.py", line 317, in setup
    res = await func(**_add_kwargs(func, kwargs, event_loop, request))
  File "/home/yanks/Documents/canonical/jenkins-k8s-operator/tests/integration/conftest.py", line 159, in jenkins_machine_agent_fixture
    agent_app = await machine_model.deploy("jenkins-agent")
  File "/home/yanks/Documents/canonical/jenkins-k8s-operator/.tox/integration/lib/python3.10/site-packages/juju/model.py", line 1787, in deploy
    is_sub = await self.charmhub.is_subordinate(url.name)
  File "/home/yanks/Documents/canonical/jenkins-k8s-operator/.tox/integration/lib/python3.10/site-packages/juju/charmhub.py", line 35, in is_subordinate
    conn, headers, path_prefix = self.model.connection().https_connection()
  File "/home/yanks/Documents/canonical/jenkins-k8s-operator/.tox/integration/lib/python3.10/site-packages/juju/client/connection.py", line 699, in https_connection
    host, int(port),
ValueError: invalid literal for int() with base 10: '7b4b:909c:3c9a:216:3eff:fe98:cf21]:17070'
```

This change adds support for ipv6 addresses.


#### QA Steps

```
tox -e py3 -- tests/unit/...
```

```
tox -e integration -- tests/integration/...
```

All CI tests need to pass.

*\<Please note that most likely an additional test will be required by the reviewers for any change that's not a one liner to land.\>*

#### Notes & Discussion

*\<Additional notes for the reviewers if needed. Please delete section if not applicable.\>*