### PR TITLE
Bring forward support for nested assumes expressions on 3x

### DIFF
--- a/juju/utils.py
+++ b/juju/utils.py
@@ -541,12 +541,13 @@ def should_upgrade_resource(available_resource, existing_resources):
     """
     # should upgrade resource?
     res_name = available_resource.get('Name', available_resource.get('name'))
-    # no, if it's upload
-    if existing_resources[res_name].origin == 'upload':
-        return False
 
-    # no, if we already have it (and upstream doesn't have a newer res available)
+    # do we have it already?
     if res_name in existing_resources:
+        # no upgrade, if it's upload
+        if existing_resources[res_name].origin == 'upload':
+            return False
+        # no upgrade, if upstream doesn't have a newer revision of the resource available
         available_rev = available_resource.get('Revision', available_resource.get('revision', -1))
         u_fields = existing_resources[res_name].unknown_fields
         existing_rev = u_fields.get('Revision', u_fields.get('revision', -1))


### PR DESCRIPTION
#### Description

This forward ports the fix for nested assume expressions from #940 into the master branch.

Fixes #938 for `3.x`.

#### QA Steps

Same QA steps can be followed from #940, so copy/pasting the manual QA steps below:

----- 

Unfortunately it's not trivial to write an integration test for this, as the code that's been changed is part of the facade api. So we'll use the `mysql-k8s` charm that's been used in #938.

```
 $ juju version
3.x
 $ juju bootstrap microk8s micro28
 $ juju add-model assumes-test
```

```python
 $ python -m asyncio
asyncio REPL 3.10.12 (main, Jun 11 2023, 05:26:28) [GCC 11.4.0] on linux
Use "await" directly instead of "asyncio.run()".
Type "help", "copyright", "credits" or "license" for more information.
>>> import asyncio
>>> from juju import model;m=model.Model();await m.connect();await m.deploy("mysql-k8s", channel="8.0/edge", trust=True)
<Application entity_id="mysql-k8s">
>>>
exiting asyncio REPL...
```

#### Notes & Discussion

JUJU-4562