### PR TITLE
[JUJU-4110] `charm_name` on Application object

### DIFF
--- a/juju/application.py
+++ b/juju/application.py
@@ -548,10 +548,18 @@ class Application(model.ModelEntity):
         )
 
     @property
-    def charm_url(self):
-        """Get the charm url for a given application
+    def charm_name(self):
+        """Get the charm name of this application
 
-        :return string: The charm url for an application
+        :return str: The name of the charm
+        """
+        return URL.parse(self.charm_url).name
+
+    @property
+    def charm_url(self):
+        """Get the charm url for this application
+
+        :return str: The charm url
         """
         return self.safe_data['charm-url']
 

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -285,3 +285,13 @@ async def test_app_remove_wait_flag(event_loop):
 
         await model.remove_application(app.name, block_until_done=True)
         assert a_name not in model.applications
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_app_charm_name(event_loop):
+    async with base.CleanModel() as model:
+        app = await model.deploy('ubuntu')
+        await model.wait_for_idle(status="active")
+        assert 'ubuntu' in app.charm_url
+        assert 'ubuntu' == app.charm_name


### PR DESCRIPTION
#### Description

Adds the `charm_name` property in `Application` object, which saves people from going through the status and stripping things from the charm URL, just to get the name of the charm.

Fixes #888 

The issue in there was that the `FullStatus` actually returns the charm URL as the `charm` field in `[] ApplicationStatus` field, but the client is aliasing it before printing so you see only the charm name in the `juju status --format yaml`

https://github.com/juju/juju/blob/87d8ddc9de5219b3a1d854e14ee4c90a7d781d25/cmd/juju/status/formatter.go#L267

#### QA Steps

```
tox -e integration -- tests/integration/test_application.py::test_app_charm_name
```