### PR TITLE
Stale bot to not bother feature requests

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -19,6 +19,6 @@ jobs:
           days-before-pr-close: 5
           stale-issue-label: 'incomplete'
           stale-pr-label: 'incomplete'
-          exempt-issue-labels: 'awaiting-approval,work-in-progress'
+          exempt-issue-labels: 'awaiting-approval,work-in-progress,wishlisted'
           exempt-pr-labels: 'awaiting-approval,work-in-progress'
           remove-stale-when-updated: true


### PR DESCRIPTION
#### Description

Currently the stale bot marks all the issues that haven't been updated for 30 days with `incomplete` and closes the issue 5 days after that if there's no update.

This change prevents the stale bot from bothering the feature requests (i.e. issues marked with `wishlisted` label), which can (and should imo) stay as long as needed.

Discussed a bit in #855, suggested https://github.com/juju/python-libjuju/issues/855#issuecomment-1655140050