### PR TITLE
Respect juju model env var

### DIFF
--- a/juju/client/jujudata.py
+++ b/juju/client/jujudata.py
@@ -23,6 +23,8 @@ class JujuData:
         If the controller part is empty, the current controller will be used.
         If the model part is empty, the current model will be used for
         the controller.
+        If no argument is given, will look first for JUJU_MODEL in environment
+        and if not found, current model and controller will be used.
         The returned model name will always be qualified with a username.
         :param model str: The model name to parse.
         :return (str, str): The controller and model names.

--- a/juju/client/jujudata.py
+++ b/juju/client/jujudata.py
@@ -18,7 +18,7 @@ class NoModelException(Exception):
 class JujuData:
     __metaclass__ = abc.ABCMeta
 
-    def parse_model(self, model):
+    def parse_model(self, model=None):
         """Split the given model_name into controller and model parts.
         If the controller part is empty, the current controller will be used.
         If the model part is empty, the current model will be used for

--- a/tests/unit/test_jujudata.py
+++ b/tests/unit/test_jujudata.py
@@ -1,0 +1,120 @@
+import unittest
+import os
+import contextlib
+
+from juju.client.jujudata import FileJujuData, NoModelException
+from juju.errors import JujuError
+
+
+def yamls():
+    return {
+        'controllers.yaml': {
+            'current-controller': 'test-controller',
+            'controllers': {
+                'test-controller': {
+                    'uuid': 'a78b712e99abc9',
+                    'api-endpoints': '10.10.10.1:17017',
+                    'ca-cert': 'somecert',
+                },
+                'other-controller': {},
+            }
+        },
+        'accounts.yaml': {
+            'controllers': {
+                'test-controller': {
+                    'user': 'test-user',
+                    'password': 'pwd',
+                },
+                'other-controller': {
+                    'user': 'other-user',
+                    'password': 'pwd',
+                },
+                'no-user-controller': {},
+            }
+        },
+        'models.yaml': {
+            'controllers': {
+                'test-controller': {
+                    'current-model': 'test-model'
+                },
+                'other-controller': {}
+            }
+        },
+    }
+
+
+@contextlib.contextmanager
+def set_env_juju_model():
+    os.environ['JUJU_MODEL'] = 'env-model'
+    yield
+    os.environ.pop('JUJU_MODEL')
+
+
+class BaseTestJujuDataParseModel:
+    def _jujudata(self):
+        jjdata = FileJujuData()
+        jjdata._loaded = yamls()
+        return jjdata
+
+    def _parse_model(self, model):
+        data = self._jujudata()
+        return data.parse_model(model)
+
+    def test_implicit_controller_name(self):
+        controller_name, model_name = self._parse_model('test-model')
+        assert controller_name == 'test-controller'
+        assert model_name == 'test-user/test-model'
+
+    def test_unknown_model_name(self):
+        controller_name, model_name = self._parse_model('some-model')
+        assert controller_name == 'test-controller'
+        assert model_name == 'test-user/some-model'
+
+    def test_explicit_current_controller_name(self):
+        controller_name, model_name = self._parse_model('test-controller:test-model')
+        assert controller_name == 'test-controller'
+        assert model_name == 'test-user/test-model'
+
+    def test_explicit_user_name(self):
+        controller_name, model_name = self._parse_model('test-controller:some-user/test-model')
+        assert controller_name == 'test-controller'
+        assert model_name == 'some-user/test-model'
+
+    def test_explicit_other_controller_name(self):
+        controller_name, model_name = self._parse_model('other-controller:test-model')
+        assert controller_name == 'other-controller'
+        assert model_name == 'other-user/test-model'
+
+    def test_explicit_unknown_controller_name_raises(self):
+        with self.assertRaises(JujuError):
+            self._parse_model('unknown-controller:test-model')
+
+    def test_explicit_controller_name_no_account_raises(self):
+        with self.assertRaises(JujuError):
+            self._parse_model('no-user-controller:test-model')
+
+    def test_implicit_controller_no_model_raises(self):
+        data = self._jujudata()
+        data._loaded['controllers.yaml']['current-controller'] = 'other-controller'
+        with self.assertRaises(NoModelException):
+            # other-controller does not have a model
+            data.parse_model(None)
+
+
+class TestJujuDataParseModelWithoutEnvVariable(unittest.TestCase, BaseTestJujuDataParseModel):
+    def test_no_args_current_model(self):
+        controller_name, model_name = self._parse_model(None)
+        assert controller_name == 'test-controller'
+        assert model_name == 'test-user/test-model'
+
+
+class TestJujuDataParseModelWithEnvVariable(unittest.TestCase, BaseTestJujuDataParseModel):
+    def _parse_model(self, model):
+        data = self._jujudata()
+        with set_env_juju_model():
+            return data.parse_model(model)
+
+    def test_no_args_env_model(self):
+        controller_name, model_name = self._parse_model(None)
+        assert controller_name == 'test-controller'
+        assert model_name == 'test-user/env-model'

--- a/tests/unit/test_jujudata.py
+++ b/tests/unit/test_jujudata.py
@@ -118,3 +118,8 @@ class TestJujuDataParseModelWithEnvVariable(unittest.TestCase, BaseTestJujuDataP
         controller_name, model_name = self._parse_model()
         assert controller_name == 'test-controller'
         assert model_name == 'test-user/env-model'
+
+    def test_controller_name_env_model(self):
+        controller_name, model_name = self._parse_model('test-controller:')
+        assert controller_name == 'test-controller'
+        assert model_name == 'test-user/env-model'

--- a/tests/unit/test_jujudata.py
+++ b/tests/unit/test_jujudata.py
@@ -56,7 +56,7 @@ class BaseTestJujuDataParseModel:
         jjdata._loaded = yamls()
         return jjdata
 
-    def _parse_model(self, model):
+    def _parse_model(self, model=None):
         data = self._jujudata()
         return data.parse_model(model)
 
@@ -98,23 +98,23 @@ class BaseTestJujuDataParseModel:
         data._loaded['controllers.yaml']['current-controller'] = 'other-controller'
         with self.assertRaises(NoModelException):
             # other-controller does not have a model
-            data.parse_model(None)
+            data.parse_model()
 
 
 class TestJujuDataParseModelWithoutEnvVariable(unittest.TestCase, BaseTestJujuDataParseModel):
     def test_no_args_current_model(self):
-        controller_name, model_name = self._parse_model(None)
+        controller_name, model_name = self._parse_model()
         assert controller_name == 'test-controller'
         assert model_name == 'test-user/test-model'
 
 
 class TestJujuDataParseModelWithEnvVariable(unittest.TestCase, BaseTestJujuDataParseModel):
-    def _parse_model(self, model):
+    def _parse_model(self, model=None):
         data = self._jujudata()
         with set_env_juju_model():
             return data.parse_model(model)
 
     def test_no_args_env_model(self):
-        controller_name, model_name = self._parse_model(None)
+        controller_name, model_name = self._parse_model()
         assert controller_name == 'test-controller'
         assert model_name == 'test-user/env-model'


### PR DESCRIPTION
#### Description

*Addresses https://github.com/juju/python-libjuju/issues/909 (respect environment variable JUJU_MODEL)*

*JujuData.parse_model() by default looks for JUJU_MODEL in the environment.*


#### QA Steps


```
tox -e py3 -- tests/unit/test_jujudata.py
```

#### Notes & Discussion
When passing a model prefixed by a username  in `parse_model` the user is not validated. Is this intended behaviour?
e.g.
```
from juju.client.jujudata import FileJujuData

controller_name, model_name = FileJujuData().parse_model('some-controller:no-controller-user/some-model')
# model_name is 'no-controller-user'
```