### PR TITLE
[JUJU-4488] Add licence headers to source files on 3.x

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,9 @@ jobs:
       - name: Install dependencies
         run: pip install tox
       - name: Run linter
-        run: tox -e lint
+        run: |
+          tox -e lint
+          ./scripts/copyright.sh
 
   unit-tests:
     needs: lint

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ test: lint
 	tox -e integration
 
 .PHONY: lint
-lint: 
+lint:
+	@./scripts/copyright.sh
 	tox -e lint
 
 .PHONY: docs

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ test: lint
 .PHONY: lint
 lint:
 	@./scripts/copyright.sh
+	@echo "==> Running flake8 linter"
 	tox -e lint
 
 .PHONY: docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 # -*- coding: utf-8 -*-
 #
 # libjuju documentation build configuration file, created by

--- a/examples/action.py
+++ b/examples/action.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/add_k8s.py
+++ b/examples/add_k8s.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/add_machine.py
+++ b/examples/add_machine.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/add_model.py
+++ b/examples/add_model.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/add_secrets_backend.py
+++ b/examples/add_secrets_backend.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 from juju import jasyncio
 from juju.model import Model
 

--- a/examples/allwatcher.py
+++ b/examples/allwatcher.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/charmhub_deploy_k8s.py
+++ b/examples/charmhub_deploy_k8s.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/charmhub_deploy_machine.py
+++ b/examples/charmhub_deploy_machine.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/charmhub_find.py
+++ b/examples/charmhub_find.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 Example to show how to connect to the current model and search the charm-hub
 repository for charms.

--- a/examples/charmhub_info.py
+++ b/examples/charmhub_info.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 Example to show how to connect to the current model and query the charm-hub
 repository for information about a given charm.

--- a/examples/cloud.py
+++ b/examples/cloud.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/clouds.py
+++ b/examples/clouds.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/config.py
+++ b/examples/config.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/connect_current_model.py
+++ b/examples/connect_current_model.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This is a very basic example that connects to the currently selected model
 and prints the number of applications deployed to it.

--- a/examples/controller.py
+++ b/examples/controller.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/credential.py
+++ b/examples/credential.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import sys
 from juju import jasyncio
 from juju.controller import Controller

--- a/examples/crossmodel.py
+++ b/examples/crossmodel.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/crossmodel_bundle.py
+++ b/examples/crossmodel_bundle.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/crossmodel_controller.py
+++ b/examples/crossmodel_controller.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/crossmodel_relation.py
+++ b/examples/crossmodel_relation.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/debug-log.py
+++ b/examples/debug-log.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example demonstrate how debug-log works
 

--- a/examples/deploy.py
+++ b/examples/deploy.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/deploy_bundle.py
+++ b/examples/deploy_bundle.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/deploy_bundle_charmhub.py
+++ b/examples/deploy_bundle_charmhub.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 1. Connects to the current model

--- a/examples/deploy_bundle_with_trust.py
+++ b/examples/deploy_bundle_with_trust.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/deploy_constraints.py
+++ b/examples/deploy_constraints.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/deploy_local_big_k8s_bundle.py
+++ b/examples/deploy_local_big_k8s_bundle.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/deploy_local_bundle_with_resources.py
+++ b/examples/deploy_local_bundle_with_resources.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/deploy_local_file_resource.py
+++ b/examples/deploy_local_file_resource.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/deploy_local_resource.py
+++ b/examples/deploy_local_resource.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/deploy_with_revision.py
+++ b/examples/deploy_with_revision.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 from juju import jasyncio
 from juju.model import Model
 

--- a/examples/expose-application.py
+++ b/examples/expose-application.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/formatted_status.py
+++ b/examples/formatted_status.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example demonstrates how to obtain a formatted full status
 description. For a similar solution using the FullStatus object

--- a/examples/fullstatus.py
+++ b/examples/fullstatus.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 from juju import jasyncio
 from juju.model import Model
 

