### PR TITLE
[3.1] Remove ceiling on pyyaml version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     install_requires=[
         'macaroonbakery>=1.1,<2.0',
         'pyRFC3339>=1.0,<2.0',
-        'pyyaml>=5.1.2,<=6.0',
+        'pyyaml>=5.1.2',
         'websockets>=8.1,<9.0 ; python_version=="3.8"',
         'websockets>=9.0,<10.0 ; python_version=="3.9"',
         'websockets>=10.0; python_version>"3.9"',


### PR DESCRIPTION
Forward port from #916

#### Description

PyYAML 6.0.1 fixes a known issue in PyYAML 6.0, this ensures the LTS 3.1 python-libjuju includes the fix

#### QA Steps

*\<Commands / tests / steps to run to verify that the change works:\>*

```
pip install -e . pyyaml==6.0.1
```

#### Notes & Discussion

3.0 should probably also be updated with this change, but we are mainly interested in the LTS 3.1 branch