### PR TITLE
Use `log.warning` instead of the deprecated `warn`

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -1558,7 +1558,7 @@ class Model:
 
         The logic is the same.
         """
-        log.warn("relate is deprecated and will be removed. Use integrate instead.")
+        log.warning("relate is deprecated and will be removed. Use integrate instead.")
         return await self.integrate(relation1, relation2)
 
     async def add_space(self, name, cidrs=None, public=True):


### PR DESCRIPTION
#### Description
Every integration test currently ends with a warning:
```
tests/integration/test_bundle.py::test_loki_receives_logs
  /home/ubuntu/code/o11y/cos-lite-bundle/.tox/integration/lib/python3.10/site-packages/juju/model.py:1513: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    log.warn("relate is deprecated and will be removed. Use integrate instead.")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

Fixes:
- Use `warning` instead of `warn`.


#### QA Steps

Run any integration test that includes a `relate` call and make sure the warning is gone from the summary.
