### PR TITLE
Remove title prefixes from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BugReport.yml
+++ b/.github/ISSUE_TEMPLATE/BugReport.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Something's not working right in python-libjuju? Use this template.
-title: "[Bug]: "
+title: ""
 labels: [bug]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/FeatureRequest.yml
+++ b/.github/ISSUE_TEMPLATE/FeatureRequest.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: You want something to be added to python-libjuju? Proceed with this one.
-title: "[Feature]: "
+title: ""
 labels: [wishlisted]
 body:
   - type: markdown


### PR DESCRIPTION
#### Description

Clears out the title prefixes (`[Bug]: ...`, `[Feature]: ...`) from issue template forms. We already have labels auto attached that differentiates between them.

#### QA Steps

No QA needed.