### PR TITLE
Add pytest.ini to register custom pytest marks

### DIFF
--- a/.pytest.ini
+++ b/.pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    bundle: tests about bundles
+    wait_for_idle: tests about wait_for_idle behavior


### PR DESCRIPTION
#### Description

Add a `.pytest.ini` at the top level to register custom pytest marks to prevent pytest from emitting  warnings for each mark, such as:

```
tests/unit/test_model.py:371: 24 warnings
  /home/caner/work/python-libjuju/tests/unit/test_model.py:371: PytestUnknownMarkWarning: Unknown pytest.mark.wait_for_idle - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.wait_for_idle
```

#### QA Steps

No QA needed.

Needs to be forward-ported to the main branch. Proactively added the `bundle` mark as it's used in there.