### PR TITLE
Remove ceiling on pyyaml version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     install_requires=[
         'macaroonbakery>=1.1,<2.0',
         'pyRFC3339>=1.0,<2.0',
-        'pyyaml>=5.1.2,<=6.0',
+        'pyyaml>=5.1.2',
         'websockets>=8.1,<9.0 ; python_version=="3.8"',
         'websockets>=9.0,<10.0 ; python_version=="3.9"',
         'websockets>=10.0; python_version>"3.9"',


### PR DESCRIPTION
#### Description

This brings forward the pyyaml version fix from #916.

#### QA Steps

Same QA from #916 should work here as well:

```sh
pip install -e . pyyaml==6.0.1
```