### PR TITLE
Improve jujudata to find controller name by endpoint

### DIFF
--- a/juju/client/jujudata.py
+++ b/juju/client/jujudata.py
@@ -15,6 +15,7 @@ from juju.utils import juju_config_dir
 
 API_ENDPOINTS_KEY = 'api-endpoints'
 
+
 class NoModelException(Exception):
     pass
 

--- a/juju/client/jujudata.py
+++ b/juju/client/jujudata.py
@@ -10,9 +10,10 @@ import juju.client.client as jujuclient
 import yaml
 from juju import tag
 from juju.client.gocookies import GoCookieJar
-from juju.errors import JujuError
+from juju.errors import JujuError, PylibjujuProgrammingError
 from juju.utils import juju_config_dir
 
+API_ENDPOINTS_KEY = 'api-endpoints'
 
 class NoModelException(Exception):
     pass
@@ -125,6 +126,23 @@ class FileJujuData(JujuData):
             )
         except (KeyError, FileNotFoundError):
             return None, None
+
+    def controller_name_by_endpoint(self, endpoint):
+        """Finds the controller that has the given endpoints, returns the name.
+
+        :param str endpoint: The endpoint of the controller we're looking for
+        """
+        for controller_name, controller in self.controllers().items():
+            if isinstance(endpoint, str):
+                if endpoint in controller[API_ENDPOINTS_KEY]:
+                    return controller_name
+            elif isinstance(endpoint, list):
+                for e in endpoint:
+                    if e in controller[API_ENDPOINTS_KEY]:
+                        return controller_name
+            else:
+                raise PylibjujuProgrammingError()
+        raise JujuError(f'Unable to find controller with endpoint {endpoint}')
 
     def controllers(self):
         return self._load_yaml('controllers.yaml', 'controllers')

--- a/juju/errors.py
+++ b/juju/errors.py
@@ -85,8 +85,10 @@ class JujuUnitError(JujuError):
 class JujuBackupError(JujuError):
     pass
 
+
 class PylibjujuProgrammingError(Exception):
     pass
+
 
 class JujuConfigError(JujuError):
     """Exception raised during processing a configuration key-value pair

--- a/juju/errors.py
+++ b/juju/errors.py
@@ -85,6 +85,8 @@ class JujuUnitError(JujuError):
 class JujuBackupError(JujuError):
     pass
 
+class PylibjujuProgrammingError(Exception):
+    pass
 
 class JujuConfigError(JujuError):
     """Exception raised during processing a configuration key-value pair


### PR DESCRIPTION
#### Description

This allows all kinds of connections to set the `controller_name` by default by looking up the `endpoints` in the `jujudata`.

Fixes #771

#### QA Steps

Manual QA should follow the steps described in #771.

Find the details of a controller you bootstrapped (any controller would do):

```sh
  $ juju show-controller --show-password
```

Grab the details there and plug them into either a script or in the repl (repl is awkward to use with the certificate):

```python
  c = Controller()
  await c.connect(endpoint="<ip>:17070", username="admin", password="admin_pass", cacert="ca_cert") # explicit connection with credential values
  # check the name
  print(c.controller_name)
```

All CI tests need to pass.

#### Notes & Discussion

JUJU-4781