### PR TITLE
Move test utils into a separate module

### DIFF
--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -204,7 +204,7 @@ async def test_deploy_charm_assumes(event_loop):
 @base.bootstrapped
 @pytest.mark.asyncio
 async def test_deploy_local_charm_base_charmcraft_yaml(event_loop):
-    charm_path = HERE_DIR / 'charm-base-charmcraft-yaml'
+    charm_path = INTEGRATION_TEST_DIR / 'charm-base-charmcraft-yaml'
 
     async with base.CleanModel() as model:
         await model.deploy(str(charm_path))

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -5,7 +5,6 @@ import string
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
-from pathlib import Path
 
 import mock
 import paramiko
@@ -19,13 +18,7 @@ from juju.model import Model, ModelObserver
 from juju.utils import block_until, run_with_interrupt, wait_for_bundle, base_channel_to_series
 
 from .. import base
-
-MB = 1
-GB = 1024
-SSH_KEY = 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsYMJGNGG74HAJha3n2CFmWYsOOaORnJK6VqNy86pj0MIpvRXBzFzVy09uPQ66GOQhTEoJHEqE77VMui7+62AcMXT+GG7cFHcnU8XVQsGM6UirCcNyWNysfiEMoAdZScJf/GvoY87tMEszhZIUV37z8PUBx6twIqMdr31W1J0IaPa+sV6FEDadeLaNTvancDcHK1zuKsL39jzAg7+LYjKJfEfrsQP+lj/EQcjtKqlhVS5kzsJVfx8ZEd0xhW5G7N6bCdKNalS8mKCMaBXJpijNQ82AiyqCIDCRrre2To0/i7pTjRiL0U9f9mV3S4NJaQaokR050w/ZLySFf6F7joJT mathijs@Qrama-Mathijs'  # noqa
-HERE_DIR = Path(__file__).absolute().parent  # tests/integration
-TESTS_DIR = HERE_DIR.parent  # tests/
-OVERLAYS_DIR = HERE_DIR / 'bundle' / 'test-overlays'
+from ..utils import MB, GB, TESTS_DIR, OVERLAYS_DIR, SSH_KEY, INTEGRATION_TEST_DIR
 
 
 @base.bootstrapped
@@ -81,7 +74,7 @@ async def test_deploy_local_bundle_file(event_loop):
 @base.bootstrapped
 @pytest.mark.asyncio
 async def test_deploy_bundle_local_resource_relative_path(event_loop):
-    bundle_file_path = HERE_DIR / 'bundle-file-resource.yaml'
+    bundle_file_path = INTEGRATION_TEST_DIR / 'bundle-file-resource.yaml'
 
     async with base.CleanModel() as model:
         await model.deploy(str(bundle_file_path))
@@ -134,7 +127,7 @@ async def test_deploy_by_revision_validate_flags(event_loop):
 @base.bootstrapped
 @pytest.mark.asyncio
 async def test_deploy_local_bundle_include_file(event_loop):
-    bundle_dir = TESTS_DIR / 'integration' / 'bundle'
+    bundle_dir = INTEGRATION_TEST_DIR / 'bundle'
     bundle_yaml_path = bundle_dir / 'bundle-include-file.yaml'
 
     async with base.CleanModel() as model:
@@ -151,7 +144,7 @@ async def test_deploy_local_bundle_include_file(event_loop):
 @base.bootstrapped
 @pytest.mark.asyncio
 async def test_deploy_local_bundle_include_base64(event_loop):
-    bundle_dir = TESTS_DIR / 'integration' / 'bundle'
+    bundle_dir = INTEGRATION_TEST_DIR / 'bundle'
     bundle_yaml_path = bundle_dir / 'bundle-include-base64.yaml'
 
     async with base.CleanModel() as model:
@@ -167,7 +160,7 @@ async def test_deploy_local_bundle_include_base64(event_loop):
 @base.bootstrapped
 @pytest.mark.asyncio
 async def test_deploy_bundle_local_charms(event_loop):
-    bundle_path = TESTS_DIR / 'integration' / 'bundle' / 'local.yaml'
+    bundle_path = INTEGRATION_TEST_DIR / 'bundle' / 'local.yaml'
 
     async with base.CleanModel() as model:
         await model.deploy(bundle_path)
@@ -739,7 +732,7 @@ async def test_local_oci_image_resource_charm(event_loop):
 @base.bootstrapped
 @pytest.mark.asyncio
 async def test_local_file_resource_charm(event_loop):
-    charm_path = TESTS_DIR / 'integration' / 'file-resource-charm'
+    charm_path = INTEGRATION_TEST_DIR / 'file-resource-charm'
     async with base.CleanModel() as model:
         resources = {"file-res": "test.file"}
         app = await model.deploy(str(charm_path), resources=resources)
@@ -777,7 +770,7 @@ async def test_attach_resource(event_loop):
 async def test_store_resources_bundle(event_loop):
     pytest.skip('test_store_resources_bundle intermittent test failure')
     async with base.CleanModel() as model:
-        bundle = str(Path(__file__).parent / 'bundle')
+        bundle = INTEGRATION_TEST_DIR / 'bundle'
         await model.deploy(bundle)
         assert 'ghost' in model.applications
         ghost = model.applications['ghost']
@@ -799,7 +792,7 @@ async def test_store_resources_bundle(event_loop):
 async def test_store_resources_bundle_revs(event_loop):
     pytest.skip('test_store_resources_bundle_revs intermittent test failure')
     async with base.CleanModel() as model:
-        bundle = str(Path(__file__).parent / 'bundle/bundle-resource-rev.yaml')
+        bundle = INTEGRATION_TEST_DIR / 'bundle/bundle-resource-rev.yaml'
         await model.deploy(bundle)
         assert 'ghost' in model.applications
         ghost = model.applications['ghost']

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+# Utilities for tests
+
+MB = 1
+GB = 1024
+SSH_KEY = 'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCsYMJGNGG74HAJha3n2CFmWYsOOaORnJK6VqNy86pj0MIpvRXBzFzVy09uPQ66GOQhTEoJHEqE77VMui7+62AcMXT+GG7cFHcnU8XVQsGM6UirCcNyWNysfiEMoAdZScJf/GvoY87tMEszhZIUV37z8PUBx6twIqMdr31W1J0IaPa+sV6FEDadeLaNTvancDcHK1zuKsL39jzAg7+LYjKJfEfrsQP+lj/EQcjtKqlhVS5kzsJVfx8ZEd0xhW5G7N6bCdKNalS8mKCMaBXJpijNQ82AiyqCIDCRrre2To0/i7pTjRiL0U9f9mV3S4NJaQaokR050w/ZLySFf6F7joJT mathijs@Qrama-Mathijs'  # noqa
+HERE_DIR = Path(__file__).absolute()  # tests/integration
+TESTS_DIR = HERE_DIR.parent  # tests/
+INTEGRATION_TEST_DIR = TESTS_DIR / 'integration'
+UNIT_TEST_DIR = TESTS_DIR / 'unit'
+OVERLAYS_DIR = INTEGRATION_TEST_DIR / 'bundle' / 'test-overlays'


### PR DESCRIPTION
#### Description

This is a small forward-port that brings 138e53aade63c634ebc1786ee9c7c9598f309d28, which moves the test utilities/constants into a separate file to be shared across all the integration tests (it used to be only in `integration/test_model.py`).

#### QA Steps

This is a simple move, no functionality change, however, the tests use those constants (some of are paths etc) so we should probably make sure no test in the CI is failing because  of that.