### PR TITLE
[JUJU-3886] Kubernetes series version

### DIFF
--- a/juju/utils.py
+++ b/juju/utils.py
@@ -316,11 +316,18 @@ UBUNTU_SERIES = {
     KINETIC: "22.10",
 }
 
+KUBERNETES = "kubernetes"
+KUBERNETES_SERIES = {
+    KUBERNETES: "kubernetes"
+}
+
+ALL_SERIES_VERSIONS = {**UBUNTU_SERIES, **KUBERNETES_SERIES}
+
 
 def get_series_version(series_name):
-    if series_name not in UBUNTU_SERIES:
+    if series_name not in ALL_SERIES_VERSIONS:
         raise errors.JujuError("Unknown series : %s", series_name)
-    return UBUNTU_SERIES[series_name]
+    return ALL_SERIES_VERSIONS[series_name]
 
 
 def get_version_series(version):
@@ -349,7 +356,10 @@ def get_local_charm_base(series, charm_path, base_class):
             # we currently only support ubuntu series (statically)
             # TODO (cderici) : go juju/core/series/supported.go and get the
             #  others here too
-            os_name_for_base = 'ubuntu'
+            if series in KUBERNETES_SERIES:
+                os_name_for_base = 'kubernetes'
+            else:
+                os_name_for_base = 'ubuntu'
 
     # Check the charm manifest
     if channel_for_base == '':

--- a/tests/integration/charm-series-kubernetes/config.yaml
+++ b/tests/integration/charm-series-kubernetes/config.yaml
@@ -1,0 +1,4 @@
+options:
+  status:
+    type: string
+    default: "active"

--- a/tests/integration/charm-series-kubernetes/dispatch
+++ b/tests/integration/charm-series-kubernetes/dispatch
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+status="$(config-get status)"
+
+if [[ "$status" == "error" ]]; then
+    if [[ -e .errored ]]; then
+        status="active"
+    else
+        touch .errored
+        exit 1
+    fi
+fi
+status-set "$status"

--- a/tests/integration/charm-series-kubernetes/metadata.yaml
+++ b/tests/integration/charm-series-kubernetes/metadata.yaml
@@ -1,0 +1,5 @@
+name: charm
+series: ["kubernetes"]
+summary: "test"
+description: "test"
+maintainers: ["test"]


### PR DESCRIPTION
#### Description

This adds the `kubernetes` among the supported series [like juju does](https://github.com/juju/juju/blob/acec126819f9e04abdf3bc1b9d0af68b05d6098c/core/series/supported.go#L489).

Fixes #865 

#### QA Steps

Added a local charm to reproduce the issue, so that should deploy just fine with this change. Obviously the charm will not work if ran on lxd, but it should deploy without any errors. (Without this PR it errors with the reported `juju.errors.JujuError: ('Unknown series : %s', 'kubernetes')`)

```sh
python -m asyncio
asyncio REPL 3.10.6 (main, Mar 10 2023, 10:55:28) [GCC 11.3.0] on linux
Use "await" directly instead of "asyncio.run()".
Type "help", "copyright", "credits" or "license" for more information.
>>> import asyncio
>>> from juju import model; m=model.Model(); await m.connect();await m.deploy('./tests/integration/charm-series-kubernetes')
```

Unfortunately we can't turn this into an integration test that uses that charm because we run our tests on lxd so the charm will be deployed but will never actually get 'active'. We could test the deployment itself (that it doesn't error), but if we did that, when we run in against 3.x it will actually fail to deploy on lxd because the series is kubernetes so the test will be invalid anyways.

All CI tests need to pass.

#### Notes & Discussion

The reported issue is happening because of our series & base resolution code that we added recently onto the master branch then backported to 2.9. That's why it's not observed in the earlier versions (because that's resolving the series the old way). For the same reason this needs to be forward ported to the master branch.