### PR TITLE
[JUJU-4018] Avoid upgrade resource in app refresh if upstream has same resource revision

### DIFF
--- a/juju/application.py
+++ b/juju/application.py
@@ -740,11 +740,22 @@ class Application(model.ModelEntity):
         }
 
         # Compute the difference btw resources needed and the existing resources
-        resources_to_update = [
-            resource for resource in charm_resources
-            if resource.get('Name', resource.get('name')) not in existing_resources or
-            existing_resources[resource.get('Name', resource.get('name'))].origin != 'upload'
-        ]
+        resources_to_update = []
+        for resource in charm_resources:
+            # should upgrade resource?
+            res_name = resource.get('Name', resource.get('name'))
+            # no, if it's upload
+            if existing_resources[res_name].origin == 'upload':
+                continue
+
+            # no, if we already have it (and upstream doesn't have a newer res available)
+            if res_name in existing_resources:
+                available_rev = resource['revision']
+                existing_rev = existing_resources[res_name].unknown_fields.get('revision', -1)
+                if existing_rev >= available_rev:
+                    continue
+
+            resources_to_update.append(resource)
 
         # Update the resources
         if resources_to_update:

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -228,6 +228,17 @@ async def test_upgrade_charm_resource(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+async def test_upgrade_charm_resource_same_rev_no_update(event_loop):
+    async with base.CleanModel() as model:
+        app = await model.deploy('keystone', channel='victoria/stable')
+        ress = await app.get_resources()
+        await app.refresh(channel='ussuri/stable')
+        ress2 = await app.get_resources()
+        assert ress['policyd-override'].fingerprint == ress2['policyd-override'].fingerprint
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
 async def test_trusted(event_loop):
     async with base.CleanModel() as model:
         await model.deploy('ubuntu', trust=True)


### PR DESCRIPTION
#### Description

This adds a condition to the logic of deciding if we need to upgrade a resource during an `app.refresh()`, analogous to the [`shouldUpgradeResource()` utility](https://github.com/juju/juju/blob/cdda0d771219c9e59bfef4579da8b6389e1b0d72/cmd/juju/application/utils/utils.go#L159) in Juju.

Fixes #883 

#### QA Steps

This adds the use case in #883 as an integration test, so the following should pass:

```
tox -e integration -- tests/integration/test_application.py::test_upgrade_charm_resource_same_rev_no_update
```