### PR TITLE
Complete support for user secrets

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -2715,6 +2715,25 @@ class Model:
         if result_error.error is not None:
             raise JujuAPIError(result_error.error)
 
+    async def grant_secret(self, secret_name, application, *applications):
+        """Grants access to a secret to the specified applications.
+
+        :param secret_name str: ID|name of the secret.
+        :param application str: name of an application for which the access is granted
+        :param applications []str: names of more applications to associate the secret with
+        """
+        if client.SecretsFacade.best_facade_version(self.connection()) < 2:
+            raise JujuNotSupportedError("user secrets")
+        secretsFacade = client.SecretsFacade.from_connection(self.connection())
+        results = await secretsFacade.GrantSecret(
+            applications=[application] + list(applications),
+            label=secret_name)
+        if len(results.results) != 1:
+            raise JujuAPIError(f"expected 1 result, got {len(results.results)}")
+        result_error = results.results[0]
+        if result_error.error is not None:
+            raise JujuAPIError(result_error.error)
+
     async def _get_source_api(self, url, controller_name=None):
         controller = Controller()
         if url.has_empty_source():

--- a/juju/model.py
+++ b/juju/model.py
@@ -2734,6 +2734,27 @@ class Model:
         if result_error.error is not None:
             raise JujuAPIError(result_error.error)
 
+    async def revoke_secret(self, secret_name, application, *applications):
+        """Revoke access to a secret.
+
+        Revoke applications' access to view the value of a specified secret.
+
+        :param secret_name str: ID|name of the secret.
+        :param application str: name of an application for which the access to the secret is revoked
+        :param applications []str: names of more applications to disassociate the secret with
+        """
+        if client.SecretsFacade.best_facade_version(self.connection()) < 2:
+            raise JujuNotSupportedError("user secrets")
+        secretsFacade = client.SecretsFacade.from_connection(self.connection())
+        results = await secretsFacade.RevokeSecret(
+            applications=[application] + list(applications),
+            label=secret_name)
+        if len(results.results) != 1:
+            raise JujuAPIError(f"expected 1 result, got {len(results.results)}")
+        result_error = results.results[0]
+        if result_error.error is not None:
+            raise JujuAPIError(result_error.error)
+
     async def _get_source_api(self, url, controller_name=None):
         controller = Controller()
         if url.has_empty_source():

--- a/tests/integration/test_secrets.py
+++ b/tests/integration/test_secrets.py
@@ -9,9 +9,8 @@ from ..utils import TESTS_DIR
 @base.bootstrapped
 @pytest.mark.bundle
 async def test_add_secret(event_loop):
-
     async with base.CleanModel() as model:
-        secret = await model.add_secret(name='my-apitoken', dataArgs=['token=34ae35facd4'])
+        secret = await model.add_secret(name='my-apitoken', data_args=['token=34ae35facd4'])
         assert secret.startswith('secret:')
 
         secrets = await model.list_secrets()
@@ -37,3 +36,17 @@ async def test_list_secrets(event_loop):
         secrets = await model.list_secrets(show_secrets=True)
         assert secrets is not None
         assert len(secrets) == 1
+
+
+@base.bootstrapped
+@pytest.mark.bundle
+async def test_update_secret(event_loop):
+    async with base.CleanModel() as model:
+        secret = await model.add_secret(name='my-apitoken', data_args=['token=34ae35facd4'])
+        assert secret.startswith('secret:')
+
+        await model.update_secret(name='my-apitoken', new_name='new-token')
+
+        secrets = await model.list_secrets()
+        assert len(secrets) == 1
+        assert secrets[0].label == 'new-token'

--- a/tests/integration/test_secrets.py
+++ b/tests/integration/test_secrets.py
@@ -63,3 +63,15 @@ async def test_remove_secret(event_loop):
 
         secrets = await model.list_secrets()
         assert len(secrets) == 0
+
+
+@base.bootstrapped
+@pytest.mark.bundle
+async def test_grant_secret(event_loop):
+    async with base.CleanModel() as model:
+        secret = await model.add_secret(name='my-apitoken', data_args=['token=34ae35facd4'])
+        assert secret.startswith('secret:')
+
+        await model.deploy('ubuntu')
+
+        await model.grant_secret('my-apitoken', 'ubuntu')

--- a/tests/integration/test_secrets.py
+++ b/tests/integration/test_secrets.py
@@ -75,3 +75,12 @@ async def test_grant_secret(event_loop):
         await model.deploy('ubuntu')
 
         await model.grant_secret('my-apitoken', 'ubuntu')
+
+
+@base.bootstrapped
+@pytest.mark.bundle
+async def test_revoke_secret(event_loop):
+    async with base.CleanModel() as model:
+        secret = await model.add_secret(name='my-apitoken', data_args=['token=34ae35facd4'])
+        assert secret.startswith('secret:')
+        await model.revoke_secret('my-apitoken', 'ubuntu')

--- a/tests/integration/test_secrets.py
+++ b/tests/integration/test_secrets.py
@@ -50,3 +50,16 @@ async def test_update_secret(event_loop):
         secrets = await model.list_secrets()
         assert len(secrets) == 1
         assert secrets[0].label == 'new-token'
+
+
+@base.bootstrapped
+@pytest.mark.bundle
+async def test_remove_secret(event_loop):
+    async with base.CleanModel() as model:
+        secret = await model.add_secret(name='my-apitoken', data_args=['token=34ae35facd4'])
+        assert secret.startswith('secret:')
+
+        await model.remove_secret('my-apitoken')
+
+        secrets = await model.list_secrets()
+        assert len(secrets) == 0


### PR DESCRIPTION
#### Description

This is the continuation of #986, completing the support for user secrets on pylibjuju by adding `update_secret`, `remove_secret`, `grant_secret` and `revoke_secret`.

#### QA Steps

Added integration tests for all of these so they can be individually ran:

```
tox -e integration -- tests/integration/test_secrets.py::test_update_secret
```

```
tox -e integration -- tests/integration/test_secrets.py::test_remove_secret
```

```
tox -e integration -- tests/integration/test_secrets.py::test_grant_secret
```

```
tox -e integration -- tests/integration/test_secrets.py::test_revoke_secret
```


All CI tests need to pass.

#### Notes & Discussion

JUJU-5093