### PR TITLE
Change dependency for macaroonbakery to support protobuf >= 4.21.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setup(
         exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
     package_data={'juju': ['py.typed']},
     install_requires=[
-        'macaroonbakery>=1.1,<2.0',
+        # see https://github.com/juju/python-libjuju/issues/914 for macaroon dependency
+        'macaroonbakery@git+https://github.com/cderici/py-macaroon-bakery@relax-protobuf-version#egg=macaroonbakery',
         'pyRFC3339>=1.0,<2.0',
         'pyyaml>=5.1.2',
         'websockets>=8.1,<9.0 ; python_version=="3.8"',

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ passenv =
     TEST_AGENTS
     LXD_DIR
 deps =
-    macaroonbakery
+    git+https://github.com/cderici/py-macaroon-bakery@relax-protobuf-version#egg=macaroonbakery
     toposort
     typing-inspect
     paramiko


### PR DESCRIPTION
#### Description

Here's what this is trying to fix:

* `macaroonbakery` library hasn't been getting much love since 2020, and currently depends on `protobuf>=3.4.0,<4.0`
* `mysql-connector-python` library [latest version](https://pypi.org/project/mysql-connector-python/#history) depends on `protobuf>=4.21.1`.
* `pylibjuju` depends on `macaroonbakery`.

Therefore anyone wants to use `pylibjuju` along with `mysql-connector-python` in their project can't satisfy `protobuf` version constraints. 

So I made a fork of macaroon bakery that relaxes the protobuf version, and pylibjuju points to that. I also created a pull request to the upstream repo. https://github.com/go-macaroon-bakery/py-macaroon-bakery/pull/90 . If that lands, then this dependency can go back to using `pypi`. But until then, pylibjuju needs to point to that fork in order to be compatible with `mysql-connector-python`.

Fixes #914

#### QA Steps

Dependency can be tested by the QA from #914, such as:

Steps to reproduce:
1. Install poetry (e.g. pipx install poetry)
2. `poetry new foo`
3. `cd foo`
4. `poetry add mysql-connector-python^8.1.0`
5. `poetry add juju>=2`


Pylibjuju should work as normal. macaroonbakery is used in `client/connection` so it's pretty central. If there's a problem, we'd definitely see it in the tests.

#### Notes & Discussion

JUJU-4620