### PR TITLE
[JUJU-4231] wait_for_idle to consider app status

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -2568,10 +2568,11 @@ class Model:
                     #  individual units, another one for waiting for an application.
                     #  The convoluted logic below is the result of trying to do both at the same
                     #  time
-                    need_to_wait_more_for_a_particular_status = status and unit.workload_status != status
+                    need_to_wait_more_for_a_particular_status = status and (unit.workload_status != status)
+                    app_is_in_desired_status = (not status) or (app_status == status)
                     if not need_to_wait_more_for_a_particular_status and \
                             unit.agent_status == "idle" and \
-                            (wait_for_units or (not status or app_status == status)):
+                            (wait_for_units or app_is_in_desired_status):
                         # A unit is ready if either:
                         # 1) Don't need to wait more for a particular status and the agent is "idle"
                         # 2) We're looking for a particular status and the unit's workload,
@@ -2581,7 +2582,7 @@ class Model:
                         # (because e.g. app can be in 'waiting' while unit.0 is 'active' and unit.1
                         # is 'waiting')
 
-                        # The unit is ready, start measuring the time period that
+                        # Either way, the unit is ready, start measuring the time period that
                         # it needs to stay in that state (i.e. idle_period)
                         units_ready.add(unit.name)
                         now = datetime.now()

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -772,12 +772,12 @@ async def test_get_machines(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.wait_for_idle
 async def test_wait_for_idle_without_units(event_loop):
     async with base.CleanModel() as model:
         await model.deploy(
             'ubuntu',
             application_name='ubuntu',
-            series='bionic',
             channel='stable',
             num_units=0,
         )
@@ -787,12 +787,12 @@ async def test_wait_for_idle_without_units(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.wait_for_idle
 async def test_wait_for_idle_with_not_enough_units(event_loop):
     async with base.CleanModel() as model:
         await model.deploy(
             'ubuntu',
             application_name='ubuntu',
-            series='bionic',
             channel='stable',
             num_units=2,
         )
@@ -802,6 +802,7 @@ async def test_wait_for_idle_with_not_enough_units(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.wait_for_idle
 async def test_wait_for_idle_more_units_than_needed(event_loop):
     async with base.CleanModel() as model:
         charm_path = TESTS_DIR / 'charm'
@@ -824,12 +825,12 @@ async def test_wait_for_idle_more_units_than_needed(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.wait_for_idle
 async def test_wait_for_idle_with_enough_units(event_loop):
     async with base.CleanModel() as model:
         await model.deploy(
             'ubuntu',
             application_name='ubuntu',
-            series='bionic',
             channel='stable',
             num_units=3,
         )
@@ -838,12 +839,12 @@ async def test_wait_for_idle_with_enough_units(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.wait_for_idle
 async def test_wait_for_idle_with_exact_units(event_loop):
     async with base.CleanModel() as model:
         await model.deploy(
             'ubuntu',
             application_name='ubuntu',
-            series='bionic',
             channel='stable',
             num_units=2,
         )
@@ -852,6 +853,7 @@ async def test_wait_for_idle_with_exact_units(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.wait_for_idle
 async def test_wait_for_idle_with_exact_units_scale_down(event_loop):
     """Deploys 3 units, waits for them to be idle, then removes 2 of them,
     then waits for exactly 1 unit to be left.
@@ -861,7 +863,7 @@ async def test_wait_for_idle_with_exact_units_scale_down(event_loop):
         app = await model.deploy(
             'ubuntu',
             application_name='ubuntu',
-            series='bionic',
+            series='jammy',
             channel='stable',
             num_units=3,
         )

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -352,7 +352,7 @@ class TestModelWaitForIdle(asynctest.TestCase):
                     workload_status_message="workload_status_message",
                     machine=None,
                     agent_status="idle",
-                )],
+            )],
         )
 
         app.get_status = base.AsyncMock(return_value=app_status)
@@ -390,7 +390,7 @@ class TestModelWaitForIdle(asynctest.TestCase):
                     workload_status_message="workload_status_message",
                     machine=None,
                     agent_status="idle",
-                )],
+            )],
         )
 
         app.get_status = base.AsyncMock(return_value=app_status)

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -296,25 +296,23 @@ class TestModelWaitForIdle(asynctest.TestCase):
         self.assertEqual(str(cm.exception), "Timed out waiting for model:\nnonexisting_app (missing)")
 
     @pytest.mark.asyncio
+    @pytest.mark.wait_for_idle
     async def test_wait_for_active_status(self):
+        app_status = 'active'
         # create a custom apps mock
         from types import SimpleNamespace
         app = SimpleNamespace(
-            status="active",
+            status=app_status,
             units=[SimpleNamespace(
                 name="mockunit/0",
-                workload_status="active",
+                workload_status='active',
                 workload_status_message="workload_status_message",
                 machine=None,
                 agent_status="idle",
             )],
         )
-        # This is a small hack to act like we're getting 'unknown'
-        # from the api (the get_status() call), which shouldn't
-        # change the semantics of this test, as the 'unknown'
-        # has the lowest severity (so the app's 'active' status
-        # will overrule it)
-        app.get_status = base.AsyncMock(return_value='unknown')
+
+        app.get_status = base.AsyncMock(return_value=app_status)
         apps = {"dummy_app": app}
 
         with patch.object(Model, 'applications', new_callable=PropertyMock) as mock_apps:
@@ -329,5 +327,80 @@ class TestModelWaitForIdle(asynctest.TestCase):
 
             # use both `status` and `wait_for_active` - `wait_for_active` takes precedence
             await m.wait_for_idle(apps=["dummy_app"], wait_for_active=True, status="doesn't matter")
+
+        mock_apps.assert_called_with()
+
+    @pytest.mark.asyncio
+    @pytest.mark.wait_for_idle
+    async def test_wait_for_active_units_waiting_application(self):
+        # If the app is in waiting state, then wait more even if the units are ready
+        app_status = 'waiting'
+        # create a custom apps mock
+        from types import SimpleNamespace
+        app = SimpleNamespace(
+            status=app_status,
+            units=[SimpleNamespace(
+                name="mockunit/0",
+                workload_status='active',
+                workload_status_message="workload_status_message",
+                machine=None,
+                agent_status="idle",
+            ),
+                SimpleNamespace(
+                    name="mockunit/1",
+                    workload_status='active',
+                    workload_status_message="workload_status_message",
+                    machine=None,
+                    agent_status="idle",
+                )],
+        )
+
+        app.get_status = base.AsyncMock(return_value=app_status)
+        apps = {"dummy_app": app}
+
+        with patch.object(Model, 'applications', new_callable=PropertyMock) as mock_apps:
+            mock_apps.return_value = apps
+            m = Model()
+
+            with self.assertRaises(jasyncio.TimeoutError):
+                await m.wait_for_idle(apps=["dummy_app"], status="active")
+
+        mock_apps.assert_called_with()
+
+    @pytest.mark.asyncio
+    @pytest.mark.wait_for_idle
+    async def test_wait_for_active_units_waiting_for_units(self):
+        # If user wants to see a particular number of units, then application may be in a waiting
+        # state, return when there's at least that number of units in the desired state
+        app_status = 'waiting'
+        # create a custom apps mock
+        from types import SimpleNamespace
+        app = SimpleNamespace(
+            status=app_status,
+            units=[SimpleNamespace(
+                name="mockunit/0",
+                workload_status='active',
+                workload_status_message="workload_status_message",
+                machine=None,
+                agent_status="idle",
+            ),
+                SimpleNamespace(
+                    name="mockunit/1",
+                    workload_status='waiting',
+                    workload_status_message="workload_status_message",
+                    machine=None,
+                    agent_status="idle",
+                )],
+        )
+
+        app.get_status = base.AsyncMock(return_value=app_status)
+        apps = {"dummy_app": app}
+
+        with patch.object(Model, 'applications', new_callable=PropertyMock) as mock_apps:
+            mock_apps.return_value = apps
+            m = Model()
+
+            await m.wait_for_idle(apps=["dummy_app"], status="active", wait_for_units=1,
+                                  timeout=None)
 
         mock_apps.assert_called_with()


### PR DESCRIPTION
#### Description

This adds logic to `wait_for_idle` to also consider application status when computing status via the unit statuses. 

Should fix #831 and #900

#### QA Steps

This adds some scenarios to the existing unit tests for `wait_for_idle`. Also adds a pytest mark "wait_for_idle", so only the tests related to `wait_for_idle` can be run as a subset:

```
tox -e py3 -- -m wait_for_idle
```

```
tox -e integration -- -m wait_for_idle
```

#### Notes & Discussion

* As I wrote a TODO in the comments, `wait_for_idle` is becoming more and more convoluted. Basically we need two versions of this function. 1) `wait_for_applications()` for users who want to wait on an application to be in a certain state and doesn't particularly care about units, and 2) `wait_for_units()` for users who want finer detailed control and want to wait on certain number of units in certain applications to be in certain states etc.
* @dnplas, @ca-scribner, @beliaev-maksim, I'm gonna ask your help validating this patch. We got a bunch of unit and integration tests that should be covering most of the scenarios related to the `wait_for_idle`, however, I'd greatly appreciate if you guys could also give this PR a good stress test. I'm basically asking you to run all the integration test you have that uses `wait_for_idle` against this patch and see if it can take a punch. Thanks!