### PR TITLE
[JUJU-3887] Avoid removing the track if set to latest in channel normalization

### DIFF
--- a/juju/origin.py
+++ b/juju/origin.py
@@ -97,7 +97,9 @@ class Channel:
         return Channel(track, risk)
 
     def normalize(self):
-        track = self.track if self.track != "latest" else ""
+        # TODO (cderici): this is essentially a noop, needs to be revised in both
+        #  2.9 and 3.x
+        track = self.track if self.track != "" else ""
         risk = self.risk if self.risk != "" else ""
         return Channel(track, risk)
 

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -355,7 +355,7 @@ class TestAddApplicationChangeRun:
 
         context = Mock()
         context.resolve.return_value = "ch:charm1"
-        context.origins = {"ch:charm1": {"stable": Mock()}}
+        context.origins = {"ch:charm1": {"latest/stable": Mock()}}
         context.trusted = False
         context.model = model
 

--- a/tests/unit/test_origin.py
+++ b/tests/unit/test_origin.py
@@ -30,7 +30,7 @@ class TestChannel(unittest.TestCase):
 
     def test_parse_then_normalize(self):
         ch = Channel.parse("latest/stable").normalize()
-        self.assertEqual(ch, Channel(None, "stable"))
+        self.assertEqual(ch, Channel("latest", "stable"))
 
     def test_str_risk_only(self):
         ch = Channel.parse("stable")
@@ -50,7 +50,7 @@ class TestChannel(unittest.TestCase):
 
     def test_str_then_normalize(self):
         ch = Channel.parse("latest/stable").normalize()
-        self.assertEqual(str(ch), "stable")
+        self.assertEqual(str(ch), "latest/stable")
 
 
 class TestPlatform(unittest.TestCase):


### PR DESCRIPTION
#### Description

This is essentially a backport of a fix we already have in the master branch. In the past we used to remove the `latest` track from the origin channel as part of the normalization even if it's set by the user via the `--channel` flag. Now we're passing it through into the `ResolveCharm`.

Fixes #863


#### QA Steps

We can directly use the scenario in #863 

```sh
python -m asyncio
asyncio REPL 3.10.6 (main, Mar 10 2023, 10:55:28) [GCC 11.3.0] on linux
Use "await" directly instead of "asyncio.run()".
Type "help", "copyright", "credits" or "license" for more information.
>>> import asyncio
>>> from juju import model; m=model.Model(); await m.connect();await m.deploy("postgresql-k8s",series="focal", channel="latest/stable")
<Application entity_id="postgresql-k8s">
>>>
```