### PR TITLE
No controller model access needed for connection with a non-admin user

### DIFF
--- a/juju/client/connector.py
+++ b/juju/client/connector.py
@@ -80,6 +80,15 @@ class Connector:
         else:
             if self._connection:
                 await self._connection.close()
+
+            account = kwargs.pop('account', {})
+            # Prioritize the username and password that user provided
+            # If not enough, try to patch it with info from accounts.yaml
+            if 'username' not in kwargs and account.get('user'):
+                kwargs.update(username=account.get('user'))
+            if 'password' not in kwargs and account.get('password'):
+                kwargs.update(password=account.get('password'))
+
             self._connection = await Connection.connect(**kwargs)
 
         if not self.controller_name:
@@ -103,7 +112,7 @@ class Connector:
             await self._log_connection.close()
             self._log_connection = None
 
-    async def connect_controller(self, controller_name=None, specified_facades=None):
+    async def connect_controller(self, controller_name=None, specified_facades=None, **kwargs):
         """Connect to a controller by name. If the name is empty, it
         connect to the current controller.
         """
@@ -118,16 +127,15 @@ class Connector:
 
         proxy = proxy_from_config(controller.get('proxy-config', None))
 
-        await self.connect(
-            endpoint=endpoints,
-            uuid=None,
-            username=accounts.get('user'),
-            password=accounts.get('password'),
-            cacert=controller.get('ca-cert'),
-            bakery_client=self.bakery_client_for_controller(controller_name),
-            specified_facades=specified_facades,
-            proxy=proxy,
-        )
+        kwargs.update(endpoint=endpoints,
+                      uuid=None,
+                      account=accounts,
+                      cacert=controller.get('ca-cert'),
+                      bakery_client=self.bakery_client_for_controller(controller_name),
+                      specified_facades=specified_facades,
+                      proxy=proxy,
+                      )
+        await self.connect(**kwargs)
         self.controller_name = controller_name
         self.controller_uuid = controller["uuid"]
 
@@ -176,8 +184,7 @@ class Connector:
         # JujuData.
         kwargs.update(endpoint=endpoints,
                       uuid=model_uuid,
-                      username=account.get('user'),
-                      password=account.get('password'),
+                      account=account,
                       cacert=controller.get('ca-cert'),
                       bakery_client=self.bakery_client_for_controller(controller_name),
                       proxy=proxy)

--- a/juju/client/connector.py
+++ b/juju/client/connector.py
@@ -89,6 +89,9 @@ class Connector:
             if 'password' not in kwargs and account.get('password'):
                 kwargs.update(password=account.get('password'))
 
+            if not ({'username', 'password'}.issubset(kwargs)):
+                required = {'username', 'password'}.difference(kwargs)
+                raise ValueError(f'Some authentication parameters are required : {",".join(required)}')
             self._connection = await Connection.connect(**kwargs)
 
         if not self.controller_name:

--- a/juju/controller.py
+++ b/juju/controller.py
@@ -146,6 +146,7 @@ class Controller:
                 for e in info.results[0].addresses
             ]
         except errors.JujuPermissionError:
+            log.warning("This user doesn't have at least read access to the controller model, so endpoints are not updated after connection.")
             pass
 
     async def connect_current(self):

--- a/juju/controller.py
+++ b/juju/controller.py
@@ -139,11 +139,14 @@ class Controller:
         await self.update_endpoints()
 
     async def update_endpoints(self):
-        info = await self.info()
-        self._connector._connection.endpoints = [
-            (e, info.results[0].cacert)
-            for e in info.results[0].addresses
-        ]
+        try:
+            info = await self.info()
+            self._connector._connection.endpoints = [
+                (e, info.results[0].cacert)
+                for e in info.results[0].addresses
+            ]
+        except errors.JujuPermissionError:
+            pass
 
     async def connect_current(self):
         """
@@ -281,6 +284,8 @@ class Controller:
         """
         log.debug('Getting information')
         uuids = await self.model_uuids()
+        if 'controller' not in uuids:
+            raise errors.JujuPermissionError('Requires access to controller model.')
         controller_facade = client.ControllerFacade.from_connection(self.connection())
         params = [client.Entity(tag.model(uuids["controller"]))]
         return await controller_facade.ControllerAPIInfoForModels(entities=params)

--- a/juju/errors.py
+++ b/juju/errors.py
@@ -82,6 +82,10 @@ class JujuUnitError(JujuError):
     pass
 
 
+class JujuPermissionError(JujuError):
+    pass
+
+
 class JujuBackupError(JujuError):
     pass
 


### PR DESCRIPTION
#### Description

This is a follow up PR, includes changes from #1002. If you're reviewing this and #1002 hasn't landed yet, you might see some additional changes that'll land with #1002. We need those changes to be able to test this change.

`ControllerAPIInfoForModels`  call in `update_endpoints` after a controller connection requires the `uuid` of the controller model, and if the user doesn't have at least read access, they won't be able to have that, so the `update_endpoint` call at the end of a
regular connection fails.

Fixes #998 

#### QA Steps

We'll need a 2.9 controller, so:

```
 $ juju_29 bootstrap localhost issue998
```

Now we have the admin user on this by default, but we don't wanna use that. Let's create a new user (that doesn't have superuser so it can't read the controller model):

```sh
 $ juju add-user caner
 $ juju register
```

Now let's make a password for this user.

```sh
 $ juju change-user-password # to be able to access the admin user later
 $ juju logout
 $ juju login -u caner -c issue998
 $ juju change-user-password
<your-password>
 This should work just fine, we're just making sure the user is ready to go.
```

Now let's spawn a pylibjuju repl to test this change with this user (that can't access the `controller` model):

Wihtout this change, you'd see the error in #998. With this change the connection should work just fine:

```python
# cd pylibjuju directory
$ python -m asyncio
>>> from juju import controller; c=controller.Controller()
>>> await c.connect(username='caner', password=<your-password>)
>>>
exiting asyncio REPL...
# Connection works without any issues.
```

#### Notes & Discussion

JUJU-5268