### PR TITLE
Cleanup release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ release:
 	git fetch --tags
 	rm dist/*.tar.gz || true
 	$(PY) setup.py sdist
-	$(BIN)/twine upload --repository-url https://upload.pypi.org/legacy/ dist/*
+	$(BIN)/twine upload --repository juju dist/*
 	git tag ${VERSION}
 	git push --tags
 

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -43,9 +43,7 @@ Here's a simple example that shows basic usage of the library. The example
 connects to the currently active Juju model, deploys a single unit of the
 ubuntu charm, then exits:
 
-.. note::
-
-Pylibjuju requires an already bootstrapped Juju controller to connect to.
+Note : Pylibjuju requires an already bootstrapped Juju controller to connect to.
 
 .. code:: python
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ long_description = '{}\n\n{}'.format(
     readme.read_text(),
     changelog.read_text()
 )
+long_description_content_type = 'text/x-rst'
 version = here / 'VERSION'
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
     maintainer_email='juju@lists.ubuntu.com',
     description=('Python library for Juju'),
     long_description=long_description,
+    long_description_content_type=long_description_content_type,
     url='https://github.com/juju/python-libjuju',
     license='Apache 2',
     classifiers=[


### PR DESCRIPTION
#### Description

This fixes up some of the bumps in the release process (`make release`).

- Twine complains about the long_description content type not being set, so this adds `long_description_content_type` in the `setup.py`
- There's a section named `note::` in the readme, apparently that's not a thing in the earlier versions of sphinx, so this removes it.
- twine uses the username/password when it's called with `--repository-url https://upload.pypi.org/legacy/` parameter, which is not anymore a thing (at least for our project), so we're using `.pypirc` with tokens (as described in the release document for pylibjuju), so this changes twine call to use ` --repository juju`,  which is simply a reference to the entry in the `.pypirc`.


#### QA Steps

No QA needed. 

#### Notes & Discussion

When forward ported, the `docs/changelog.rst` in the master branch needs to be fixed (for sections/subsections). Just call and you'll see the error:

```sh 
.tox/py3/bin/python3 setup.py sdist && twine check dist/*
```