### PR TITLE
docs: add model connection reminder to docstring for add-model

### DIFF
--- a/juju/controller.py
+++ b/juju/controller.py
@@ -309,7 +309,9 @@ class Controller:
             the current user.
         :param dict config: Model configuration.
         :param str region: Region in which to create the model.
-        :return Model: A connection to the newly created model.
+        :return Model: A connection to the newly created model. Run
+            await <model>.connect(<connect-params>) to ensure the model
+            is connected before using the model.
         """
         model_facade = client.ModelManagerFacade.from_connection(
             self.connection())


### PR DESCRIPTION
#### Description

Adds a docstring to add a reminder to run `model.connect()` before using the model on `controller.add_model` method.

#### QA Steps

No QA required since it's a trivial docstring change.

All CI tests need to pass.

*\<Please note that most likely an additional test will be required by the reviewers for any change that's not a one liner to land.\>*
