### PR TITLE
[JUJU-4204] Model.name on 2.9

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -1022,6 +1022,14 @@ class Model:
         return self.info
 
     @property
+    def name(self):
+        """Return the name of this model
+        """
+        if self._info is None:
+            raise JujuError("Model is not connected")
+        return self._info.name
+
+    @property
     def info(self):
         """Return the cached client.ModelInfo object for this Model.
 

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -23,6 +23,19 @@ from ..utils import MB, GB, TESTS_DIR, OVERLAYS_DIR, SSH_KEY, INTEGRATION_TEST_D
 
 @base.bootstrapped
 @pytest.mark.asyncio
+async def test_model_name(event_loop):
+    model = Model()
+    with pytest.raises(JujuError):
+        model.name
+
+    async with base.CleanModel() as new_model:
+        await model.connect(new_model.name)
+        assert model.name == new_model.name
+        await model.disconnect()
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
 async def test_deploy_local_bundle_dir(event_loop):
     bundle_path = TESTS_DIR / 'bundle'
 


### PR DESCRIPTION
#### Description

Backports `model.name` from HEAD into 2.9. Gets this particular change from 55ea0e29d83e040435e4074ecc3d6bccbc641472 adds the name property into a Model object. Couldn't directly cherry pick because of the other stuff in the commit.

Fixes #893 

#### QA Steps

Also backports the integration test as well, so:

```
tox -e integration -- tests/integration/test_model.py::test_model_name
```