### PR TITLE
Parse charm URLs consistantly for local charms

### DIFF
--- a/juju/bundle.py
+++ b/juju/bundle.py
@@ -223,24 +223,28 @@ class BundleHandler:
 
         return self.bundle, self.overlays
 
-    async def fetch_plan(self, charm_url, origin, overlays=[]):
-        entity_id = charm_url.path()
-        is_local = Schema.LOCAL.matches(charm_url.schema)
+    async def fetch_plan(self, bundle, origin, overlays=[]):
         bundle_dir = None
 
-        if is_local and os.path.isfile(entity_id):
-            bundle_yaml = Path(entity_id).read_text()
-            bundle_dir = Path(entity_id).parent
-        elif is_local and os.path.isdir(entity_id):
-            bundle_yaml = (Path(entity_id) / "bundle.yaml").read_text()
-            bundle_dir = Path(entity_id)
+        if is_local_bundle(str(bundle)):
+            path = str(bundle)
+            if path.startswith("local:"):
+                path = path[6:]
+            bundle_yaml, bundle_dir = read_local_bundle(path)
 
-        if Schema.CHARM_STORE.matches(charm_url.schema):
-            bundle_yaml = await self.charmstore.files(entity_id,
-                                                      filename='bundle.yaml',
-                                                      read_file=True)
-        elif Schema.CHARM_HUB.matches(charm_url.schema):
-            bundle_yaml = await self._download_bundle(charm_url, origin)
+        else:
+            if client.CharmsFacade.best_facade_version(self.model.connection()) < 3:
+                url = URL.parse(bundle, default_store=Schema.CHARM_STORE)
+            else:
+                url = URL.parse(bundle)
+            path = url.path()
+
+            if Schema.CHARM_STORE.matches(url.schema):
+                bundle_yaml = await self.charmstore.files(bundle,
+                                                          filename='bundle.yaml',
+                                                          read_file=True)
+            elif Schema.CHARM_HUB.matches(url.schema):
+                bundle_yaml = await self._download_bundle(bundle, origin)
 
         if not bundle_yaml:
             raise JujuError('empty bundle, nothing to deploy')
@@ -267,7 +271,7 @@ class BundleHandler:
 
         self.bundle = await self._validate_bundle(self.bundle)
 
-        if is_local:
+        if is_local_bundle(path):
             self.bundle = await self._handle_local_charms(self.bundle, bundle_dir)
 
         self.bundle, self.overlays = self._resolve_include_file_config(bundle_dir)
@@ -278,7 +282,7 @@ class BundleHandler:
         yaml_data = "---\n".join(_yaml_data)
 
         self.plan = await self.bundle_facade.GetChanges(
-            bundleurl=entity_id,
+            bundleurl=path,
             yaml=yaml_data)
 
         if self.plan.errors:
@@ -362,7 +366,7 @@ class BundleHandler:
                                             architecture=architecture,
                                             risk=risk,
                                             track=track)
-                charm_url, charm_origin = await self.model._resolve_charm(charm_url, origin)
+                charm_url, charm_origin = await self.model._charmhub_resolve_charm(charm_url, origin)
 
                 spec['charm'] = str(charm_url)
             else:
@@ -414,6 +418,21 @@ class BundleHandler:
 
 def is_local_charm(charm_url):
     return charm_url.startswith('.') or charm_url.startswith('local:') or os.path.isabs(charm_url)
+
+
+is_local_bundle = is_local_charm
+
+
+def read_local_bundle(path):
+    path = Path(path)
+    if os.path.isfile(path):
+        bundle_yaml = path.read_text()
+        bundle_dir = path.parent
+    elif os.path.isdir(path):
+        bundle_yaml = (path / "bundle.yaml").read_text()
+        bundle_dir = path
+
+    return (bundle_yaml, bundle_dir)
 
 
 async def get_charm_series(metadata, model):
@@ -709,14 +728,14 @@ class AddCharmChange(ChangeInfo):
 
         # We don't add local charms because they've already been added
         # by self._handle_local_charms
-        url = URL.parse(str(self.charm))
-        ch = None
-        identifier = None
-        if Schema.LOCAL.matches(url.schema):
+        if is_local_charm(str(self.charm)):
             origin = client.CharmOrigin(source="local", risk="stable")
             context.origins[self.charm] = {str(None): origin}
             return self.charm
 
+        url = URL.parse(str(self.charm))
+        ch = None
+        identifier = None
         if Schema.CHARM_STORE.matches(url.schema):
             entity_id = await context.charmstore.entityId(self.charm, channel=self.channel)
             log.debug('Adding %s', entity_id)
@@ -735,7 +754,7 @@ class AddCharmChange(ChangeInfo):
                                         architecture=arch,
                                         risk=ch.risk,
                                         track=ch.track)
-            identifier, origin = await context.model._resolve_charm(url, origin)
+            identifier, origin = await context.model._charmhub_resolve_charm(url, origin)
 
         if identifier is None:
             raise JujuError('unknown charm {}'.format(self.charm))

--- a/tests/unit/test_url.py
+++ b/tests/unit/test_url.py
@@ -11,10 +11,6 @@ class TestURLV1(unittest.TestCase):
         u = URL.parse("cs:mysql")
         self.assertEqual(u, URL(Schema.CHARM_STORE, name="mysql"))
 
-    def test_parse_local(self):
-        u = URL.parse("local:mysql")
-        self.assertEqual(u, URL(Schema.LOCAL, name="mysql"))
-
     def test_parse_v1_user(self):
         u = URL.parse("cs:~fred/mysql")
         self.assertEqual(u, URL(Schema.CHARM_STORE, name="mysql", user="fred"))
