### PR TITLE
Allow switch kwarg in refresh to switch to local charms

### DIFF
--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -219,6 +219,21 @@ async def test_upgrade_charm_resource_same_rev_no_update(event_loop):
 
 
 @base.bootstrapped
+@pytest.mark.asyncio
+async def test_refresh_charmhub_to_local(event_loop):
+    charm_path = INTEGRATION_TEST_DIR / 'charm'
+    async with base.CleanModel() as model:
+        app = await model.deploy('ubuntu', application_name='ubu-path')
+        await app.refresh(path=str(charm_path))
+        assert app.data['charm-url'].startswith('local:')
+
+        app = await model.deploy('ubuntu', application_name='ubu-switch')
+        await app.refresh(switch=str(charm_path))
+        assert app.data['charm-url'].startswith('local:')
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
 async def test_trusted(event_loop):
     async with base.CleanModel() as model:
         await model.deploy('ubuntu', trust=True)

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -166,3 +166,14 @@ class TestUnExposeApplication(unittest.IsolatedAsyncioTestCase):
             application="panther",
             exposed_endpoints=["alpha", "beta"]
         )
+
+
+class TestRefreshApplication(unittest.IsolatedAsyncioTestCase):
+    @mock.patch("juju.model.Model.connection")
+    async def test_refresh_mutually_exclusive_kwargs(self, mock_conn):
+        app = Application(entity_id="app-id", model=Model())
+        with self.assertRaises(ValueError):
+            await app.refresh(switch="charm1", revision=10)
+
+        with self.assertRaises(ValueError):
+            await app.refresh(switch="charm1", path="/path/to/charm2")


### PR DESCRIPTION
Port forward https://github.com/juju/python-libjuju/pull/968

Check if the switch param is pointing to a local charm. If it is, run local_refresh as if it were provided

This is how the Juju CLI works, which was missing from pylibjuju. Replicate this.

Also push url parsing of switch kwarg behind a check if it's local charm, meaning we avoid the possibility where we attempt to parse a path as if it were a url

Resolves https://github.com/juju/python-libjuju/issues/963

### QA Steps

```
tox -e integration -- tests/integration/test_application.py::test_refresh_charmhub_to_local
```

All CI tests need to pass.

Verify the following example script runs successfully:
```
from juju import jasyncio
from juju.model import Model


async def main():
    model = Model()
    print('Connecting to model')
    await model.connect()
    try:
        print('path="/home/jack/charms/ubuntu"')
        await depl(model, path="/home/jack/charms/ubuntu")
        print('switch="/home/jack/charms/ubuntu"')
        await depl(model, switch="/home/jack/charms/ubuntu")
        print('switch="local:/home/jack/charms/ubuntu"')
        await depl(model, switch="local:/home/jack/charms/ubuntu")
    finally:
        print('Disconnecting from model')
        await model.disconnect()

async def depl(model, **kwargs):
    try:
        app = await model.deploy("ubuntu")
        await model.block_until(lambda: all(u[0].workload_status == 'active' for u in app.units))
        await app.refresh(**kwargs)
    finally:
        await app.remove()
        await model.block_until(lambda: not len(model.applications))

if __name__ == '__main__':
    jasyncio.run(main())
```