### PR TITLE
Pass websocket Close frame into ConnectionClosed

### DIFF
--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -436,7 +436,9 @@ class Connection:
 
     async def _recv(self, request_id):
         if not self.is_open:
-            raise websockets.exceptions.ConnectionClosed(0, 'websocket closed')
+            raise websockets.exceptions.ConnectionClosed(
+                websockets.frames.Close(websockets.frames.CloseCode.NORMAL_CLOSURE,
+                                        'websocket closed'))
         try:
             return await self.messages.get(request_id)
         except GeneratorExit:
@@ -604,7 +606,8 @@ class Connection:
             if self.monitor.status == Monitor.DISCONNECTED:
                 # closed cleanly; shouldn't try to reconnect
                 raise websockets.exceptions.ConnectionClosed(
-                    0, 'websocket closed')
+                    websockets.frames.Close(websockets.frames.CloseCode.NORMAL_CLOSURE,
+                                            'websocket closed'))
             try:
                 await self._ws.send(outgoing)
                 break


### PR DESCRIPTION


#### Description

This fixes a bug in connection where we pass close code and reason directly into the `websockets.exception.ConnectionClosed`, where it needs a Close frame that contains those.

Fixes #989


#### QA Steps

This doesn't affect any normal behavior, as this is sort of a safeguard against races. The only two times we raise this explicit exception is when the `MONITOR` is closed but either the receiver task is running still or someone makes an rpc call, which shouldn't happen anyways. So manually checking the arguments by the [doc](https://websockets.readthedocs.io/en/stable/reference/exceptions.html#websockets.exceptions.ConnectionClosed) is sufficient.

All CI tests need to pass.

#### Notes & Discussion

Needs to be forward ported into 3.x.