### PR TITLE
[JUJU-3952] Revisit access control levels

### DIFF
--- a/juju/access.py
+++ b/juju/access.py
@@ -1,0 +1,47 @@
+
+from .errors import JujuNotValid
+
+# No permissions at all
+NO_ACCESS = ""
+
+# Model permissions
+
+READ_ACCESS = "read"
+WRITE_ACCESS = "write"
+CONSUME_ACCESS = "consume"
+ADMIN_ACCESS = "admin"
+MODEL_ACCESS_LEVELS = {READ_ACCESS, WRITE_ACCESS, CONSUME_ACCESS, ADMIN_ACCESS}
+
+# Controller permissions
+
+LOGIN_ACCESS = "login"
+ADD_MODEL_ACCESS = "add-model"
+SUPERUSER_ACCESS = "superuser"
+CONTROLLER_ACCESS_LEVELS = {LOGIN_ACCESS, ADD_MODEL_ACCESS, SUPERUSER_ACCESS}
+
+OFFER_ACCESS_LEVELS = {READ_ACCESS, CONSUME_ACCESS, ADMIN_ACCESS}
+
+ALL_ACCESS_LEVELS = MODEL_ACCESS_LEVELS.union(CONTROLLER_ACCESS_LEVELS)
+
+
+def validate_access_level(access):
+    if access not in ALL_ACCESS_LEVELS:
+        raise JujuNotValid("access level", access)
+
+
+def validate_offer_access(access):
+    validate_access_level()
+    if access not in OFFER_ACCESS_LEVELS:
+        raise JujuNotValid("offer access level", access)
+
+
+def validate_model_access(access):
+    validate_access_level(access)
+    if access not in MODEL_ACCESS_LEVELS:
+        raise JujuNotValid("model access level", access)
+
+
+def validate_controller_access(access):
+    validate_access_level(access)
+    if access not in CONTROLLER_ACCESS_LEVELS:
+        raise JujuNotValid("controller access level", access)

--- a/juju/errors.py
+++ b/juju/errors.py
@@ -87,6 +87,13 @@ class JujuBackupError(JujuError):
     pass
 
 
+class JujuNotValid(JujuError):
+    def __init__(self, entity_type, entity_name):
+        self.entity_type = entity_type
+        self.entity_name = entity_name
+        super().__init__(f'Invalid {entity_type} : {entity_name}')
+
+
 class JujuConfigError(JujuError):
     """Exception raised during processing a configuration key-value pair
     in a config set for an application.


### PR DESCRIPTION
#### Description

This is something that we [stumbled upon](https://github.com/juju/python-libjuju/pull/874#issuecomment-1579061438) in one of the integration tests, which initially led me to believe there might be a regression in `ModelManager` facade. However, I realized that the libjuju only deals with the controller level access and doesn't know anything about model or offer access levels. 

There are two main contributions here:
1) Changes the way the controller object gets the `model_uuid`s (i.e. `cmd list-models` on juju). The old way was to call the `ControllerFacade.AllModels()` for admin users and `ModelManager.ListModels()` for anyone else. This changes it by calling  `ModelManager.ListModelSummaries` for everyone just like [how `cmd` does it](https://github.com/juju/juju/blob/576c487266443c1b3d788bd1c85c4a45d0f91db0/cmd/juju/controller/listmodels.go#L126).
2) Adds new module `access.py` that has all the access levels for models, controllers and offers that can be used with `user.grant()` and `user.revoke()`.
3) Improves the existing `user.grant()` and `user.revoke()` which together with (2) should give a more fine grained control over permissions for pylibjuju users to test their stuff in setups involving multiple models, relations and users.


#### QA Steps

This revisits the existing integration tests and adds a new one too, so there are two main ways to QA this, manual, and automatic. The automatic way is to run the integration tests:

```
tox -e integration -- tests/integration/test_controller.py::test_grant_revoke_controller_access
```

```
tox -e integration -- tests/integration/test_controller.py::test_grant_revoke_model_access
```

All CI tests need to pass.

The manual way is to fire up a pylibjuju console and :
```python
 $ python -m asyncio
asyncio REPL 3.10.6 (main, May 29 2023, 11:10:38) [GCC 11.3.0] on linux
Use "await" directly instead of "asyncio.run()".
Type "help", "copyright", "credits" or "license" for more information.
>>> import asyncio
>>> from juju import controller;c = controller.Controller(); await c.connect()
>>> user = await c.add_user('foouser')
>>> await c.list_models(username=user.username)
[]
>>> await user.grant('read', model_name='controller')
True
>>> await c.list_models(username=user.username)
['controller']
>>> await user.revoke('read', model_name='controller')
True
>>> await c.list_models(username=user.username)
[]
>>>
```

It is advisable to QA also the offer stuff as well.