### PR TITLE
Pass correct charm url to series selector

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -1897,7 +1897,7 @@ class Model:
         charm_url = URL.parse(result.url)
 
         # run the series selector to get a series for the base
-        selected_series = utils.series_selector(series, url, model_config, supported_series, force)
+        selected_series = utils.series_selector(series, charm_url, model_config, supported_series, force)
         result.charm_origin.base = utils.get_base_from_origin_or_channel(resolved_origin, selected_series)
         charm_url.series = selected_series
 


### PR DESCRIPTION
#### Description

Currently (before this change) we seem to be passing to the series selector the default url for the charm (e.g. `ch:zinc-k8s`), instead of the url returned from the `ResolveCharms` facade call (e.g. `ch:amd64/jammy/zinc-k8s-117`). As a result we're sending the wrong url (e.g., in #925 `ch:amd64/focal/zinc-k8s-117`) to the `AddPendingResources`, which results in the wrong image to be selected for the resources for the charm (e.g., the incorrect oci-image for the zinc-k8s charm in #925).

Fixes #925

#### QA Steps

```sh
 $ juju version
3.x (mine is 3.1.6-ubuntu-amd64)
 $ juju bootstrap microk8s deleteme
 $ juju add-model issue925
 $ juju deploy zinc-k8s --channel edge --trust zinc-with-juju
 $ microk8s.kubectl -n issue925 get pods zinc-with-juju-0 -o json | jq '.spec.containers[1].image'
"registry.jujucharms.com/charm/hgjw3c886prn4ysv07exaoapcjerfrxyxjt7d/zinc-image@sha256:f5a776b8d6c9dbcbae71983438837b3b3f06d65b631e49c6f12350b340b2f563"
```

Now deploy with pylibjuju 

```python
 $ python -m asyncio
>>> from juju import model;m=model.Model();await m.connect();
>>> await m.deploy("zinc-k8s", channel="edge", application_name="zinc-with-pylibjuju")
<Application entity_id="zinc-with-pylibjuju">
>>> exit()
```
and check to see if the images are the same:

```sh
 $ microk8s.kubectl -n issue925 get pods zinc-with-pylibjuju-0 -o json | jq '.spec.containers[1].image'
"registry.jujucharms.com/charm/hgjw3c886prn4ysv07exaoapcjerfrxyxjt7d/zinc-image@sha256:f5a776b8d6c9dbcbae71983438837b3b3f06d65b631e49c6f12350b340b2f563"
```

#### Notes & Discussion

JUJU-4556