### PR TITLE
Forward ports from 2.9 to 3.x

### DIFF
--- a/juju/application.py
+++ b/juju/application.py
@@ -568,10 +568,18 @@ class Application(model.ModelEntity):
         )
 
     @property
-    def charm_url(self):
-        """Get the charm url for a given application
+    def charm_name(self):
+        """Get the charm name of this application
 
-        :return string: The charm url for an application
+        :return str: The name of the charm
+        """
+        return URL.parse(self.charm_url).name
+
+    @property
+    def charm_url(self):
+        """Get the charm url for this application
+
+        :return str: The charm url
         """
         return self.safe_data['charm-url']
 

--- a/juju/bundle.py
+++ b/juju/bundle.py
@@ -129,7 +129,10 @@ class BundleHandler:
             if not series:
                 metadata = utils.get_local_charm_metadata(charm_dir)
                 series = await get_charm_series(metadata, self.model)
-            if not self.model.connection().is_using_old_client and not series:
+            if not series:
+                base = utils.get_local_charm_base(None, charm_path, client.Base)
+                series = utils.base_channel_to_series(base.channel)
+            if not series:
                 raise JujuError(
                     "Couldn't determine series for charm at {}. "
                     "Add a 'series' key to the bundle.".format(charm_dir))

--- a/juju/model.py
+++ b/juju/model.py
@@ -2749,7 +2749,7 @@ class Model:
             if not busy:
                 break
             busy = "\n  ".join(busy)
-            if timeout and datetime.now() - start_time > timeout:
+            if timeout is not None and datetime.now() - start_time > timeout:
                 raise jasyncio.TimeoutError("Timed out waiting for model:\n" + busy)
             if last_log_time is None or datetime.now() - last_log_time > log_interval:
                 log.info("Waiting for model:\n  " + busy)

--- a/juju/model.py
+++ b/juju/model.py
@@ -2623,7 +2623,7 @@ class Model:
             warnings.warn("wait_for_active is deprecated; use status", DeprecationWarning)
             status = "active"
 
-        _wait_for_units = wait_for_at_least_units or 1
+        _wait_for_units = wait_for_at_least_units if wait_for_at_least_units is not None else 1
 
         timeout = timedelta(seconds=timeout) if timeout is not None else None
         idle_period = timedelta(seconds=idle_period)
@@ -2657,7 +2657,7 @@ class Model:
                     ", ".join(errored),
                 ))
 
-        if wait_for_exact_units:
+        if wait_for_exact_units is not None:
             assert type(wait_for_exact_units) == int and wait_for_exact_units >= 0, \
                 'Invalid value for wait_for_exact_units : %s' % wait_for_exact_units
 
@@ -2680,7 +2680,7 @@ class Model:
                     blocks.setdefault("App", []).append(app.name)
 
                 # Check if wait_for_exact_units flag is used
-                if wait_for_exact_units:
+                if wait_for_exact_units is not None:
                     if len(app.units) != wait_for_exact_units:
                         busy.append(app.name + " (waiting for exactly %s units, current : %s)" %
                                     (wait_for_exact_units, len(app.units)))
@@ -2697,7 +2697,7 @@ class Model:
                     # errors to raise at the end
                     break
                 for unit in app.units:
-                    if unit.machine and unit.machine.status == "error":
+                    if unit.machine is not None and unit.machine.status == "error":
                         errors.setdefault("Machine", []).append(unit.machine.id)
                         continue
                     if unit.agent_status == "error":

--- a/tests/integration/bundle/local-manifest.yaml
+++ b/tests/integration/bundle/local-manifest.yaml
@@ -1,0 +1,4 @@
+applications:
+  test1:
+    charm: "../charm-manifest"
+    num_units: 1

--- a/tests/integration/charm-manifest/config.yaml
+++ b/tests/integration/charm-manifest/config.yaml
@@ -1,0 +1,4 @@
+options:
+  status:
+    type: string
+    default: "active"

--- a/tests/integration/charm-manifest/dispatch
+++ b/tests/integration/charm-manifest/dispatch
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+status="$(config-get status)"
+
+if [[ "$status" == "error" ]]; then
+    if [[ -e .errored ]]; then
+        status="active"
+    else
+        touch .errored
+        exit 1
+    fi
+fi
+status-set "$status"

--- a/tests/integration/charm-manifest/manifest.yaml
+++ b/tests/integration/charm-manifest/manifest.yaml
@@ -1,0 +1,13 @@
+analysis:
+  attributes:
+  - name: language
+    result: python
+  - name: framework
+    result: operator
+bases:
+- architectures:
+  - amd64
+  channel: '20.04'
+  name: ubuntu
+charmcraft-started-at: '2021-08-20T08:09:00.639806Z'
+charmcraft-version: 1.2.1

--- a/tests/integration/charm-manifest/metadata.yaml
+++ b/tests/integration/charm-manifest/metadata.yaml
@@ -1,0 +1,4 @@
+name: charm
+summary: "test"
+description: "test"
+maintainers: ["test"]

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -297,3 +297,13 @@ async def test_app_remove_wait_flag(event_loop):
 
         await model.remove_application(app.name, block_until_done=True)
         assert a_name not in model.applications
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_app_charm_name(event_loop):
+    async with base.CleanModel() as model:
+        app = await model.deploy('ubuntu')
+        await model.wait_for_idle(status="active")
+        assert 'ubuntu' in app.charm_url
+        assert 'ubuntu' == app.charm_name

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -848,12 +848,12 @@ async def test_get_machines(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.wait_for_idle
 async def test_wait_for_idle_without_units(event_loop):
     async with base.CleanModel() as model:
         await model.deploy(
             'ubuntu',
             application_name='ubuntu',
-            series='bionic',
             channel='stable',
             num_units=0,
         )
@@ -863,12 +863,12 @@ async def test_wait_for_idle_without_units(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.wait_for_idle
 async def test_wait_for_idle_with_not_enough_units(event_loop):
     async with base.CleanModel() as model:
         await model.deploy(
             'ubuntu',
             application_name='ubuntu',
-            series='bionic',
             channel='stable',
             num_units=2,
         )
@@ -878,6 +878,7 @@ async def test_wait_for_idle_with_not_enough_units(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.wait_for_idle
 async def test_wait_for_idle_more_units_than_needed(event_loop):
     async with base.CleanModel() as model:
         charm_path = TESTS_DIR / 'charm'
@@ -900,13 +901,13 @@ async def test_wait_for_idle_more_units_than_needed(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.wait_for_idle
 async def test_wait_for_idle_with_enough_units(event_loop):
     pytest.skip("This is testing juju functionality")
     async with base.CleanModel() as model:
         await model.deploy(
             'ubuntu',
             application_name='ubuntu',
-            series='jammy',
             channel='stable',
             num_units=3,
         )
@@ -915,13 +916,13 @@ async def test_wait_for_idle_with_enough_units(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.wait_for_idle
 async def test_wait_for_idle_with_exact_units(event_loop):
     pytest.skip("This is testing juju functionality")
     async with base.CleanModel() as model:
         await model.deploy(
             'ubuntu',
             application_name='ubuntu',
-            series='jammy',
             channel='stable',
             num_units=2,
         )
@@ -930,6 +931,7 @@ async def test_wait_for_idle_with_exact_units(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+@pytest.mark.wait_for_idle
 async def test_wait_for_idle_with_exact_units_scale_down(event_loop):
     """Deploys 3 units, waits for them to be idle, then removes 2 of them,
     then waits for exactly 1 unit to be left.

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -181,6 +181,20 @@ async def test_deploy_bundle_local_charms(event_loop):
 @base.bootstrapped
 @pytest.mark.asyncio
 @pytest.mark.bundle
