### PR TITLE
Drop use of walrus operator

### DIFF
--- a/juju/utils.py
+++ b/juju/utils.py
@@ -49,11 +49,11 @@ def juju_config_dir():
     config_dir = Path('~/.local/share/juju')
 
     # Check $JUJU_DATA
-    if juju_data := os.environ.get('JUJU_DATA'):
-        config_dir = Path(juju_data)
+    if os.environ.get('JUJU_DATA'):
+        config_dir = Path(os.environ.get('JUJU_DATA'))
     # Secondly check: $XDG_DATA_HOME for ~/.local/share
-    elif xdg_data_home := os.environ.get('XDG_DATA_HOME'):
-        config_dir = Path(xdg_data_home) / 'juju'
+    elif os.environ.get('XDG_DATA_HOME'):
+        config_dir = Path(os.environ.get('XDG_DATA_HOME')) / 'juju'
 
     return str(config_dir.expanduser().resolve())
 


### PR DESCRIPTION
#### Description

The walrus operator (`:=`) was introduced in Python 3.8, the use of it in the `2.9` branch breaks python 3.6 compatibility which is the version used in Ubuntu 18.04 (Bionic).

https://docs.python.org/3/whatsnew/3.8.html#assignment-expressions

#### QA Steps

1. Install python-libjuju in python 3.6
2. python3 -c "import juju.utils"

```
virtualenv -p /usr/bin/python3.6 /tmp/myvenv
source /tmp/myvenv/bin/activate
python3 setup.py install
python3 -c "import juju.utils"
```

All CI tests need to pass.

#### Notes & Discussion

This regression was introduced by https://github.com/juju/python-libjuju/pull/975