### PR TITLE
Password resolution in connector

### DIFF
--- a/juju/client/connector.py
+++ b/juju/client/connector.py
@@ -80,6 +80,15 @@ class Connector:
         else:
             if self._connection:
                 await self._connection.close()
+
+            account = kwargs.pop('account', {})
+            # Prioritize the username and password that user provided
+            # If not enough, try to patch it with info from accounts.yaml
+            if 'username' not in kwargs and account.get('user'):
+                kwargs.update(username=account.get('user'))
+            if 'password' not in kwargs and account.get('password'):
+                kwargs.update(password=account.get('password'))
+
             self._connection = await Connection.connect(**kwargs)
 
         if not self.controller_name:
@@ -103,7 +112,7 @@ class Connector:
             await self._log_connection.close()
             self._log_connection = None
 
-    async def connect_controller(self, controller_name=None, specified_facades=None):
+    async def connect_controller(self, controller_name=None, specified_facades=None, **kwargs):
         """Connect to a controller by name. If the name is empty, it
         connect to the current controller.
         """
@@ -118,16 +127,15 @@ class Connector:
 
         proxy = proxy_from_config(controller.get('proxy-config', None))
 
-        await self.connect(
-            endpoint=endpoints,
-            uuid=None,
-            username=accounts.get('user'),
-            password=accounts.get('password'),
-            cacert=controller.get('ca-cert'),
-            bakery_client=self.bakery_client_for_controller(controller_name),
-            specified_facades=specified_facades,
-            proxy=proxy,
-        )
+        kwargs.update(endpoint=endpoints,
+                      uuid=None,
+                      account=accounts,
+                      cacert=controller.get('ca-cert'),
+                      bakery_client=self.bakery_client_for_controller(controller_name),
+                      specified_facades=specified_facades,
+                      proxy=proxy,
+                      )
+        await self.connect(**kwargs)
         self.controller_name = controller_name
         self.controller_uuid = controller["uuid"]
 
@@ -176,8 +184,7 @@ class Connector:
         # JujuData.
         kwargs.update(endpoint=endpoints,
                       uuid=model_uuid,
-                      username=account.get('user'),
-                      password=account.get('password'),
+                      account=account,
                       cacert=controller.get('ca-cert'),
                       bakery_client=self.bakery_client_for_controller(controller_name),
                       proxy=proxy)

--- a/juju/client/connector.py
+++ b/juju/client/connector.py
@@ -89,6 +89,9 @@ class Connector:
             if 'password' not in kwargs and account.get('password'):
                 kwargs.update(password=account.get('password'))
 
+            if not ({'username', 'password'}.issubset(kwargs)):
+                required = {'username', 'password'}.difference(kwargs)
+                raise ValueError(f'Some authentication parameters are required : {",".join(required)}')
             self._connection = await Connection.connect(**kwargs)
 
         if not self.controller_name:


### PR DESCRIPTION
#### Description

For both model and controller connections, `accounts.yaml` is required to have both username and password for connection to be established. This is not always true, for example, juju change-user-password actually removes the password from the
`accounts.yaml` file, so we pass an empty password to the connection.

This fixes #1001 by checking the credentials before trying to establish connection, and asks for whichever cred is required:


#### QA Steps

This will require a `2.9` controller, so bootstrap one.

```
 $ juju_29 bootstrap localhost issue1001
```

Then check the `accounts.yaml` file to see a line like the following for the admin, make sure the password is in there:

```sh
issue1001:
    user: admin
    password: asdasdsadasdadasdasdasdasd
    last-known-access: superuser
```

Now go ahead and try to connect via python-libjuju repl:

```python
$ python -m asyncio
>>> from juju import controller
>>> c=controller.Model()
>>> await c.connect()
>>>
exiting asyncio REPL...
# Connection works without any issues.
```

Change the admin user password with `juju change-user-password`:

```sh
$ juju change-user-password
new password: <your-password>
type new password again: <your-password>
Your password has been changed.
 $ juju users
Controller: lxd292

Name    Display name  Access     Date created   Last connection
admin*  admin         superuser  2 minutes ago  just now
```

Go take another look at the `accounts.yaml`, the password field should've disappeared.

```sh
issue1001:
    user: admin
    last-known-access: superuser
```

Without this change, you'd see the ssl error from #1001, because pylibjuju was trying to establish a connection with passing `None` as password. But with this change, first you need to see a nice error message when it fails:

```python
$ python -m asyncio
>>> from juju import controller
>>> c=controller.Model()
>>> await c.connect()
>>>
...
...
ValueError: Some authentication parameters are required : password
```

Now provide your password in `connect` and it should connect just fine:

```python
>>> await c.connect(password=<your-password-as-string>) # string
```

#### Notes & Discussion

JUJU-5267