### PR TITLE
Application refresh with resources

### DIFF
--- a/juju/application.py
+++ b/juju/application.py
@@ -760,13 +760,11 @@ class Application(model.ModelEntity):
                 res_name = resource.get('Name', resource.get('name'))
                 request_data.append(client.CharmResource(
                     description=resource.get('Description', resource.get('description')),
-                    fingerprint=resource.get('Fingerprint', resource.get('fingerprint', [])),
                     name=res_name,
                     path=_arg_res_filenames.get(res_name,
                                                 resource.get('Path',
                                                              resource.get('filename', ''))),
                     revision=_arg_res_revisions.get(res_name, -1),
-                    size=resource.get('Size', resource.get('size', 0)),
                     type_=resource.get('Type', resource.get('type')),
                     origin='store',
                 ))

--- a/juju/utils.py
+++ b/juju/utils.py
@@ -394,7 +394,7 @@ def base_channel_to_series(channel):
     return get_version_series(origin.Channel.parse(channel).track)
 
 
-def should_upgrade_resource(available_resource, existing_resources):
+def should_upgrade_resource(available_resource, existing_resources, arg_resources):
     """Called in the context of upgrade_charm. Given a resource R, takes a look at the resources we
     already have and decides if we need to refresh R.
 
@@ -402,11 +402,16 @@ def should_upgrade_resource(available_resource, existing_resources):
     charmhub api. We're considering if we need to refresh this during upgrade_charm.
     :param dict[str] existing_resources: The dict coming from resources_facade.ListResources
     representing the resources of the currently deployed charm.
+    :param dict[str] arg_resources: user provided resources to be refreshed
 
     :result bool: The decision to refresh the given resource
     """
+
     # should upgrade resource?
     res_name = available_resource.get('Name', available_resource.get('name'))
+
+    if res_name in arg_resources:
+        return True
 
     # do we have it already?
     if res_name in existing_resources:

--- a/juju/utils.py
+++ b/juju/utils.py
@@ -394,7 +394,7 @@ def base_channel_to_series(channel):
     return get_version_series(origin.Channel.parse(channel).track)
 
 
-def should_upgrade_resource(available_resource, existing_resources, arg_resources):
+def should_upgrade_resource(available_resource, existing_resources, arg_resources={}):
     """Called in the context of upgrade_charm. Given a resource R, takes a look at the resources we
     already have and decides if we need to refresh R.
 

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -232,6 +232,18 @@ async def test_upgrade_charm_resource(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
+async def test_refresh_with_resource_argument(event_loop):
+    async with base.CleanModel() as model:
+        app = await model.deploy('juju-qa-test', resources={'foo-file': 2})
+        res2 = await app.get_resources()
+        assert res2['foo-file'].revision == 2
+        await app.refresh(resources={'foo-file': 4})
+        res4 = await app.get_resources()
+        assert res4['foo-file'].revision == 4
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
 async def test_upgrade_charm_resource_same_rev_no_update(event_loop):
     async with base.CleanModel() as model:
         app = await model.deploy('keystone', channel='victoria/stable')


### PR DESCRIPTION
#### Description

This adds two things:

1. Fixes the error that causes #955 where we were trying to pass a revision for a resource in refresh, can be reproduced with the `juju-cli` as well as follows:

```sh
 $ juju deploy ceph-mon --channel octopus/stable
 $ juju refresh ceph-juju --channel quincy/stable --resource alert-rules=1
ERROR while adding pending resource info for "alert-rules": bad resource metadata: bad info: bad metadata: resource missing filename
```

2. This also implements functionality that allows passing `resources` argument to application refresh for non-local charms.

Fixes #955 and #883 

#### QA Steps

So the fix for the #955 can be tested manually by recreating the scenario above with pylibjuju as follows:

```python
 $ python -m asyncio
>>> import asyncio
>>> from juju import model;m=model.Model();await m.connect()
>>> await m.deploy('ceph-mon', channel='octopus/stable')
```

Check the resources for that using juju-cli:

```sh
  $ juju resources ceph-mon
No resources to display.
```

Go back to the python repl:

```python
>>> await m.applications['ceph-mon'].refresh(channel='quincy/stable')
This should succeed
```

And check the resources again external to pylibjuju, you should see the resource is added:

```sh
  $ juju resources ceph-juju
Resource     Supplied by  Revision
alert-rules  charmstore   1
```

Additionally, an integration test for the second part of the PR that adds the resource argument to refresh is added, so just run that, and maybe play with it manually for different charms:

```
tox -e integration -- tests/integration/test_application.py::test_refresh_with_resource_argument
```

All CI tests need to pass.

#### Notes & Discussion

JUJU-4736