--- a/examples/future.py
+++ b/examples/future.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example doesn't work - it demonstrates features that don't exist yet.
 

--- a/examples/get_cloud.py
+++ b/examples/get_cloud.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/leadership.py
+++ b/examples/leadership.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/list_secrets.py
+++ b/examples/list_secrets.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 from juju import jasyncio
 from juju.model import Model
 

--- a/examples/livemodel.py
+++ b/examples/livemodel.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/local_refresh.py
+++ b/examples/local_refresh.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/localcharm.py
+++ b/examples/localcharm.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example shows how to deploy a local charm. It:
 

--- a/examples/machine_hostname.py
+++ b/examples/machine_hostname.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
+
 """
 This example:
 

--- a/examples/model.py
+++ b/examples/model.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example shows how to reconnect to a model if you encounter an error
 

--- a/examples/modelsummaries.py
+++ b/examples/modelsummaries.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/relate.py
+++ b/examples/relate.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/run_action.py
+++ b/examples/run_action.py
@@ -1,3 +1,5 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
 
 from juju import jasyncio
 from juju.model import Model

--- a/examples/scp.py
+++ b/examples/scp.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This is a very basic example that connects to the currently selected model
 and prints the number of applications deployed to it.

--- a/examples/status.py
+++ b/examples/status.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example demonstrate how status works
 

--- a/examples/unitrun.py
+++ b/examples/unitrun.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/examples/upgrade_local_charm_k8s.py
+++ b/examples/upgrade_local_charm_k8s.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 This example:
 

--- a/juju/access.py
+++ b/juju/access.py
@@ -1,3 +1,5 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
 
 from .errors import JujuNotValid
 

--- a/juju/action.py
+++ b/juju/action.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 from . import model
 
 

--- a/juju/annotation.py
+++ b/juju/annotation.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import logging
 
 from . import model

--- a/juju/annotationhelper.py
+++ b/juju/annotationhelper.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import logging
 
 from .client import client

--- a/juju/application.py
+++ b/juju/application.py
@@ -1,16 +1,5 @@
-# Copyright 2016 Canonical Ltd.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-#     Unless required by applicable law or agreed to in writing, software
-#     distributed under the License is distributed on an "AS IS" BASIS,
-#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#     See the License for the specific language governing permissions and
-#     limitations under the License.
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
 
 import hashlib
 import json

--- a/juju/bundle.py
+++ b/juju/bundle.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import logging
 import io
 import os

--- a/juju/charm.py
+++ b/juju/charm.py
@@ -1,16 +1,5 @@
-# Copyright 2019 Canonical Ltd.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-#     Unless required by applicable law or agreed to in writing, software
-#     distributed under the License is distributed on an "AS IS" BASIS,
-#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#     See the License for the specific language governing permissions and
-#     limitations under the License.
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
 
 import logging
 from . import model

--- a/juju/charmhub.py
+++ b/juju/charmhub.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 from .client import client
 from .errors import JujuError
 from juju import jasyncio

--- a/juju/client/client.py
+++ b/juju/client/client.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 '''Replace auto-generated classes with our own, where necessary.
 '''
 

--- a/juju/client/codegen.py
+++ b/juju/client/codegen.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 from collections import defaultdict
 from io import StringIO
 from textwrap import indent

--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import base64
 import json
 import logging

--- a/juju/client/connector.py
+++ b/juju/client/connector.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import copy
 import logging
 

--- a/juju/client/facade.py
+++ b/juju/client/facade.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import argparse
 import builtins
 import functools

--- a/juju/client/flags.py
+++ b/juju/client/flags.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import os
 
 PYLIBJUJU_DEV_FEATURE_FLAG = "PYLIBJUJU_DEV_FEATURE_FLAGS"

--- a/juju/client/gocookies.py
+++ b/juju/client/gocookies.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import datetime
 import http.cookiejar as cookiejar
 import json

--- a/juju/client/jujudata.py
+++ b/juju/client/jujudata.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import abc
 import io
 import os

--- a/juju/client/overrides.py
+++ b/juju/client/overrides.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import re
 from collections import namedtuple
 

--- a/juju/client/proxy/factory.py
+++ b/juju/client/proxy/factory.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 from juju.client.proxy.kubernetes.proxy import KubernetesProxy
 
 

--- a/juju/client/proxy/kubernetes/proxy.py
+++ b/juju/client/proxy/kubernetes/proxy.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import tempfile
 
 from juju.client.proxy.proxy import Proxy, ProxyNotConnectedError

--- a/juju/client/proxy/proxy.py
+++ b/juju/client/proxy/proxy.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 from abc import abstractmethod
 
 from juju.errors import AbstractMethodError

--- a/juju/client/runner.py
+++ b/juju/client/runner.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 
 class AsyncRunner:
     async def __call__(self, facade_method, *args, **kwargs):

--- a/juju/constraints.py
+++ b/juju/constraints.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 #
 # Module that parses constraints
 #

--- a/juju/controller.py
+++ b/juju/controller.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import json
 import logging
 from concurrent.futures import CancelledError

--- a/juju/delta.py
+++ b/juju/delta.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 from .client import client
 
 

--- a/juju/errors.py
+++ b/juju/errors.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 class JujuError(Exception):
     def __init__(self, *args, **kwargs):
         self.message = ''

--- a/juju/exceptions.py
+++ b/juju/exceptions.py
@@ -1,2 +1,5 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 class DeadEntityException(Exception):
     pass

--- a/juju/jasyncio.py
+++ b/juju/jasyncio.py
@@ -1,16 +1,5 @@
-# Copyright 2016 Canonical Ltd.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-#     Unless required by applicable law or agreed to in writing, software
-#     distributed under the License is distributed on an "AS IS" BASIS,
-#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#     See the License for the specific language governing permissions and
-#     limitations under the License.
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
 
 # A compatibility layer on asyncio that ensures we have all the right
 # bindings for the functions we need from asyncio. Reason for this

--- a/juju/juju.py
+++ b/juju/juju.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 from juju.controller import Controller
 from juju.client.jujudata import FileJujuData
 from juju.errors import JujuError

--- a/juju/loop.py
+++ b/juju/loop.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 from .jasyncio import * # noqa
 
 import warnings

--- a/juju/machine.py
+++ b/juju/machine.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import ipaddress
 import logging
 

--- a/juju/model.py
+++ b/juju/model.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import base64
 import collections
 import hashlib

--- a/juju/names.py
+++ b/juju/names.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import re
 from enum import Enum, unique
 

--- a/juju/offerendpoints.py
+++ b/juju/offerendpoints.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 #
 # Module that parses offer endpoints
 #

--- a/juju/origin.py
+++ b/juju/origin.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 from enum import Enum
 from .errors import JujuError
 

--- a/juju/placement.py
+++ b/juju/placement.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 #
 # This module allows us to parse a machine placement directive into a
 # Placement object suitable for passing through the websocket API.

--- a/juju/provisioner.py
+++ b/juju/provisioner.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import os
 import re
 import shlex

--- a/juju/relation.py
+++ b/juju/relation.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import logging
 
 from . import model

--- a/juju/remoteapplication.py
+++ b/juju/remoteapplication.py
@@ -1,16 +1,5 @@
-# Copyright 2019 Canonical Ltd.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-#     Unless required by applicable law or agreed to in writing, software
-#     distributed under the License is distributed on an "AS IS" BASIS,
-#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#     See the License for the specific language governing permissions and
-#     limitations under the License.
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
 
 import logging
 

--- a/juju/status.py
+++ b/juju/status.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import logging
 
 from .client import client

--- a/juju/tag.py
+++ b/juju/tag.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 # TODO: Tags should be a proper class, so that we can distinguish whether
 # something is already a tag or not.  For example, 'user-foo' is a valid
 # username, but is ambiguous with the already-tagged username 'foo'.

--- a/juju/unit.py
+++ b/juju/unit.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import logging
 
 import pyrfc3339

--- a/juju/url.py
+++ b/juju/url.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 from enum import Enum
 from .errors import JujuError
 from urllib.parse import urlparse

--- a/juju/user.py
+++ b/juju/user.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import logging
 
 import pyrfc3339

--- a/juju/utils.py
+++ b/juju/utils.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import os
 import textwrap
 from collections import defaultdict

--- a/juju/version.py
+++ b/juju/version.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 
 LTS_RELEASES = ["jammy", "focal", "bionic", "xenial", "trusty", "precise"]
 

--- a/scripts/copyright.sh
+++ b/scripts/copyright.sh
@@ -25,7 +25,7 @@ red() {
 }
 
 run_copyright() {
-	OUT=$(find . -name '*.py' | grep -v -E "./(docs|scripts|debian|juju-egg-info|.tox|.git|juju/client)|__init__" | sort | xargs grep -L -E '# (Copyright|Code generated)' || true)
+	OUT=$(find . -name '*.py' | grep -v -E "./(docs|scripts|debian|juju-egg-info|.tox|.git|juju/client|tests/charm)|__init__" | sort | xargs grep -L -E '# (Copyright|Code generated)' || true)
 	LINES=$(echo "${OUT}" | wc -w)
 	if [ "$LINES" != 0 ]; then
 		echo ""

--- a/scripts/copyright.sh
+++ b/scripts/copyright.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+supports_colors() {
+	if [[ -z ${TERM} ]] || [[ ${TERM} == "" ]] || [[ ${TERM} == "dumb" ]]; then
+		echo "NO"
+		return
+	fi
+	if which tput >/dev/null 2>&1; then
+		# shellcheck disable=SC2046
+		if [[ $(tput colors) -gt 1 ]]; then
+			echo "YES"
+			return
+		fi
+	fi
+	echo "NO"
+}
+
+red() {
+	if [[ "$(supports_colors)" == "YES" ]]; then
+		tput sgr0
+		echo "$(tput setaf 1)${1}$(tput sgr0)"
+		return
+	fi
+	echo "${1}"
+}
+
+run_copyright() {
+	OUT=$(find . -name '*.py' | grep -v -E "./(docs|scripts|debian|juju-egg-info|.tox|.git|juju/client)|__init__" | sort | xargs grep -L -E '# (Copyright|Code generated)' || true)
+	LINES=$(echo "${OUT}" | wc -w)
+	if [ "$LINES" != 0 ]; then
+		echo ""
+		echo "$(red 'Found some issues:')"
+		echo -e '\nThe following files are missing copyright headers'
+		echo "${OUT}"
+		exit 1
+	fi
+}
+
+test_copyright() {
+	echo "==> Copyright analysis"
+
+	(
+		# cd .. || exit
+
+		# Check for copyright notices
+		run_copyright
+	)
+}
+
+test_copyright

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,5 @@
-# Copyright 2016 Canonical Ltd.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-#     Unless required by applicable law or agreed to in writing, software
-#     distributed under the License is distributed on an "AS IS" BASIS,
-#     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#     See the License for the specific language governing permissions and
-#     limitations under the License.
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
 
 from pathlib import Path
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import inspect
 import subprocess
 import uuid

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 from pathlib import Path
 
 import pytest

--- a/tests/integration/test_charmhub.py
+++ b/tests/integration/test_charmhub.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import pytest
 
 from .. import base

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 from juju.client import client
 
 import pytest

--- a/tests/integration/test_connection.py
+++ b/tests/integration/test_connection.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import http
 import logging
 import socket

--- a/tests/integration/test_controller.py
+++ b/tests/integration/test_controller.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import asyncio
 import uuid
 import hvac

--- a/tests/integration/test_crossmodel.py
+++ b/tests/integration/test_crossmodel.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import tempfile
 from pathlib import Path
 

--- a/tests/integration/test_errors.py
+++ b/tests/integration/test_errors.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import pytest
 
 from .. import base

--- a/tests/integration/test_expose.py
+++ b/tests/integration/test_expose.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import pytest
 
 from juju.application import ExposedEndpoint

--- a/tests/integration/test_juju.py
+++ b/tests/integration/test_juju.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import pytest
 
 from juju.controller import Controller

--- a/tests/integration/test_macaroon_auth.py
+++ b/tests/integration/test_macaroon_auth.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import logging
 import subprocess
 import os

--- a/tests/integration/test_machine.py
+++ b/tests/integration/test_machine.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import asyncio
 from tempfile import NamedTemporaryFile
 

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import json
 import os
 import random

--- a/tests/integration/test_unit.py
+++ b/tests/integration/test_unit.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import asyncio
 from pathlib import Path
 from tempfile import NamedTemporaryFile

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import mock
 import asynctest
 import asyncio

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 from pathlib import Path
 import unittest
 from unittest import mock

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 Tests for generated client code
 

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import asyncio
 import json
 from collections import deque

--- a/tests/unit/test_constraints.py
+++ b/tests/unit/test_constraints.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 #
 # Test our constraints parser
 #

--- a/tests/unit/test_controller.py
+++ b/tests/unit/test_controller.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 

--- a/tests/unit/test_definitions.py
+++ b/tests/unit/test_definitions.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import unittest
 
 from juju.client import client

--- a/tests/unit/test_flags.py
+++ b/tests/unit/test_flags.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import os
 import unittest
 

--- a/tests/unit/test_gocookies.py
+++ b/tests/unit/test_gocookies.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 """
 Tests for the gocookies code.
 """

--- a/tests/unit/test_loop.py
+++ b/tests/unit/test_loop.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import unittest
 
 from juju import jasyncio

--- a/tests/unit/test_machine.py
+++ b/tests/unit/test_machine.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import asynctest
 import mock
 import pytest

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import unittest
 from unittest.mock import patch, PropertyMock
 

--- a/tests/unit/test_offerendpoint.py
+++ b/tests/unit/test_offerendpoint.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 #
 # Test our offer endpoint parser
 #

--- a/tests/unit/test_origin.py
+++ b/tests/unit/test_origin.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import unittest
 
 from juju.origin import Channel, Origin, Platform, Risk, Source

--- a/tests/unit/test_overrides.py
+++ b/tests/unit/test_overrides.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 from juju.client.overrides import Binary, Number  # noqa
 
 import pytest

--- a/tests/unit/test_placement.py
+++ b/tests/unit/test_placement.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 #
 # Test our placement helper
 #

--- a/tests/unit/test_proxy.py
+++ b/tests/unit/test_proxy.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import unittest
 
 from juju.client.proxy.factory import proxy_from_config

--- a/tests/unit/test_proxy_kubernetes.py
+++ b/tests/unit/test_proxy_kubernetes.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import unittest
 from juju.client.proxy.kubernetes.proxy import KubernetesProxy
 

--- a/tests/unit/test_registration_string.py
+++ b/tests/unit/test_registration_string.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 #
 # Test our placement helper
 #

--- a/tests/unit/test_relation.py
+++ b/tests/unit/test_relation.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import unittest
 
 import mock

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import unittest
 
 

--- a/tests/unit/test_unit.py
+++ b/tests/unit/test_unit.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import asynctest
 import mock
 import pytest

--- a/tests/unit/test_url.py
+++ b/tests/unit/test_url.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import unittest
 
 from juju.url import Schema, URL

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 import unittest
 import pytest
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# Licensed under the Apache V2, see LICENCE file for details.
+
 from pathlib import Path
 
 # Utilities for tests


### PR DESCRIPTION
#### Description

This is a forward port of #933, adding license headers to source files:

```python
# Copyright 2023 Canonical Ltd.
# Licensed under the Apache V2, see LICENCE file for details.
```

#### QA Steps

No behavior change.