### PR TITLE
[JUJU-3885] forward port ipv6 support

### DIFF
--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -694,7 +694,9 @@ class Connection:
 
         """
         endpoint = self.endpoint
-        host, remainder = endpoint.split(':', 1)
+        # Support IPv6 by right splitting on : and removing [] around IP address for host
+        host, remainder = endpoint.rsplit(':', 1)
+        host = host.strip("[]")
         port = remainder
         if '/' in remainder:
             port, _ = remainder.split('/', 1)


### PR DESCRIPTION
#### Description

This PR cherry picks the ipv6 support from 2.9 branch onto the master branch.

Initially reported by https://github.com/juju/python-libjuju/pull/862.


#### QA Steps

All CI tests need to pass.

Particularly the `test/integration/test_connection.py` and `tests/integration/test_controller.py` should be passing.

Manually testing with ipv4 and ipv6 allocation would help.