### PR TITLE
Parse nested assumes expressions

### DIFF
--- a/juju/client/facade.py
+++ b/juju/client/facade.py
@@ -661,6 +661,18 @@ class Type:
 
     @classmethod
     def from_json(cls, data):
+        def _parse_nested_list_entry(expr, result_dict):
+            if isinstance(expr, str):
+                cls.splitEntries(expr, result_dict)
+            elif isinstance(expr, dict):
+                for _, v in expr.items():
+                    _parse_nested_list_entry(v, result_dict)
+            elif isinstance(expr, list):
+                for v in expr:
+                    _parse_nested_list_entry(v, result_dict)
+            else:
+                raise TypeError(f"Unexpected type of entry in assumes expression: {expr}")
+
         if isinstance(data, cls):
             return data
         if isinstance(data, str):
@@ -679,20 +691,7 @@ class Type:
         if isinstance(data, list):
             # check: https://juju.is/docs/sdk/assumes
             d = {}
-            for entry in data:
-                if isinstance(entry, dict):
-                    # this could be
-                    # any-of
-                    # all-of
-                    for _, v in entry.items():
-                        if isinstance(v, list):
-                            for i in v:
-                                cls.splitEntries(i, d)
-                        else:
-                            cls.splitEntries(v, d)
-                else:
-                    # this is a simple entry
-                    cls.splitEntries(entry, d)
+            _parse_nested_list_entry(data, d)
             return cls(**d)
         return None
 

--- a/juju/utils.py
+++ b/juju/utils.py
@@ -407,12 +407,13 @@ def should_upgrade_resource(available_resource, existing_resources):
     """
     # should upgrade resource?
     res_name = available_resource.get('Name', available_resource.get('name'))
-    # no, if it's upload
-    if existing_resources[res_name].origin == 'upload':
-        return False
 
-    # no, if we already have it (and upstream doesn't have a newer res available)
+    # do we have it already?
     if res_name in existing_resources:
+        # no upgrade, if it's upload
+        if existing_resources[res_name].origin == 'upload':
+            return False
+        # no upgrade, if upstream doesn't have a newer revision of the resource available
         available_rev = available_resource.get('Revision', available_resource.get('revision', -1))
         u_fields = existing_resources[res_name].unknown_fields
         existing_rev = u_fields.get('Revision', u_fields.get('revision', -1))


### PR DESCRIPTION
#### Description

This adds support for nested `assumes` expression. Without this change, pylibjuju could only parse 1-level of `assumes`, with this change, we can support assumes expression that look like:

```
assumes:
  - juju
  - any-of:
      - all-of:
          - juju >= 2.9
          - juju < 3
      - all-of:
          - juju >= 3.1
          - juju < 4
```

Fixes #938


#### QA Steps

Unfortunately it's not trivial to write an integration test for this, as the code that's been changed is part of the facade api. So we'll use the `mysql-k8s` charm that's been used in #938.

```
 $ juju version
2.9.x
 $ juju bootstrap microk8s micro28
 $ juju add-model assumes-test
```

```python
 $ python -m asyncio
asyncio REPL 3.10.12 (main, Jun 11 2023, 05:26:28) [GCC 11.4.0] on linux
Use "await" directly instead of "asyncio.run()".
Type "help", "copyright", "credits" or "license" for more information.
>>> import asyncio
>>> from juju import model;m=model.Model();await m.connect();await m.deploy("mysql-k8s", channel="8.0/edge", trust=True)
<Application entity_id="mysql-k8s">
>>>
exiting asyncio REPL...
```

#### Notes & Discussion

JUJU-4562