### PR TITLE
[JUJU-4048] Use GetChangesMapArgs for bundle changes

### DIFF
--- a/tests/integration/test_crossmodel.py
+++ b/tests/integration/test_crossmodel.py
@@ -142,6 +142,7 @@ async def test_relate_with_offer(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.bundle
 async def test_add_bundle(event_loop):
     pytest.skip("skip until we have a faster example to test")
     tests_dir = Path(__file__).absolute().parent

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -36,6 +36,7 @@ async def test_model_name(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.bundle
 async def test_deploy_local_bundle_dir(event_loop):
     bundle_path = TESTS_DIR / 'bundle'
 
@@ -56,6 +57,7 @@ async def test_deploy_local_bundle_dir(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.bundle
 async def test_deploy_local_bundle_file(event_loop):
     bundle_path = TESTS_DIR / 'bundle'
     mini_bundle_file_path = bundle_path / 'mini-bundle.yaml'
@@ -73,6 +75,7 @@ async def test_deploy_local_bundle_file(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.bundle
 async def test_deploy_bundle_local_resource_relative_path(event_loop):
     bundle_file_path = INTEGRATION_TEST_DIR / 'bundle-file-resource.yaml'
 
@@ -126,6 +129,7 @@ async def test_deploy_by_revision_validate_flags(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.bundle
 async def test_deploy_local_bundle_include_file(event_loop):
     bundle_dir = INTEGRATION_TEST_DIR / 'bundle'
     bundle_yaml_path = bundle_dir / 'bundle-include-file.yaml'
@@ -143,6 +147,7 @@ async def test_deploy_local_bundle_include_file(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.bundle
 async def test_deploy_local_bundle_include_base64(event_loop):
     bundle_dir = INTEGRATION_TEST_DIR / 'bundle'
     bundle_yaml_path = bundle_dir / 'bundle-include-base64.yaml'
@@ -159,6 +164,7 @@ async def test_deploy_local_bundle_include_base64(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.bundle
 async def test_deploy_bundle_local_charms(event_loop):
     bundle_path = INTEGRATION_TEST_DIR / 'bundle' / 'local.yaml'
 
@@ -174,6 +180,7 @@ async def test_deploy_bundle_local_charms(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.bundle
 async def test_deploy_invalid_bundle(event_loop):
     pytest.skip('test_deploy_invalid_bundle intermittent test failure')
     bundle_path = TESTS_DIR / 'bundle' / 'invalid.yaml'
@@ -252,6 +259,7 @@ async def test_wait_local_charm_waiting_timeout(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.bundle
 async def test_deploy_bundle(event_loop):
     async with base.CleanModel() as model:
         await model.deploy('anbox-cloud-core', channel='stable',
@@ -263,6 +271,7 @@ async def test_deploy_bundle(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.bundle
 async def test_deploy_local_bundle_with_overlay_multi(event_loop):
     async with base.CleanModel() as model:
         bundle_with_overlay_path = OVERLAYS_DIR / 'bundle-with-overlay-multi.yaml'
@@ -276,6 +285,7 @@ async def test_deploy_local_bundle_with_overlay_multi(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.bundle
 async def test_deploy_bundle_with_overlay_as_argument(event_loop):
     async with base.CleanModel() as model:
         overlay_path = OVERLAYS_DIR / 'test-overlay.yaml'
@@ -297,6 +307,7 @@ async def test_deploy_bundle_with_overlay_as_argument(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.bundle
 async def test_deploy_bundle_with_multi_overlay_as_argument(event_loop):
     async with base.CleanModel() as model:
         overlay_path = OVERLAYS_DIR / 'test-multi-overlay.yaml'
@@ -309,6 +320,7 @@ async def test_deploy_bundle_with_multi_overlay_as_argument(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.bundle
 async def test_deploy_bundle_with_multiple_overlays_with_include_files(event_loop):
     async with base.CleanModel() as model:
         bundle_yaml_path = TESTS_DIR / 'integration' / 'bundle' / 'bundle.yaml'
@@ -357,6 +369,7 @@ async def test_deploy_from_ch_channel_revision_success(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.bundle
 async def test_deploy_trusted_bundle(event_loop):
     pytest.skip("skip until we have a deployable bundle available. Right now the landscape-dense fails because postgresql is broken")
     async with base.CleanModel() as model:
@@ -767,6 +780,7 @@ async def test_attach_resource(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.bundle
 async def test_store_resources_bundle(event_loop):
     pytest.skip('test_store_resources_bundle intermittent test failure')
     async with base.CleanModel() as model:
@@ -789,6 +803,7 @@ async def test_store_resources_bundle(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.bundle
 async def test_store_resources_bundle_revs(event_loop):
     pytest.skip('test_store_resources_bundle_revs intermittent test failure')
     async with base.CleanModel() as model:

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -72,54 +72,6 @@ class TestAddApplicationChange(unittest.TestCase):
     def test_method(self):
         self.assertEqual("deploy", AddApplicationChange.method())
 
-    def test_list_params_juju_2_4(self):
-        change = AddApplicationChange(1, [], params=["charm",
-                                                     "series",
-                                                     "application",
-                                                     "options",
-                                                     "constraints",
-                                                     {"db": "pool,1,1GB"},
-                                                     "endpoint_bindings",
-                                                     "resources"])
-        self.assertEqual({"change_id": 1,
-                          "requires": [],
-                          "charm": "charm",
-                          "series": "series",
-                          "application": "application",
-                          "options": "options",
-                          "constraints": "constraints",
-                          "storage": {"db": {"pool": "pool", "count": 1, "size": 1024}},
-                          "endpoint_bindings": "endpoint_bindings",
-                          "resources": "resources",
-                          "devices": None,
-                          "num_units": None,
-                          "channel": None}, change.__dict__)
-
-    def test_list_params_juju_2_5(self):
-        change = AddApplicationChange(1, [], params=["charm",
-                                                     "series",
-                                                     "application",
-                                                     "options",
-                                                     "constraints",
-                                                     {"db": "pool,1,1GB"},
-                                                     {"gpu": "1,gpu,attr1=a;attr2=b"},
-                                                     "endpoint_bindings",
-                                                     "resources",
-                                                     "num_units"])
-        self.assertEqual({"change_id": 1,
-                          "requires": [],
-                          "charm": "charm",
-                          "series": "series",
-                          "application": "application",
-                          "options": "options",
-                          "constraints": "constraints",
-                          "storage": {"db": {"pool": "pool", "count": 1, "size": 1024}},
-                          "endpoint_bindings": "endpoint_bindings",
-                          "resources": "resources",
-                          "devices": {"gpu": {"type": "gpu", "count": 1, "attributes": {"attr1": "a", "attr2": "b"}}},
-                          "num_units": "num_units",
-                          "channel": None}, change.__dict__)
-
     def test_dict_params(self):
         change = AddApplicationChange(1, [], params={"charm": "charm",
                                                      "series": "series",
@@ -360,27 +312,6 @@ class TestAddCharmChange(unittest.TestCase):
     def test_method(self):
         self.assertEqual("addCharm", AddCharmChange.method())
 
-    def test_list_params_juju_2_6(self):
-        change = AddCharmChange(1, [], params=["charm",
-                                               "series"])
-        self.assertEqual({"change_id": 1,
-                          "requires": [],
-                          "charm": "charm",
-                          "series": "series",
-                          "channel": None,
-                          "architecture": None}, change.__dict__)
-
-    def test_list_params_juju_2_7(self):
-        change = AddCharmChange(1, [], params=["charm",
-                                               "series",
-                                               "channel"])
-        self.assertEqual({"change_id": 1,
-                          "requires": [],
-                          "charm": "charm",
-                          "series": "series",
-                          "channel": "channel",
-                          "architecture": None}, change.__dict__)
-
     def test_dict_params(self):
         change = AddCharmChange(1, [], params={"charm": "charm",
                                                "series": "series",
@@ -435,18 +366,6 @@ class TestAddMachineChange(unittest.TestCase):
 
     def test_method(self):
         self.assertEqual("addMachines", AddMachineChange.method())
-
-    def test_list_params(self):
-        change = AddMachineChange(1, [], params=[{"series": "series",
-                                                  "constraints": "constraints",
-                                                  "containerType": "container_type",
-                                                  "parentId": "parent_id"}])
-        self.assertEqual({"change_id": 1,
-                          "requires": [],
-                          "series": "series",
-                          "constraints": "constraints",
-                          "container_type": "container_type",
-                          "parent_id": "parent_id"}, change.__dict__)
 
     def test_dict_params(self):
         change = AddMachineChange(1, [], params={"series": "series",
@@ -506,13 +425,6 @@ class TestAddRelationChange(unittest.TestCase):
     def test_method(self):
         self.assertEqual("addRelation", AddRelationChange.method())
 
-    def test_list_params(self):
-        change = AddRelationChange(1, [], params=["endpoint1", "endpoint2"])
-        self.assertEqual({"change_id": 1,
-                          "requires": [],
-                          "endpoint1": "endpoint1",
-                          "endpoint2": "endpoint2"}, change.__dict__)
-
     def test_dict_params(self):
         change = AddRelationChange(1, [], params={"endpoint1": "endpoint1",
                                                   "endpoint2": "endpoint2"})
@@ -567,13 +479,6 @@ class TestAddUnitChange(unittest.TestCase):
 
     def test_method(self):
         self.assertEqual("addUnit", AddUnitChange.method())
-
-    def test_list_params(self):
-        change = AddUnitChange(1, [], params=["application", "to"])
-        self.assertEqual({"change_id": 1,
-                          "requires": [],
-                          "application": "application",
-                          "to": "to"}, change.__dict__)
 
     def test_dict_params(self):
         change = AddUnitChange(1, [], params={"application": "application",
@@ -630,14 +535,6 @@ class TestCreateOfferChange(unittest.TestCase):
     def test_method(self):
         self.assertEqual("createOffer", CreateOfferChange.method())
 
-    def test_list_params(self):
-        change = CreateOfferChange(1, [], params=["application", "endpoints", "offer_name"])
-        self.assertEqual({"change_id": 1,
-                          "requires": [],
-                          "application": "application",
-                          "endpoints": "endpoints",
-                          "offer_name": "offer_name"}, change.__dict__)
-
     def test_dict_params(self):
         change = CreateOfferChange(1, [], params={"application": "application",
                                                   "endpoints": "endpoints",
@@ -687,13 +584,6 @@ class TestConsumeOfferChange(unittest.TestCase):
     def test_method(self):
         self.assertEqual("consumeOffer", ConsumeOfferChange.method())
 
-    def test_list_params(self):
-        change = ConsumeOfferChange(1, [], params=["url", "application_name"])
-        self.assertEqual({"change_id": 1,
-                          "requires": [],
-                          "url": "url",
-                          "application_name": "application_name"}, change.__dict__)
-
     def test_dict_params(self):
         change = ConsumeOfferChange(1, [], params={"url": "url",
                                                    "application-name": "application_name"})
@@ -736,13 +626,6 @@ class TestExposeChange(unittest.TestCase):
 
     def test_method(self):
         self.assertEqual("expose", ExposeChange.method())
-
-    def test_list_params(self):
-        change = ExposeChange(1, [], params=["application"])
-        self.assertEqual({"change_id": 1,
-                          "requires": [],
-                          "application": "application",
-                          "exposed_endpoints": None}, change.__dict__)
 
     def test_dict_params(self):
         change = ExposeChange(1, [], params={"application": "application"})
@@ -837,13 +720,6 @@ class TestScaleChange(unittest.TestCase):
     def test_method(self):
         self.assertEqual("scale", ScaleChange.method())
 
-    def test_list_params(self):
-        change = ScaleChange(1, [], params=["application", "scale"])
-        self.assertEqual({"change_id": 1,
-                          "requires": [],
-                          "application": "application",
-                          "scale": "scale"}, change.__dict__)
-
     def test_dict_params(self):
         change = ScaleChange(1, [], params={"application": "application",
                                             "scale": "scale"})
@@ -887,14 +763,6 @@ class TestSetAnnotationsChange(unittest.TestCase):
 
     def test_method(self):
         self.assertEqual("setAnnotations", SetAnnotationsChange.method())
-
-    def test_list_params(self):
-        change = SetAnnotationsChange(1, [], params=["id", "entity_type", "annotations"])
-        self.assertEqual({"change_id": 1,
-                          "requires": [],
-                          "id": "id",
-                          "entity_type": "entity_type",
-                          "annotations": "annotations"}, change.__dict__)
 
     def test_dict_params(self):
         change = SetAnnotationsChange(1, [], params={"id": "id",


### PR DESCRIPTION
Use GetChangesMapArgs for bundle changes instead of GetChanges

Also, drop support for GetChanges when parsing ChangeInfos

GetChanges returns a list of params in a magical order. This makes it brittle and adds lots of special knowledge boiler plate. GetChangesMapArgs was added a few years ago to replace it.

 Wer already support map arg params, we just never do so

#### QA Steps

```
tox -e py3
```

```
tox -e integration -- -m bundle
```