### PR TITLE
[JUJU-4779] Ensure valid charm origin for local charm switches

### DIFF
--- a/examples/local_refresh.py
+++ b/examples/local_refresh.py
@@ -20,7 +20,7 @@ async def main():
 
     try:
         print('Get deployed application')
-        app = model.appplications["ubuntu"]
+        app = model.applications["ubuntu"]
 
         print('Refresh/Upgrade Ubuntu charm with local charm')
         await app.refresh(path="path/to/local/ubuntu.charm")

--- a/juju/application.py
+++ b/juju/application.py
@@ -848,6 +848,17 @@ class Application(model.ModelEntity):
                                                              metadata,
                                                              resources=resources)
 
+        # We know this charm is a local charm, but this charm origin could be
+        # the charm origin of a charmhub charm. Ensure that we update/remove
+        # the appropriate fields.
+        charm_origin.source = "local"
+        charm_origin.track = None
+        charm_origin.risk = None
+        charm_origin.branch = None
+        charm_origin.hash_ = None
+        charm_origin.id_ = None
+        charm_origin.revision = URL.parse(charm_url).revision
+
         set_charm_args = {
             'application': self.entity_id,
             'charm_origin': charm_origin,

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -9,6 +9,7 @@ import logging
 from .. import base
 from juju import jasyncio, errors
 from juju.url import URL, Schema
+from juju.client import client
 
 MB = 1
 
@@ -230,6 +231,22 @@ async def test_refresh_charmhub_to_local(event_loop):
         app = await model.deploy('ubuntu', application_name='ubu-switch')
         await app.refresh(switch=str(charm_path))
         assert app.data['charm-url'].startswith('local:')
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
+async def test_local_refresh(event_loop):
+    charm_path = INTEGRATION_TEST_DIR / 'charm'
+    async with base.CleanModel() as model:
+        app = await model.deploy('ubuntu')
+        origin = client.CharmOrigin(source="charm-hub", track="20.04", risk="stable",
+                                    branch="deadbeef", hash_="hash", id_="id", revision=12,
+                                    base=client.Base("20.04", "ubuntu"))
+
+        await app.local_refresh(charm_origin=origin, path=charm_path)
+
+        assert origin == client.CharmOrigin(source="local", revision=0,
+                                            base=client.Base("20.04", "ubuntu"))
 
 
 @base.bootstrapped


### PR DESCRIPTION
Ensure that we provide the server with a valid charm origin when switching to local charms. Previously, we simply sent back the same charm origin when switching to a local charm.

However, this is not valid, since we don't know where we switched from. If it's a charmhub charm, it's origin will not be valid.

Also, parse the revision from the new charm url the server sends us

This is equivalent to: https://github.com/juju/juju/pull/16434

#### QA Steps

Edit line 26 of examples/local_refresh.py to point to a local ubuntu charm

```
$ juju deploy ubuntu
$ juju mongo
juju:PRIMARY> db.applications.find().pretty()
...
{
	"_id" : "277dae9c-abe3-4aba-83e4-0a63622e2981:ubuntu",
	"name" : "ubuntu",
	"model-uuid" : "277dae9c-abe3-4aba-83e4-0a63622e2981",
	"subordinate" : false,
	"charmurl" : "ch:amd64/focal/ubuntu-24",
	"charm-origin" : {
		"source" : "charm-hub",
		"type" : "charm",
		"id" : "DksXQKAQTZfsUmBAGanZAhpoS4dpmXel",
		"hash" : "9b2877f7ebf04b348cf40ace32fdfc6d1cc0157dea7fd6740c4ba74e0e201e5b",
		"revision" : 24,
		"channel" : {
			"risk" : "stable"
		},
		"platform" : {
			"architecture" : "amd64",
			"os" : "ubuntu",
			"channel" : "22.04"
		}
	},
	"charmmodifiedversion" : 0,
	"forcecharm" : false,
	"life" : 0,
	"unitcount" : 1,
	"relationcount" : 0,
	"minunits" : 0,
	"txn-revno" : NumberLong(3),
	"metric-credentials" : BinData(0,""),
	"exposed" : false,
	"scale" : 0,
	"passwordhash" : "",
	"provisioning-state" : null
}
 
$ python examples/local_refresh.py
$ juju mongo
juju:PRIMARY> db.applications.find().pretty()
...
{
	"_id" : "277dae9c-abe3-4aba-83e4-0a63622e2981:ubuntu",
	"name" : "ubuntu",
	"model-uuid" : "277dae9c-abe3-4aba-83e4-0a63622e2981",
	"subordinate" : false,
	"charmurl" : "local:jammy/ubuntu-13",
	"charm-origin" : {
		"source" : "local",
		"type" : "charm",
		"id" : "DksXQKAQTZfsUmBAGanZAhpoS4dpmXel",
		"hash" : "9b2877f7ebf04b348cf40ace32fdfc6d1cc0157dea7fd6740c4ba74e0e201e5b",
		"revision" : 13,
		"channel" : {
			"risk" : "stable"
		},
		"platform" : {
			"architecture" : "amd64",
			"os" : "ubuntu",
			"channel" : "22.04"
		}
	},
	"charmmodifiedversion" : 1,
	"forcecharm" : false,
	"life" : 0,
	"unitcount" : 1,
	"relationcount" : 0,
	"minunits" : 0,
	"txn-revno" : NumberLong(4),
	"metric-credentials" : BinData(0,""),
	"exposed" : false,
	"scale" : 0,
	"passwordhash" : "",
	"provisioning-state" : null
}
```
NOTE: This doesn't quite work as expected, but this is not a python-libjuju bug, but in juju/juju here:
https://github.com/juju/juju/blob/3.3/state/application.go#L1792-L1840

However, @hmlanigan is working on a fix (https://github.com/juju/juju/pull/16315) that will resolve this, so proposing this change to python-libjuju as a stepping stone towards to complete solution

```
tox -e integration -- tests/integration/test_application.py::test_local_refresh
```

All CI tests need to pass.