### PR TITLE
[JUJU-4112] Determining series for local bundle deploying local charm with manifest

### DIFF
--- a/juju/bundle.py
+++ b/juju/bundle.py
@@ -127,8 +127,9 @@ class BundleHandler:
                 metadata = utils.get_local_charm_metadata(charm_dir)
                 series = await get_charm_series(metadata, self.model)
             if not series:
-                metadata = utils.get_local_charm_metadata(charm_dir)
-                series = await get_charm_series(metadata, self.model)
+                base = utils.get_local_charm_base(None, charm_path, client.Base)
+                series = utils.base_channel_to_series(base.channel)
+            if not series:
                 raise JujuError(
                     "Couldn't determine series for charm at {}. "
                     "Add a 'series' key to the bundle.".format(charm_dir))

--- a/tests/integration/bundle/local-manifest.yaml
+++ b/tests/integration/bundle/local-manifest.yaml
@@ -1,0 +1,4 @@
+applications:
+  test1:
+    charm: "../charm-manifest"
+    num_units: 1

--- a/tests/integration/charm-manifest/config.yaml
+++ b/tests/integration/charm-manifest/config.yaml
@@ -1,0 +1,4 @@
+options:
+  status:
+    type: string
+    default: "active"

--- a/tests/integration/charm-manifest/dispatch
+++ b/tests/integration/charm-manifest/dispatch
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+status="$(config-get status)"
+
+if [[ "$status" == "error" ]]; then
+    if [[ -e .errored ]]; then
+        status="active"
+    else
+        touch .errored
+        exit 1
+    fi
+fi
+status-set "$status"

--- a/tests/integration/charm-manifest/manifest.yaml
+++ b/tests/integration/charm-manifest/manifest.yaml
@@ -1,0 +1,13 @@
+analysis:
+  attributes:
+  - name: language
+    result: python
+  - name: framework
+    result: operator
+bases:
+- architectures:
+  - amd64
+  channel: '20.04'
+  name: ubuntu
+charmcraft-started-at: '2021-08-20T08:09:00.639806Z'
+charmcraft-version: 1.2.1

--- a/tests/integration/charm-manifest/metadata.yaml
+++ b/tests/integration/charm-manifest/metadata.yaml
@@ -1,0 +1,4 @@
+name: charm
+summary: "test"
+description: "test"
+maintainers: ["test"]

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -129,6 +129,19 @@ async def test_deploy_bundle_local_charms(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+async def test_deploy_bundle_local_charm_series_manifest(event_loop):
+    bundle_path = TESTS_DIR / 'integration' / 'bundle' / 'local-manifest.yaml'
+
+    async with base.CleanModel() as model:
+        await model.deploy(bundle_path)
+        await wait_for_bundle(model, bundle_path)
+        assert set(model.units.keys()) == set(['test1/0'])
+        assert model.units['test1/0'].agent_status == 'idle'
+        assert model.units['test1/0'].workload_status == 'active'
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
 async def test_deploy_invalid_bundle(event_loop):
     pytest.skip('test_deploy_invalid_bundle intermittent test failure')
     bundle_path = TESTS_DIR / 'bundle' / 'invalid.yaml'


### PR DESCRIPTION
#### Description

This fixes a duplication introduced in this cherry pick https://github.com/juju/python-libjuju/commit/bd06a2470ce3122a54f3fdabccf92164f5b7e680, and adds functionality to determine series using utils for base, which already has the logic for checking `manifest.yaml` for bases (alongside with `metadata.yaml` etc).

Fixes #891 


#### QA Steps

This adds the simplified version of the scenario in #891 as an integration test, so the following should pass:

```sh
tox -e integration -- tests/integration/test_model.py::test_deploy_bundle_local_charm_series_manifest
```

**Alternatively**, get the onos charm:

```sh
wget https://osm.etsi.org/gitlab/vnf-onboarding/osm-packages/-/raw/master/charm-packages/pebble_charm_vnf/juju-bundles/charms/onos_ubuntu-20.04-amd64.charm
```

Write the following in a `bundle.yaml`:

```yaml
description: Onos Bundle
bundle: kubernetes
applications:
  onos:
    charm: './onos_ubuntu-20.04-amd64.charm'
    scale: 1
    options:
      admin-password: admin
    resources:
      onos-image: onosproject/onos:2.6.0
```

Deploy with this change, should go through just fine without complaining about the series:

```sh
$ python -m asyncio
asyncio REPL 3.10.6 (main, May 29 2023, 11:10:38) [GCC 11.3.0] on linux
Use "await" directly instead of "asyncio.run()".
Type "help", "copyright", "credits" or "license" for more information.
>>> import asyncio
>>> from juju import model;m=model.Model();await m.connect();await m.deploy('./bundle.yaml')
unknown facade AgentLifeFlag
unexpected facade AgentLifeFlag found, unable to decipher version to use
[<Application entity_id="onos">]
>>>
```