+async def test_deploy_bundle_local_charm_series_manifest(event_loop):
+    bundle_path = INTEGRATION_TEST_DIR / 'bundle' / 'local-manifest.yaml'
+
+    async with base.CleanModel() as model:
+        await model.deploy(bundle_path)
+        await wait_for_bundle(model, bundle_path)
+        assert set(model.units.keys()) == set(['test1/0'])
+        assert model.units['test1/0'].agent_status == 'idle'
+        assert model.units['test1/0'].workload_status == 'active'
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+@pytest.mark.bundle
 async def test_deploy_invalid_bundle(event_loop):
     pytest.skip('test_deploy_invalid_bundle intermittent test failure')
     bundle_path = TESTS_DIR / 'bundle' / 'invalid.yaml'

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -349,7 +349,7 @@ class TestModelWaitForIdle(asynctest.TestCase):
                     workload_status_message="workload_status_message",
                     machine=None,
                     agent_status="idle",
-                )],
+            )],
         )
 
         app.get_status = base.AsyncMock(return_value=app_status)
@@ -387,7 +387,7 @@ class TestModelWaitForIdle(asynctest.TestCase):
                     workload_status_message="workload_status_message",
                     machine=None,
                     agent_status="idle",
-                )],
+            )],
         )
 
         app.get_status = base.AsyncMock(return_value=app_status)

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -293,25 +293,23 @@ class TestModelWaitForIdle(asynctest.TestCase):
         self.assertEqual(str(cm.exception), "Timed out waiting for model:\nnonexisting_app (missing)")
 
     @pytest.mark.asyncio
+    @pytest.mark.wait_for_idle
     async def test_wait_for_active_status(self):
