### PR TITLE
Juju config directory location fix on 3.x

### DIFF
--- a/juju/utils.py
+++ b/juju/utils.py
@@ -48,19 +48,17 @@ def juju_config_dir():
 
     """
     # Check $JUJU_DATA first
-    config_dir = os.environ.get('JUJU_DATA', None)
+    config_dir = Path(os.environ.get('JUJU_DATA', None))
 
     # Second option: $XDG_DATA_HOME for ~/.local/share
-    if not config_dir:
-        base_dir = os.environ.get('XDG_DATA_HOME', None)
-        if base_dir is not None:
-            config_dir = base_dir + '/juju'
+    if not config_dir.exists():
+        config_dir = Path(os.environ.get('XDG_DATA_HOME', '')) / 'juju'
 
     # Third option: just set it to ~/.local/share/juju
-    if not config_dir:
-        config_dir = '~/.local/share/juju'
+    if not config_dir.exists():
+        config_dir = Path('~/.local/share/juju')
 
-    return os.path.abspath(os.path.expanduser(config_dir))
+    return str(config_dir.expanduser().resolve())
 
 
 def juju_ssh_key_paths():

--- a/juju/utils.py
+++ b/juju/utils.py
@@ -47,16 +47,15 @@ def juju_config_dir():
     * ~/.local/share/juju
 
     """
-    # Check $JUJU_DATA first
-    config_dir = Path(os.environ.get('JUJU_DATA', None))
+    # Set it to ~/.local/share/juju as default
+    config_dir = Path('~/.local/share/juju')
 
-    # Second option: $XDG_DATA_HOME for ~/.local/share
-    if not config_dir.exists():
-        config_dir = Path(os.environ.get('XDG_DATA_HOME', '')) / 'juju'
-
-    # Third option: just set it to ~/.local/share/juju
-    if not config_dir.exists():
-        config_dir = Path('~/.local/share/juju')
+    # Check $JUJU_DATA
+    if juju_data := os.environ.get('JUJU_DATA'):
+        config_dir = Path(juju_data)
+    # Secondly check: $XDG_DATA_HOME for ~/.local/share
+    elif xdg_data_home := os.environ.get('XDG_DATA_HOME'):
+        config_dir = Path(xdg_data_home) / 'juju'
 
     return str(config_dir.expanduser().resolve())
 

--- a/juju/utils.py
+++ b/juju/utils.py
@@ -52,7 +52,9 @@ def juju_config_dir():
 
     # Second option: $XDG_DATA_HOME for ~/.local/share
     if not config_dir:
-        config_dir = os.environ.get('XDG_DATA_HOME', None)
+        base_dir = os.environ.get('XDG_DATA_HOME', None)
+        if base_dir is not None:
+            config_dir = base_dir + '/juju'
 
     # Third option: just set it to ~/.local/share/juju
     if not config_dir:


### PR DESCRIPTION
#### Description

Forward port of #975 

XDG_DATA_HOME is supposed to point to the parent directory for applications. We were incorrectly setting that as Juju config dir.

#### QA Steps

No operational logic changes. There's one CI failure on the master branch about add manual machine ssh that's unrelated to this change, that one's aside, all the others need to be passing.