### PR TITLE
Free pyblijuju from relying on juju client when connecting to a controller

### DIFF
--- a/juju/controller.py
+++ b/juju/controller.py
@@ -49,6 +49,7 @@ class Controller:
             bakery_client=bakery_client,
             jujudata=jujudata,
         )
+        self._controller_name = None
 
     async def __aenter__(self):
         await self.connect()
@@ -174,7 +175,13 @@ class Controller:
 
     @property
     def controller_name(self):
-        return self._connector.controller_name
+        if not self._controller_name:
+            try:
+                self._controller_name = self._connector.jujudata.controller_name_by_endpoint(
+                    self._connector.connection().endpoint)
+            except FileNotFoundError:
+                raise errors.PylibjujuError("Unable to determine controller name. controllers.yaml not found.")
+        return self._controller_name
 
     @property
     def controller_uuid(self):

--- a/juju/model.py
+++ b/juju/model.py
@@ -663,7 +663,7 @@ class Model:
                 model_name = args[0]
             else:
                 model_name = kwargs.pop('model_name', None)
-            _, model_uuid = await self._connector.connect_model(model_name, **kwargs)
+            model_uuid = await self._connector.connect_model(model_name, **kwargs)
         else:
             # Then we're using the endpoint to pick the model
             if 'model_name' in kwargs:

--- a/tests/integration/test_controller.py
+++ b/tests/integration/test_controller.py
@@ -5,7 +5,7 @@ import asyncio
 import uuid
 import hvac
 
-from juju import access
+from juju import access, controller
 from juju.client.connection import Connection
 from juju.client import client
 from juju.errors import JujuAPIError, JujuError
@@ -296,6 +296,22 @@ async def test_grant_revoke_controller_access(event_loop):
                 pass
             else:
                 raise
+
+
+@base.bootstrapped
+async def test_connection_lazy_jujudata(event_loop):
+    async with base.CleanController() as cont1:
+        conn = cont1.connection()
+        new_controller = controller.Controller()
+        await new_controller.connect(endpoint=conn.endpoints[0][0],
+                                     cacert=conn.cacert,
+                                     username=conn.usertag,
+                                     password=conn.password,
+                                     )
+        assert new_controller._controller_name is None
+        new_controller.controller_name
+        assert new_controller._controller_name is not None
+        await new_controller.disconnect()
 
 
 @base.bootstrapped


### PR DESCRIPTION
#### Description

This moves the computation of the `controller_name` from the `connector` to the `Controller` class, to be lazily evaluated from `jujudata` (and cached). We can move it out of the connector safely because:

1 - `controller_name` is not used within the connector.
2 - the only location that the `controller_name` is returned to, ignores it.

This has the nice consequence of freeing pylibjuju from relying on things like the `controllers.yaml` file (in turn the juju client to be installed) to connect to a controller.

Fixes https://github.com/juju/python-libjuju/issues/983


#### QA Steps

Added a test for lazy computation of `controller_name`. 

```sh
 $ tox -e integration -- tests/integration/test_controller.py::test_connection_lazy_jujudata
```

But the scenario from the #983 can be tried easily as follows:

```python
# make a new controller and connect it in a normal way:
from juju import controller
c = controller.Controller()
await c.connect()

# get the connection
conn = c.connection()
```

Now go move the `.local/share/juju/controllers.yaml` file temporarily.

```python
# make a new controller
c2 = controller.Controller()

# connect it using the information within the connection we got above
await c2.connect(endpoint=conn.endpoints[0][0], cacert=conn.cacert, username=conn.usertag, password=conn.password)
```

Should succeed without any errors.

Don't forget to move back your `controllers.yaml` back so nothing else on your machine freaks out.

All CI tests need to pass.

#### Notes & Discussion

juju-4891