@@ -33,22 +29,33 @@ class TestURLV1(unittest.TestCase):
 
 
 class TestURLV2(unittest.TestCase):
+
+    schema = Schema.CHARM_HUB
+
     def test_parse_charmhub(self):
-        u = URL.parse("ch:arm64/bionic/mysql-1")
-        self.assertEqual(u, URL(Schema.CHARM_HUB, name="mysql", architecture="arm64", series="bionic", revision=1))
+        u = URL.parse(f"{self.schema}:arm64/bionic/mysql-1")
+        self.assertEqual(u, URL(self.schema, name="mysql", architecture="arm64", series="bionic", revision=1))
 
     def test_parse_charmhub_with_no_series(self):
-        u = URL.parse("ch:arm64/mysql")
-        self.assertEqual(u, URL(Schema.CHARM_HUB, name="mysql", architecture="arm64"))
+        u = URL.parse(f"{self.schema}:arm64/mysql")
+        self.assertEqual(u, URL(self.schema, name="mysql", architecture="arm64"))
 
     def test_parse_charmhub_with_no_series_arch(self):
-        u = URL.parse("ch:mysql")
-        self.assertEqual(u, URL(Schema.CHARM_HUB, name="mysql"))
+        u = URL.parse(f"{self.schema}:mysql")
+        self.assertEqual(u, URL(self.schema, name="mysql"))
 
     def test_parse_v2_revision(self):
-        u = URL.parse("ch:mysql-1")
-        self.assertEqual(u, URL(Schema.CHARM_HUB, name="mysql", revision=1))
+        u = URL.parse(f"{self.schema}:mysql-1")
+        self.assertEqual(u, URL(self.schema, name="mysql", revision=1))
 
     def test_parse_v2_large_revision(self):
-        u = URL.parse("ch:mysql-12345")
-        self.assertEqual(u, URL(Schema.CHARM_HUB, name="mysql", revision=12345))
+        u = URL.parse(f"{self.schema}:mysql-12345")
+        self.assertEqual(u, URL(self.schema, name="mysql", revision=12345))
+
+    def test_parse_v2_without_store(self):
+        u = URL.parse("mysql-1", default_store=self.schema)
+        self.assertEqual(u, URL(self.schema, name="mysql", revision=1))
+
+
+class TestURLLocal(TestURLV2):
+    schema = Schema.LOCAL


### PR DESCRIPTION
Parse charm URLs consistantly for local charms

Local charm URLs are confused in pylibjuju because often a charm
url-like string is passed into deploy, to explicitly specify a local
charm. These 'urls' were of the form 'local:/path/to/charm'

Local URLs were parsed accordingly.

However, the above is in no sense a url really so should be treated as
such. This also means that pylibjuju is unable to parse real local charm
urls returned to the client from the server when, say, uploading a local
charm.

Drop support for local charms like this. Instead parse local charm urls the
same way we parse charmhub charm url.

This has the side-effect, however, that we can no longer treat all
objects to deploy as URLs. Now, they are either URLs (ch or cs charms)
or paths or paths prepended with 'local:' (local charms)

As such, in deploy code and refresh code, we often need to branch on
is_local_charm. This is to ensure we don't attempt to parse paths as
URLs. Everywhere we URL.parse user input, we ensure the entity is not a
path

This resolves https://github.com/juju/python-libjuju/issues/961

#### QA Steps

```
tox -e py3 -- tests/unit/test_url.py
```

```
tox -e integration -- tests/integration/test_model.py::test_deploy_local_bundle_dir
tox -e integration -- tests/integration/test_model.py::test_deploy_local_bundle_file
tox -e integration -- tests/integration/test_model.py::test_deploy_bundle_local_charms
tox -e integration -- tests/integration/test_model.py::test_deploy_local_charm
```

All CI tests need to pass.

(In a python interpreter)
```
>>> from juju.url import URL
>>> u = URL.parse("local:focal/ubuntu-12")
>>> print(u.name)
ubuntu
>>> print(u.revision)
12
>>> URL.parse("local:/path/to/charm")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jack/juju/python-libjuju/juju/url.py", line 50, in parse
    c = parse_v2_url(u, s, default_store)
  File "/home/jack/juju/python-libjuju/juju/url.py", line 138, in parse_v2_url
    raise JujuError("charm or bundle URL {} malformed".format(s))
juju.errors.JujuError: charm or bundle URL local:/path/to/charm malformed
```

Ensure the example scripts still function
```
$ python examples/deploy_bundle.py
$ python examples/deploy_local_bundle_with_resources.py
```

Verify the following example script runs successfully:
```
from juju import jasyncio
from juju.model import Model


async def main():
    model = Model()
    print('Connecting to model')
    await model.connect()
    try:
        print('path="/home/jack/charms/ubuntu"')
        await depl(model, path="/home/jack/charms/ubuntu")
        print('switch="/home/jack/charms/ubuntu"')
        await depl(model, switch="/home/jack/charms/ubuntu")
        print('switch="local:/home/jack/charms/ubuntu"')
        await depl(model, switch="local:/home/jack/charms/ubuntu")
    finally:
        print('Disconnecting from model')
        await model.disconnect()

async def depl(model, **kwargs):
    try:
        app = await model.deploy("ubuntu")
        await model.block_until(lambda: all(u[0].workload_status == 'active' for u in app.units))
        await app.refresh(**kwargs)
    finally:
        await app.remove()
        await model.block_until(lambda: not len(model.applications))

if __name__ == '__main__':
    jasyncio.run(main())
```

