### PR TITLE
[JUJU-4779] Switch to local properly

### DIFF
--- a/examples/local_refresh.py
+++ b/examples/local_refresh.py
@@ -20,7 +20,7 @@ async def main():
 
     try:
         print('Get deployed application')
-        app = model.appplications["ubuntu"]
+        app = model.applications["ubuntu"]
 
         print('Refresh/Upgrade Ubuntu charm with local charm')
         await app.refresh(path="path/to/local/ubuntu.charm")

--- a/juju/application.py
+++ b/juju/application.py
@@ -849,6 +849,17 @@ class Application(model.ModelEntity):
                                                              metadata,
                                                              resources=resources)
 
+        # We know this charm is a local charm, but this charm origin could be
+        # the charm origin of a charmhub charm. Ensure that we update/remove
+        # the appropriate fields.
+        charm_origin.source = "local"
+        charm_origin.track = None
+        charm_origin.risk = None
+        charm_origin.branch = None
+        charm_origin.hash_ = None
+        charm_origin.id_ = None
+        charm_origin.revision = URL.parse(charm_url).revision
+
         # Update application
         await app_facade.SetCharm(
             application=self.entity_id,

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -10,6 +10,7 @@ from .. import base
 from ..utils import INTEGRATION_TEST_DIR
 from juju import errors
 from juju.url import URL, Schema
+from juju.client import client
 
 MB = 1
 
@@ -265,6 +266,22 @@ async def test_refresh_charmhub_to_local(event_loop):
         app = await model.deploy('ubuntu', application_name='ubu-switch')
         await app.refresh(switch=str(charm_path))
         assert app.data['charm-url'].startswith('local:')
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_local_refresh(event_loop):
+    charm_path = INTEGRATION_TEST_DIR / 'charm'
+    async with base.CleanModel() as model:
+        app = await model.deploy('ubuntu')
+        origin = client.CharmOrigin(source="charm-hub", track="20.04", risk="stable",
+                                    branch="deadbeef", hash_="hash", id_="id", revision=12,
+                                    base=client.Base("20.04", "ubuntu"))
+
+        await app.local_refresh(charm_origin=origin, path=charm_path)
+
+        assert origin == client.CharmOrigin(source="local", revision=0,
+                                            base=client.Base("20.04", "ubuntu"))
 
 
 @base.bootstrapped


### PR DESCRIPTION
Ensure that we provide the server with a valid charm origin when switching to local charms. Previosuly, we simply sent back the same charm origin when switching to a local charm.

However, this is not valid, since we don't know where we switched from. If it's a charmhub charm, it's origin will not be valid.

Also, parse the revision from the new charm url the server sends us

This is equivalent to: https://github.com/juju/juju/pull/16434

#### QA Steps

Edit line 26 of examples/local_refresh.py to point to a local ubuntu charm

```
$ juju deploy ubuntu
$ juju mongo
juju:PRIMARY> db.applications.find().pretty()
{
	"_id" : "307e2580-61cd-4b10-852d-503a469bc9fe:ubuntu",
	"name" : "ubuntu",
	"model-uuid" : "307e2580-61cd-4b10-852d-503a469bc9fe",
	"series" : "focal",
	"subordinate" : false,
	"charmurl" : "ch:amd64/focal/ubuntu-24",
	"cs-channel" : "stable",
	"charm-origin" : {
		"source" : "charm-hub",
		"type" : "charm",
		"id" : "DksXQKAQTZfsUmBAGanZAhpoS4dpmXel",
		"hash" : "9b2877f7ebf04b348cf40ace32fdfc6d1cc0157dea7fd6740c4ba74e0e201e5b",
		"revision" : 24,
		"channel" : {
			"risk" : "stable"
		},
		"platform" : {
			"architecture" : "amd64",
			"os" : "ubuntu",
			"series" : "focal"
		}
	},
	"charmmodifiedversion" : 0,
	"forcecharm" : false,
	"life" : 0,
	"unitcount" : 1,
	"relationcount" : 0,
	"minunits" : 0,
	"txn-revno" : NumberLong(30),
	"metric-credentials" : BinData(0,""),
	"exposed" : false,
	"scale" : 0,
	"passwordhash" : "",
	"provisioning-state" : null,
	"txn-queue" : [
		"653aad0b07032e0a3c048519_3d3200d2"
	]
}
 
$ python examples/local_refresh.py
$ juju mongo
juju:PRIMARY> db.applications.find().pretty()
{
	"_id" : "307e2580-61cd-4b10-852d-503a469bc9fe:ubuntu",
	"name" : "ubuntu",
	"model-uuid" : "307e2580-61cd-4b10-852d-503a469bc9fe",
	"series" : "focal",
	"subordinate" : false,
	"charmurl" : "local:focal/ubuntu-16",
	"cs-channel" : "",
	"charm-origin" : {
		"source" : "local",
		"id" : "",
		"hash" : "",
		"revision" : 16,
		"platform" : {
			"architecture" : "amd64",
			"os" : "ubuntu",
			"series" : "focal"
		}
	},
	"charmmodifiedversion" : 1,
	"forcecharm" : false,
	"life" : 0,
	"unitcount" : 1,
	"relationcount" : 0,
	"minunits" : 0,
	"txn-revno" : NumberLong(33),
	"metric-credentials" : BinData(0,""),
	"exposed" : false,
	"scale" : 0,
	"passwordhash" : "",
	"provisioning-state" : null,
	"txn-queue" : [
		"653aad3c07032e0a3c04854e_42797690"
	]
}
```

```
tox -e integration -- tests/integration/test_application.py::test_local_refresh
```

All CI tests need to pass.