+        app_status = 'active'
         # create a custom apps mock
         from types import SimpleNamespace
         app = SimpleNamespace(
-            status="active",
+            status=app_status,
             units=[SimpleNamespace(
                 name="mockunit/0",
-                workload_status="active",
+                workload_status='active',
                 workload_status_message="workload_status_message",
                 machine=None,
                 agent_status="idle",
             )],
         )
-        # This is a small hack to act like we're getting 'unknown'
-        # from the api (the get_status() call), which shouldn't
-        # change the semantics of this test, as the 'unknown'
-        # has the lowest severity (so the app's 'active' status
-        # will overrule it)
-        app.get_status = base.AsyncMock(return_value='unknown')
+
+        app.get_status = base.AsyncMock(return_value=app_status)
         apps = {"dummy_app": app}
 
         with patch.object(Model, 'applications', new_callable=PropertyMock) as mock_apps:
@@ -326,5 +324,80 @@ class TestModelWaitForIdle(asynctest.TestCase):
 
             # use both `status` and `wait_for_active` - `wait_for_active` takes precedence
             await m.wait_for_idle(apps=["dummy_app"], wait_for_active=True, status="doesn't matter")
+
+        mock_apps.assert_called_with()
+
+    @pytest.mark.asyncio
+    @pytest.mark.wait_for_idle
+    async def test_wait_for_active_units_waiting_application(self):
+        # If the app is in waiting state, then wait more even if the units are ready
+        app_status = 'waiting'
+        # create a custom apps mock
+        from types import SimpleNamespace
+        app = SimpleNamespace(
+            status=app_status,
+            units=[SimpleNamespace(
+                name="mockunit/0",
+                workload_status='active',
+                workload_status_message="workload_status_message",
+                machine=None,
+                agent_status="idle",
+            ),
+                SimpleNamespace(
+                    name="mockunit/1",
+                    workload_status='active',
+                    workload_status_message="workload_status_message",
+                    machine=None,
+                    agent_status="idle",
+                )],
+        )
+
+        app.get_status = base.AsyncMock(return_value=app_status)
+        apps = {"dummy_app": app}
+
+        with patch.object(Model, 'applications', new_callable=PropertyMock) as mock_apps:
+            mock_apps.return_value = apps
+            m = Model()
+
+            with self.assertRaises(jasyncio.TimeoutError):
+                await m.wait_for_idle(apps=["dummy_app"], status="active")
+
+        mock_apps.assert_called_with()
+
+    @pytest.mark.asyncio
+    @pytest.mark.wait_for_idle
+    async def test_wait_for_active_units_waiting_for_units(self):
+        # If user wants to see a particular number of units, then application may be in a waiting
+        # state, return when there's at least that number of units in the desired state
+        app_status = 'waiting'
+        # create a custom apps mock
+        from types import SimpleNamespace
+        app = SimpleNamespace(
+            status=app_status,
+            units=[SimpleNamespace(
+                name="mockunit/0",
+                workload_status='active',
+                workload_status_message="workload_status_message",
+                machine=None,
+                agent_status="idle",
+            ),
+                SimpleNamespace(
+                    name="mockunit/1",
+                    workload_status='waiting',
+                    workload_status_message="workload_status_message",
+                    machine=None,
+                    agent_status="idle",
+                )],
+        )
+
+        app.get_status = base.AsyncMock(return_value=app_status)
+        apps = {"dummy_app": app}
+
+        with patch.object(Model, 'applications', new_callable=PropertyMock) as mock_apps:
+            mock_apps.return_value = apps
+            m = Model()
+
+            await m.wait_for_idle(apps=["dummy_app"], status="active", wait_for_units=1,
+                                  timeout=None)
 
         mock_apps.assert_called_with()

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -397,7 +397,7 @@ class TestModelWaitForIdle(asynctest.TestCase):
             mock_apps.return_value = apps
             m = Model()
 
-            await m.wait_for_idle(apps=["dummy_app"], status="active", wait_for_units=1,
+            await m.wait_for_idle(apps=["dummy_app"], status="active", wait_for_at_least_units=1,
                                   timeout=None)
 
         mock_apps.assert_called_with()


### PR DESCRIPTION
#### Description

This brings forward from `2.9` the following PRs: #901, #905, and #896 into `3.x` (the main branch).

#### QA Steps

There were a couple of conflicts that needed to be fixed, so QA will be necessary, make sure the following tests are passing:

```
tox -e integration -- tests/integration/test_application.py::test_app_charm_name
```
```
tox -e py3 -- -m wait_for_idle
```

```
tox -e integration -- -m wait_for_idle
```
```sh
tox -e integration -- tests/integration/test_model.py::test_deploy_bundle_local_charm_series_manifest
```