### PR TITLE
Removing Upper Constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     install_requires=[
         'macaroonbakery>=1.1,<2.0',
         'pyRFC3339>=1.0,<2.0',
-        'pyyaml>=5.1.2,<=6.0',
+        'pyyaml>=5.1.2',
         'theblues>=0.5.1,<1.0',
         'websockets>=7.0,<8.0 ; python_version<"3.9"',
         'websockets>=8.0,<9.0 ; python_version=="3.9"',


### PR DESCRIPTION
There is no reason to believe that future versions of PyYAML will not be compatible with this package, so we are removing this is an upper bound

#### Description

Python libjuju cannot be installed with the latest version of PyYAML (6.0.1), which fixes a [breaking change](https://github.com/yaml/pyyaml/issues/601) caused by an update to CPython.

Fixes: #913 

By removing the upper constraint on PyYAML, we can allow for future updates to this package to work with ours.

QA Steps
Attempt to install both PyYAML 6.0.1 and Python Juju at the same time:

```
pip install -e . pyyaml==6.0.1
```
