### PR TITLE
Remove paramiko upper-bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'websockets>=8.1,<9.0 ; python_version=="3.8"',
         'websockets>=9.0,<10.0 ; python_version=="3.9"',
         'websockets>=10.0; python_version>"3.9"',
-        'paramiko>=2.4.0,<3.0.0',
+        'paramiko>=2.4.0',
         'pyasn1>=0.4.4',
         'toposort>=1.5,<2',
         'typing_inspect>=0.6.0',

--- a/tox.ini
+++ b/tox.ini
@@ -19,8 +19,6 @@ filterwarnings =
 [testenv]
 usedevelop=True
 commands =
-    # These need to be installed in a specific order
-    pip install urllib3
     pip install pylxd
     python -m pytest --tb native -ra -v -s -n auto -k 'not integration' -m 'not serial' {posargs}
 passenv =
@@ -60,16 +58,12 @@ deps =
 [testenv:integration]
 envdir = {toxworkdir}/py3
 commands =
-    # These need to be installed in a specific order
-    pip install urllib3
     pip install pylxd
     python -m pytest --tb native -ra -v -n auto -k 'integration' -m 'not serial' {posargs}
 
 [testenv:unit]
 envdir = {toxworkdir}/py3
 commands =
-    # These need to be installed in a specific order
-    pip install urllib3
     pip install pylxd
     python -m pytest --tb native -ra -v -n auto {toxinidir}/tests/unit {posargs}
 
@@ -77,8 +71,6 @@ commands =
 # tests that can't be run in parallel
 envdir = {toxworkdir}/py3
 commands =
-    # These need to be installed in a specific order
-    pip install urllib3
     pip install pylxd
     python -m pytest --tb native -ra -v -s {posargs:-m 'serial'}
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ filterwarnings =
 [testenv]
 usedevelop=True
 commands =
+    pip install urllib3<2
     pip install pylxd
     python -m pytest --tb native -ra -v -s -n auto -k 'not integration' -m 'not serial' {posargs}
 passenv =
@@ -58,12 +59,14 @@ deps =
 [testenv:integration]
 envdir = {toxworkdir}/py3
 commands =
+    pip install urllib3<2
     pip install pylxd
     python -m pytest --tb native -ra -v -n auto -k 'integration' -m 'not serial' {posargs}
 
 [testenv:unit]
 envdir = {toxworkdir}/py3
 commands =
+    pip install urllib3<2
     pip install pylxd
     python -m pytest --tb native -ra -v -n auto {toxinidir}/tests/unit {posargs}
 
@@ -71,6 +74,7 @@ commands =
 # tests that can't be run in parallel
 envdir = {toxworkdir}/py3
 commands =
+    pip install urllib3<2
     pip install pylxd
     python -m pytest --tb native -ra -v -s {posargs:-m 'serial'}
 


### PR DESCRIPTION
#### Description

This change removes paramiko upper bound, allow using paramiko >3.0

Fixes: #1004


#### QA Steps

*\<Commands / tests / steps to run to verify that the change works:\>*

```
tox -e py3 -- tests/unit/...
```

```
tox -e integration -- tests/integration/test_model.py::test_add_manual_machine_ssh
tox -e integration -- tests/integration/test_model.py::test_add_manual_machine_ssh_root
```

All CI tests need to pass.

#### Notes & Discussion


I've had to pin `urllib3` to `urllib3==1.25.7` to have the test pass. but the error was from pylxd failing with `TypeError: HTTPConnection.request() got an unexpected keyword argument 'chunked'`. Not sure this is related to paramiko change, since paramiko does not depend on urllib3.

```
File "/home/gboutry/python-libjuju/tests/integration/test_model.py", line 596, in test_add_manual_machine_ssh
    await add_manual_machine_ssh(event_loop, is_root=False)
  File "/home/gboutry/python-libjuju/tests/integration/test_model.py", line 463, in add_manual_machine_ssh
    client = pylxd.Client()
  File "/home/gboutry/python-libjuju/.tox/py3/lib/python3.10/site-packages/pylxd/client.py", line 383, in __init__
    response = self.api.get()
  File "/home/gboutry/python-libjuju/.tox/py3/lib/python3.10/site-packages/pylxd/client.py", line 192, in get
    response = self.session.get(self._api_endpoint, *args, **kwargs)
  File "/home/gboutry/python-libjuju/.tox/py3/lib/python3.10/site-packages/requests/sessions.py", line 602, in get
    return self.request("GET", url, **kwargs)
  File "/home/gboutry/python-libjuju/.tox/py3/lib/python3.10/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/gboutry/python-libjuju/.tox/py3/lib/python3.10/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
  File "/home/gboutry/python-libjuju/.tox/py3/lib/python3.10/site-packages/requests/adapters.py", line 486, in send
    resp = conn.urlopen(
  File "/home/gboutry/python-libjuju/.tox/py3/lib/python3.10/site-packages/urllib3/connectionpool.py", line 790, in urlopen
    response = self._make_request(
  File "/home/gboutry/python-libjuju/.tox/py3/lib/python3.10/site-packages/urllib3/connectionpool.py", line 496, in _make_request
    conn.request(
TypeError: HTTPConnection.request() got an unexpected keyword argument 'chunked'
```