### PR TITLE
Fix linter issues

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -1705,7 +1705,7 @@ class Model:
         if trust and (self.info.agent_version < client.Number.from_json('2.4.0')):
             raise NotImplementedError("trusted is not supported on model version {}".format(self.info.agent_version))
 
-        if not all([type(st) == str for st in attach_storage]):
+        if not all([isinstance(st, str) for st in attach_storage]):
             raise JujuError("Expected attach_storage to be a list of strings, given {}".format(attach_storage))
 
         # Ensure what we pass in, is a string.
@@ -2658,7 +2658,7 @@ class Model:
                 ))
 
         if wait_for_exact_units is not None:
-            assert type(wait_for_exact_units) == int and wait_for_exact_units >= 0, \
+            assert isinstance(wait_for_exact_units, int) and wait_for_exact_units >= 0, \
                 'Invalid value for wait_for_exact_units : %s' % wait_for_exact_units
 
         while True:

--- a/juju/utils.py
+++ b/juju/utils.py
@@ -419,7 +419,7 @@ def parse_base_arg(base):
     :param base str : The base to deploy a charm (e.g. ubuntu@22.04)
     """
     client.CharmBase()
-    if not isinstance(base, str) or "@" not in base:
+    if not (isinstance(base, str) and "@" in base):
         raise errors.JujuError(f"expected base string to contain os and channel separated by '@', got : {base}")
 
     name, channel = base.split('@')

--- a/juju/utils.py
+++ b/juju/utils.py
@@ -419,7 +419,7 @@ def parse_base_arg(base):
     :param base str : The base to deploy a charm (e.g. ubuntu@22.04)
     """
     client.CharmBase()
-    if type(base) != str or "@" not in base:
+    if not isinstance(base, str) or "@" not in base:
         raise errors.JujuError(f"expected base string to contain os and channel separated by '@', got : {base}")
 
     name, channel = base.split('@')

--- a/tests/integration/test_charmhub.py
+++ b/tests/integration/test_charmhub.py
@@ -19,7 +19,7 @@ async def test_info(event_loop):
         assert charm_info['id'] == 'Hw30RWzpUBnJLGtO71SX8VDWvd3WrjaJ'
         assert '2.0/stable' in charm_info['channel-map']
         cm_rev = charm_info['channel-map']['2.0/stable']['revision']
-        if type(cm_rev) == dict:
+        if isinstance(cm_rev, dict):
             # New client (>= 3.0)
             assert cm_rev['revision'] == 22
         else:
@@ -135,4 +135,4 @@ async def test_subordinate_false_field_exists(event_loop):
 async def test_list_resources(event_loop):
     async with base.CleanModel() as model:
         resources = await model.charmhub.list_resources('hello-kubecon')
-        assert type(resources) == list and len(resources) > 0
+        assert isinstance(resources, list) and len(resources) > 0


### PR DESCRIPTION
#### Description

This fixes [the linter issues seen in the CI](https://github.com/juju/python-libjuju/actions/runs/5727882624/job/15521577432?pr=927) recently in #927. In particular, it changes the uses of `type(something) == T` into `isinstance(something, T)`. It also simplifies logical statement `~a or ~b == ~(a and b)`.


#### QA Steps

Linter job in the CI should pass. Could also be run manually by `make lint`.