### PR TITLE
Remove explicit passing of event_loop into tests

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -11,20 +11,6 @@ import pytest
 from juju.client.jujudata import FileJujuData
 from juju.controller import Controller
 
-from juju.jasyncio import SingletonEventLoop
-
-
-@pytest.fixture(scope="session")
-def event_loop():
-    """
-    This fixture forces all the asyncio tests
-    to use the same events loop
-    """
-
-    loop = SingletonEventLoop().loop
-    yield loop
-    loop.close()
-
 
 def is_bootstrapped():
     try:

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -19,7 +19,7 @@ from ..utils import INTEGRATION_TEST_DIR
 
 
 @base.bootstrapped
-async def test_action(event_loop):
+async def test_action():
     async with base.CleanModel() as model:
         app = await model.deploy('juju-qa-test')
         await jasyncio.sleep(10)
@@ -28,7 +28,7 @@ async def test_action(event_loop):
 
 
 @base.bootstrapped
-async def test_get_set_config(event_loop):
+async def test_get_set_config():
     async with base.CleanModel() as model:
         app = await model.deploy(
             'ubuntu',
@@ -53,7 +53,7 @@ async def test_get_set_config(event_loop):
 
 @base.bootstrapped
 @pytest.mark.skip('Update charm')
-async def test_status_is_not_unset(event_loop):
+async def test_status_is_not_unset():
     async with base.CleanModel() as model:
         app = await model.deploy(
             'ubuntu-0',
@@ -67,7 +67,7 @@ async def test_status_is_not_unset(event_loop):
 
 @base.bootstrapped
 @pytest.mark.skip('Update charm')
-async def test_status(event_loop):
+async def test_status():
     async with base.CleanModel() as model:
         app = await model.deploy('ch:juju-qa-test')
 
@@ -82,7 +82,7 @@ async def test_status(event_loop):
 
 @base.bootstrapped
 @pytest.mark.skip('Update charm')
-async def test_add_units(event_loop):
+async def test_add_units():
     from juju.unit import Unit
 
     async with base.CleanModel() as model:
@@ -100,7 +100,7 @@ async def test_add_units(event_loop):
 
 
 @base.bootstrapped
-async def test_deploy_charmhub_charm(event_loop):
+async def test_deploy_charmhub_charm():
     async with base.CleanModel() as model:
         app = await model.deploy('ubuntu')
         await model.block_until(lambda: (len(app.units) > 0 and
@@ -110,7 +110,7 @@ async def test_deploy_charmhub_charm(event_loop):
 
 @base.bootstrapped
 @pytest.mark.skip('Skip until a similar k8s solution is found')
-async def test_upgrade_charm_switch_channel(event_loop):
+async def test_upgrade_charm_switch_channel():
     # Note for future:
     # This test requires a charm that has different
     # revisions for different channels/risks.
@@ -154,7 +154,7 @@ async def test_upgrade_charm_switch_channel(event_loop):
 
 @base.bootstrapped
 @pytest.mark.skip('Update charm')
-async def test_upgrade_charm_revision(event_loop):
+async def test_upgrade_charm_revision():
     async with base.CleanModel() as model:
         app = await model.deploy('ubuntu')
         await model.block_until(lambda: (len(app.units) > 0 and
@@ -166,7 +166,7 @@ async def test_upgrade_charm_revision(event_loop):
 
 @base.bootstrapped
 @pytest.mark.skip('Update charm')
-async def test_upgrade_charm_switch(event_loop):
+async def test_upgrade_charm_switch():
     async with base.CleanModel() as model:
         app = await model.deploy('ubuntu')
         await model.block_until(lambda: (len(app.units) > 0 and
@@ -179,7 +179,7 @@ async def test_upgrade_charm_switch(event_loop):
 
 
 @base.bootstrapped
-async def test_upgrade_local_charm(event_loop):
+async def test_upgrade_local_charm():
     async with base.CleanModel() as model:
         tests_dir = Path(__file__).absolute().parent
         charm_path = tests_dir / 'upgrade-charm'
@@ -192,7 +192,7 @@ async def test_upgrade_local_charm(event_loop):
 
 
 @base.bootstrapped
-async def test_upgrade_local_charm_resource(event_loop):
+async def test_upgrade_local_charm_resource():
     async with base.CleanModel() as model:
         charm_path = INTEGRATION_TEST_DIR / 'file-resource-charm'
         resources = {"file-res": "test.file"}
@@ -212,7 +212,7 @@ async def test_upgrade_local_charm_resource(event_loop):
 @base.bootstrapped
 @pytest.mark.asyncio
 @pytest.mark.skip('Update charm')
-async def test_upgrade_charm_resource(event_loop):
+async def test_upgrade_charm_resource():
     async with base.CleanModel() as model:
         app = await model.deploy('cs:~juju-qa/bionic/upgrade-charm-resource-test-0')
 
@@ -232,7 +232,7 @@ async def test_upgrade_charm_resource(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_refresh_with_resource_argument(event_loop):
+async def test_refresh_with_resource_argument():
     async with base.CleanModel() as model:
         app = await model.deploy('juju-qa-test', resources={'foo-file': '2'})
         res2 = await app.get_resources()
@@ -244,7 +244,7 @@ async def test_refresh_with_resource_argument(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_upgrade_charm_resource_same_rev_no_update(event_loop):
+async def test_upgrade_charm_resource_same_rev_no_update():
     async with base.CleanModel() as model:
         app = await model.deploy('keystone', channel='victoria/stable')
         ress = await app.get_resources()
@@ -255,7 +255,7 @@ async def test_upgrade_charm_resource_same_rev_no_update(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_refresh_charmhub_to_local(event_loop):
+async def test_refresh_charmhub_to_local():
     charm_path = INTEGRATION_TEST_DIR / 'charm'
     async with base.CleanModel() as model:
         app = await model.deploy('ubuntu', application_name='ubu-path')
@@ -269,7 +269,7 @@ async def test_refresh_charmhub_to_local(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_local_refresh(event_loop):
+async def test_local_refresh():
     charm_path = INTEGRATION_TEST_DIR / 'charm'
     async with base.CleanModel() as model:
         app = await model.deploy('ubuntu')
@@ -285,7 +285,7 @@ async def test_local_refresh(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_trusted(event_loop):
+async def test_trusted():
     async with base.CleanModel() as model:
         await model.deploy('ubuntu', trust=True)
 
@@ -299,7 +299,7 @@ async def test_trusted(event_loop):
 
 
 @base.bootstrapped
-async def test_app_destroy(event_loop):
+async def test_app_destroy():
     async with base.CleanModel() as model:
         app = await model.deploy('ubuntu')
         a_name = app.name  # accessing name is impossible after the app is destroyed
@@ -314,7 +314,7 @@ async def test_app_destroy(event_loop):
 
 
 @base.bootstrapped
-async def test_app_remove_wait_flag(event_loop):
+async def test_app_remove_wait_flag():
     async with base.CleanModel() as model:
         app = await model.deploy('ubuntu')
         a_name = app.name
@@ -325,7 +325,7 @@ async def test_app_remove_wait_flag(event_loop):
 
 
 @base.bootstrapped
-async def test_app_charm_name(event_loop):
+async def test_app_charm_name():
     async with base.CleanModel() as model:
         app = await model.deploy('ubuntu')
         await model.wait_for_idle(status="active")

--- a/tests/integration/test_charmhub.py
+++ b/tests/integration/test_charmhub.py
@@ -9,7 +9,7 @@ from juju import jasyncio
 
 
 @base.bootstrapped
-async def test_info(event_loop):
+async def test_info():
     async with base.CleanModel() as model:
         _, name = await model.charmhub.get_charm_id("ubuntu")
         assert name == "ubuntu"
@@ -30,7 +30,7 @@ async def test_info(event_loop):
 
 
 @base.bootstrapped
-async def test_info_with_channel(event_loop):
+async def test_info_with_channel():
     async with base.CleanModel() as model:
         charm_info = await model.charmhub.info("juju-qa-test", "2.0/stable")
         assert charm_info['name'] == 'juju-qa-test'
@@ -48,7 +48,7 @@ async def test_info_with_channel(event_loop):
 
 
 @base.bootstrapped
-async def test_info_not_found(event_loop):
+async def test_info_not_found():
     async with base.CleanModel() as model:
         with pytest.raises(JujuError) as err:
             await model.charmhub.info("badnameforapp")
@@ -57,7 +57,7 @@ async def test_info_not_found(event_loop):
 
 @base.bootstrapped
 @pytest.mark.skip('CharmHub facade no longer exists')
-async def test_find(event_loop):
+async def test_find():
     async with base.CleanModel() as model:
         result = await model.charmhub.find("kube")
 
@@ -69,7 +69,7 @@ async def test_find(event_loop):
 
 @base.bootstrapped
 @pytest.mark.skip('CharmHub facade no longer exists')
-async def test_find_bundles(event_loop):
+async def test_find_bundles():
     async with base.CleanModel() as model:
         result = await model.charmhub.find("kube", charm_type="bundle")
 
@@ -81,7 +81,7 @@ async def test_find_bundles(event_loop):
 
 @base.bootstrapped
 @pytest.mark.skip('CharmHub facade no longer exists')
-async def test_find_all(event_loop):
+async def test_find_all():
     async with base.CleanModel() as model:
         result = await model.charmhub.find("")
 
@@ -93,7 +93,7 @@ async def test_find_all(event_loop):
 
 @base.bootstrapped
 @pytest.mark.skip('This tries to test juju controller logic')
-async def test_subordinate_charm_zero_units(event_loop):
+async def test_subordinate_charm_zero_units():
     # normally in pylibjuju deploy num_units defaults to 1, we switch
     # that to 0 behind the scenes if we see that the charmhub charm
     # we're deploying is a subordinate charm
@@ -119,14 +119,14 @@ async def test_subordinate_charm_zero_units(event_loop):
 
 
 @base.bootstrapped
-async def test_subordinate_false_field_exists(event_loop):
+async def test_subordinate_false_field_exists():
     async with base.CleanModel() as model:
         assert await model.charmhub.is_subordinate("rsyslog-forwarder-ha")
         assert not await model.charmhub.is_subordinate("mysql-innodb-cluster")
 
 
 @base.bootstrapped
-async def test_list_resources(event_loop):
+async def test_list_resources():
     async with base.CleanModel() as model:
         resources = await model.charmhub.list_resources('hello-kubecon')
         assert isinstance(resources, list) and len(resources) > 0

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -7,7 +7,7 @@ from .. import base
 
 
 @base.bootstrapped
-async def test_user_info(event_loop):
+async def test_user_info():
     async with base.CleanModel() as model:
         controller_conn = await model.connection().controller()
 

--- a/tests/integration/test_connection.py
+++ b/tests/integration/test_connection.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 @base.bootstrapped
-async def test_monitor(event_loop):
+async def test_monitor():
     async with base.CleanModel() as model:
         conn = model.connection()
         assert conn.monitor.status == 'connected'
@@ -35,7 +35,7 @@ async def test_monitor(event_loop):
 
 
 @base.bootstrapped
-async def test_monitor_catches_error(event_loop):
+async def test_monitor_catches_error():
 
     async with base.CleanModel() as model:
         conn = model.connection()
@@ -56,7 +56,7 @@ async def test_monitor_catches_error(event_loop):
 
 @base.bootstrapped
 @pytest.mark.skip('Update charm')
-async def test_full_status(event_loop):
+async def test_full_status():
     async with base.CleanModel() as model:
         await model.deploy(
             'ubuntu',
@@ -71,7 +71,7 @@ async def test_full_status(event_loop):
 
 
 @base.bootstrapped
-async def test_reconnect(event_loop):
+async def test_reconnect():
     async with base.CleanModel() as model:
         kwargs = model.connection().connect_params()
         conn = await Connection.connect(**kwargs)
@@ -87,7 +87,7 @@ async def test_reconnect(event_loop):
 
 @base.bootstrapped
 @pytest.mark.skip('tests the websocket protocol, not pylibjuju, needs to be revised')
-async def test_redirect(event_loop):
+async def test_redirect():
     controller = Controller()
     await controller.connect()
     kwargs = controller.connection().connect_params()
@@ -233,7 +233,7 @@ class RedirectServer:
 
 
 @base.bootstrapped
-async def test_verify_controller_cert(event_loop):
+async def test_verify_controller_cert():
     jujudata = FileJujuData()
     controller_name = jujudata.current_controller()
     endpoint = jujudata.controllers()[controller_name]['api-endpoints'][0]

--- a/tests/integration/test_controller.py
+++ b/tests/integration/test_controller.py
@@ -16,7 +16,7 @@ from .. import base
 
 
 @base.bootstrapped
-async def test_add_remove_user(event_loop):
+async def test_add_remove_user():
     async with base.CleanController() as controller:
         username = 'test{}'.format(uuid.uuid4())
         user = await controller.get_user(username)
@@ -35,7 +35,7 @@ async def test_add_remove_user(event_loop):
 
 
 @base.bootstrapped
-async def test_disable_enable_user(event_loop):
+async def test_disable_enable_user():
     async with base.CleanController() as controller:
         username = 'test-disable{}'.format(uuid.uuid4())
         user = await controller.add_user(username)
@@ -58,7 +58,7 @@ async def test_disable_enable_user(event_loop):
 
 
 @base.bootstrapped
-async def test_change_user_password(event_loop):
+async def test_change_user_password():
     async with base.CleanController() as controller:
         username = 'test-password{}'.format(uuid.uuid4())
         user = await controller.add_user(username)
@@ -78,7 +78,7 @@ async def test_change_user_password(event_loop):
 
 
 @base.bootstrapped
-async def test_reset_user_password(event_loop):
+async def test_reset_user_password():
     async with base.CleanController() as controller:
         username = 'test{}'.format(uuid.uuid4())
         user = await controller.add_user(username)
@@ -106,7 +106,7 @@ async def test_reset_user_password(event_loop):
 
 
 @base.bootstrapped
-async def test_list_models(event_loop):
+async def test_list_models():
     async with base.CleanController() as controller:
         async with base.CleanModel() as model:
             result = await controller.list_models()
@@ -114,7 +114,7 @@ async def test_list_models(event_loop):
 
 
 @base.bootstrapped
-async def test_get_model(event_loop):
+async def test_get_model():
     async with base.CleanController() as controller:
         by_name, by_uuid = None, None
         model_name = 'test-{}'.format(uuid.uuid4())
@@ -147,7 +147,7 @@ async def _wait_for_model_gone(controller, model_name):
 
 
 @base.bootstrapped
-async def test_destroy_model_by_name(event_loop):
+async def test_destroy_model_by_name():
     async with base.CleanController() as controller:
         model_name = 'test-{}'.format(uuid.uuid4())
         model = await controller.add_model(model_name)
@@ -162,7 +162,7 @@ async def test_destroy_model_by_name(event_loop):
 
 
 @base.bootstrapped
-async def test_add_destroy_model_by_uuid(event_loop):
+async def test_add_destroy_model_by_uuid():
     async with base.CleanController() as controller:
         model_name = 'test-{}'.format(uuid.uuid4())
         model = await controller.add_model(model_name)
@@ -178,7 +178,7 @@ async def test_add_destroy_model_by_uuid(event_loop):
 
 
 @base.bootstrapped
-async def test_add_remove_cloud(event_loop):
+async def test_add_remove_cloud():
     async with base.CleanController() as controller:
         cloud_name = 'test-{}'.format(uuid.uuid4())
         cloud = client.Cloud(
@@ -195,7 +195,7 @@ async def test_add_remove_cloud(event_loop):
 
 
 @base.bootstrapped
-async def test_secrets_backend_lifecycle(event_loop):
+async def test_secrets_backend_lifecycle():
     """Testing the add_secret_backends is particularly
     costly in term of resources. This test sets a vault
     charm, add it to the controller and plays with the
@@ -272,7 +272,7 @@ async def test_secrets_backend_lifecycle(event_loop):
 
 
 @base.bootstrapped
-async def test_grant_revoke_controller_access(event_loop):
+async def test_grant_revoke_controller_access():
     async with base.CleanController() as controller:
         username = 'test-grant{}'.format(uuid.uuid4())
         user = await controller.add_user(username)
@@ -299,7 +299,7 @@ async def test_grant_revoke_controller_access(event_loop):
 
 
 @base.bootstrapped
-async def test_connection_lazy_jujudata(event_loop):
+async def test_connection_lazy_jujudata():
     async with base.CleanController() as cont1:
         conn = cont1.connection()
         new_controller = controller.Controller()
@@ -315,7 +315,7 @@ async def test_connection_lazy_jujudata(event_loop):
 
 
 @base.bootstrapped
-async def test_grant_revoke_model_access(event_loop):
+async def test_grant_revoke_model_access():
     async with base.CleanController() as controller:
         username = 'test-grant{}'.format(uuid.uuid4())
         user = await controller.add_user(username)

--- a/tests/integration/test_crossmodel.py
+++ b/tests/integration/test_crossmodel.py
@@ -12,7 +12,7 @@ from juju import jasyncio
 
 @base.bootstrapped
 @pytest.mark.skip('Update charm')
-async def test_offer(event_loop):
+async def test_offer():
     async with base.CleanModel() as model:
         await model.deploy(
             'ubuntu',
@@ -33,7 +33,7 @@ async def test_offer(event_loop):
 
 @base.bootstrapped
 @pytest.mark.skip('Update charm')
-async def test_consume(event_loop):
+async def test_consume():
     async with base.CleanModel() as model_1:
         await model_1.deploy(
             'ubuntu',
@@ -63,7 +63,7 @@ async def test_consume(event_loop):
 
 @base.bootstrapped
 @pytest.mark.skip('Update charm')
-async def test_remove_saas(event_loop):
+async def test_remove_saas():
     async with base.CleanModel() as model_1:
         await model_1.deploy(
             'ubuntu',
@@ -95,7 +95,7 @@ async def test_remove_saas(event_loop):
 
 
 @base.bootstrapped
-async def test_relate_with_offer(event_loop):
+async def test_relate_with_offer():
     # pytest.skip('Revise: intermittent problem with the remove_saas call')
     async with base.CleanModel() as model_1:
         application = await model_1.deploy(
@@ -141,7 +141,7 @@ async def test_relate_with_offer(event_loop):
 
 @base.bootstrapped
 @pytest.mark.bundle
-async def test_add_bundle(event_loop):
+async def test_add_bundle():
     pytest.skip("skip until we have a faster example to test")
     tests_dir = Path(__file__).absolute().parent
     bundle_path = tests_dir / 'bundle'

--- a/tests/integration/test_errors.py
+++ b/tests/integration/test_errors.py
@@ -10,7 +10,7 @@ GB = 1024
 
 
 @base.bootstrapped
-async def test_juju_api_error(event_loop):
+async def test_juju_api_error():
     '''
     Verify that we raise a JujuAPIError for responses with an error in
     a top level key (for completely invalid requests).
@@ -24,7 +24,7 @@ async def test_juju_api_error(event_loop):
 
 
 @base.bootstrapped
-async def test_juju_error_in_results_list(event_loop):
+async def test_juju_error_in_results_list():
     '''
     Replicate the code that caused
     https://github.com/juju/python-libjuju/issues/67, and verify that
@@ -52,7 +52,7 @@ async def test_juju_error_in_results_list(event_loop):
 
 
 @base.bootstrapped
-async def test_juju_error_in_result(event_loop):
+async def test_juju_error_in_result():
     '''
     Verify that we raise a JujuError when appropriate when we are
     looking at a single result coming back.

--- a/tests/integration/test_expose.py
+++ b/tests/integration/test_expose.py
@@ -10,7 +10,7 @@ from .. import base
 
 @base.bootstrapped
 @pytest.mark.skip('Update charm')
-async def test_expose_unexpose(event_loop):
+async def test_expose_unexpose():
     async with base.CleanModel() as model:
         app = await model.deploy(
             "ubuntu",

--- a/tests/integration/test_juju.py
+++ b/tests/integration/test_juju.py
@@ -7,7 +7,7 @@ from .. import base
 
 
 @base.bootstrapped
-async def test_get_controllers(event_loop):
+async def test_get_controllers():
     async with base.CleanController() as controller:
         j = Juju()
 

--- a/tests/integration/test_macaroon_auth.py
+++ b/tests/integration/test_macaroon_auth.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 @base.bootstrapped
 @pytest.mark.serial
 @pytest.mark.skip('one of old macaroon_auth tests, needs to be revised')
-async def test_macaroon_auth_serial(event_loop):
+async def test_macaroon_auth_serial():
     jujudata = FileJujuData()
     account = jujudata.accounts()[jujudata.current_controller()]
     with base.patch_file('~/.local/share/juju/accounts.yaml'):
@@ -51,7 +51,7 @@ async def test_macaroon_auth_serial(event_loop):
 @base.bootstrapped
 # @pytest.mark.xfail
 @pytest.mark.skip('one of old macaroon_auth tests, needs to be revised')
-async def test_macaroon_auth(event_loop):
+async def test_macaroon_auth():
     auth_info, username = agent_auth_info()
     # Create a bakery client that can do agent authentication.
     client = httpbakery.Client(
@@ -72,7 +72,7 @@ async def test_macaroon_auth(event_loop):
 @base.bootstrapped
 # @pytest.mark.xfail
 @pytest.mark.skip('one of old macaroon_auth tests, needs to be revised')
-async def test_macaroon_auth_with_bad_key(event_loop):
+async def test_macaroon_auth_with_bad_key():
     auth_info, username = agent_auth_info()
     # Use a random key rather than the correct key.
     auth_info = auth_info._replace(key=bakery.generate_key())
@@ -100,7 +100,7 @@ async def test_macaroon_auth_with_bad_key(event_loop):
 @base.bootstrapped
 # @pytest.mark.xfail
 @pytest.mark.skip('one of old macaroon_auth tests, needs to be revised')
-async def test_macaroon_auth_with_unauthorized_user(event_loop):
+async def test_macaroon_auth_with_unauthorized_user():
     auth_info, username = agent_auth_info()
     # Create a bakery client can do agent authentication.
     client = httpbakery.Client(

--- a/tests/integration/test_machine.py
+++ b/tests/integration/test_machine.py
@@ -11,7 +11,7 @@ from .. import base
 
 @base.bootstrapped
 @pytest.mark.skip('Update charm')
-async def test_status(event_loop):
+async def test_status():
     async with base.CleanModel() as model:
         await model.deploy(
             'ubuntu',
@@ -40,10 +40,10 @@ async def test_status(event_loop):
 
 
 @base.bootstrapped
-async def test_scp(event_loop):
+async def test_scp():
     # ensure that asyncio.subprocess will work;
     try:
-        asyncio.get_child_watcher().attach_loop(event_loop)
+        asyncio.get_child_watcher().attach_loop()
     except RuntimeError:
         pytest.skip('test_scp will always fail outside of MainThread')
     async with base.CleanModel() as model:

--- a/tests/integration/test_machine.py
+++ b/tests/integration/test_machine.py
@@ -2,7 +2,6 @@
 # Licensed under the Apache V2, see LICENCE file for details.
 
 import asyncio
-from tempfile import NamedTemporaryFile
 
 import pytest
 
@@ -37,31 +36,3 @@ async def test_status():
                          machine.status_message.lower() == 'running' and
                          machine.agent_status == 'started')),
             timeout=480)
-
-
-@base.bootstrapped
-async def test_scp():
-    # ensure that asyncio.subprocess will work;
-    try:
-        asyncio.get_child_watcher().attach_loop()
-    except RuntimeError:
-        pytest.skip('test_scp will always fail outside of MainThread')
-    async with base.CleanModel() as model:
-        await model.add_machine()
-        await asyncio.wait_for(
-            model.block_until(lambda: model.machines),
-            timeout=240)
-        machine = model.machines['0']
-        await asyncio.wait_for(
-            model.block_until(lambda: (machine.status == 'running' and
-                                       machine.agent_status == 'started')),
-            timeout=480)
-
-        with NamedTemporaryFile() as f:
-            f.write(b'testcontents')
-            f.flush()
-            await machine.scp_to(f.name, 'testfile', scp_opts='-p')
-
-        with NamedTemporaryFile() as f:
-            await machine.scp_from('testfile', f.name, scp_opts='-p')
-            assert f.read() == b'testcontents'

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -24,7 +24,7 @@ from ..utils import MB, GB, TESTS_DIR, OVERLAYS_DIR, SSH_KEY, INTEGRATION_TEST_D
 
 
 @base.bootstrapped
-async def test_model_name(event_loop):
+async def test_model_name():
     model = Model()
     with pytest.raises(JujuModelError):
         model.name
@@ -37,7 +37,7 @@ async def test_model_name(event_loop):
 
 @base.bootstrapped
 @pytest.mark.bundle
-async def test_deploy_local_bundle_dir(event_loop):
+async def test_deploy_local_bundle_dir():
     bundle_path = TESTS_DIR / 'bundle'
 
     async with base.CleanModel() as model:
@@ -56,7 +56,7 @@ async def test_deploy_local_bundle_dir(event_loop):
 
 @base.bootstrapped
 @pytest.mark.bundle
-async def test_deploy_local_bundle_file(event_loop):
+async def test_deploy_local_bundle_file():
     bundle_path = TESTS_DIR / 'bundle'
     mini_bundle_file_path = bundle_path / 'mini-bundle.yaml'
 
@@ -71,7 +71,7 @@ async def test_deploy_local_bundle_file(event_loop):
 
 @base.bootstrapped
 @pytest.mark.bundle
-async def test_deploy_bundle_local_resource_relative_path(event_loop):
+async def test_deploy_bundle_local_resource_relative_path():
     bundle_file_path = INTEGRATION_TEST_DIR / 'bundle-file-resource.yaml'
 
     async with base.CleanModel() as model:
@@ -84,7 +84,7 @@ async def test_deploy_bundle_local_resource_relative_path(event_loop):
 
 
 @base.bootstrapped
-async def test_deploy_by_revision(event_loop):
+async def test_deploy_by_revision():
     async with base.CleanModel() as model:
         app = await model.deploy('juju-qa-test',
                                  application_name='test1',
@@ -102,7 +102,7 @@ async def test_deploy_by_revision(event_loop):
 
 
 @base.bootstrapped
-async def test_deploy_by_revision_validate_flags(event_loop):
+async def test_deploy_by_revision_validate_flags():
     # Make sure we fail gracefully when invalid --revision/--channel
     # flags are used
 
@@ -122,7 +122,7 @@ async def test_deploy_by_revision_validate_flags(event_loop):
 
 @base.bootstrapped
 @pytest.mark.bundle
-async def test_deploy_local_bundle_include_file(event_loop):
+async def test_deploy_local_bundle_include_file():
     bundle_dir = INTEGRATION_TEST_DIR / 'bundle'
     bundle_yaml_path = bundle_dir / 'bundle-include-file.yaml'
 
@@ -139,7 +139,7 @@ async def test_deploy_local_bundle_include_file(event_loop):
 
 @base.bootstrapped
 @pytest.mark.bundle
-async def test_deploy_local_bundle_include_base64(event_loop):
+async def test_deploy_local_bundle_include_base64():
     bundle_dir = INTEGRATION_TEST_DIR / 'bundle'
     bundle_yaml_path = bundle_dir / 'bundle-include-base64.yaml'
 
@@ -155,7 +155,7 @@ async def test_deploy_local_bundle_include_base64(event_loop):
 
 @base.bootstrapped
 @pytest.mark.bundle
-async def test_deploy_bundle_local_charms(event_loop):
+async def test_deploy_bundle_local_charms():
     bundle_path = INTEGRATION_TEST_DIR / 'bundle' / 'local.yaml'
 
     async with base.CleanModel() as model:
@@ -170,7 +170,7 @@ async def test_deploy_bundle_local_charms(event_loop):
 
 @base.bootstrapped
 @pytest.mark.bundle
-async def test_deploy_bundle_local_charm_series_manifest(event_loop):
+async def test_deploy_bundle_local_charm_series_manifest():
     bundle_path = INTEGRATION_TEST_DIR / 'bundle' / 'local-manifest.yaml'
 
     async with base.CleanModel() as model:
@@ -183,7 +183,7 @@ async def test_deploy_bundle_local_charm_series_manifest(event_loop):
 
 @base.bootstrapped
 @pytest.mark.bundle
-async def test_deploy_invalid_bundle(event_loop):
+async def test_deploy_invalid_bundle():
     pytest.skip('test_deploy_invalid_bundle intermittent test failure')
     bundle_path = TESTS_DIR / 'bundle' / 'invalid.yaml'
     async with base.CleanModel() as model:
@@ -192,7 +192,7 @@ async def test_deploy_invalid_bundle(event_loop):
 
 
 @base.bootstrapped
-async def test_deploy_local_charm(event_loop):
+async def test_deploy_local_charm():
     charm_path = TESTS_DIR / 'charm'
 
     async with base.CleanModel() as model:
@@ -203,13 +203,13 @@ async def test_deploy_local_charm(event_loop):
 
 
 @base.bootstrapped
-async def test_deploy_charm_assumes(event_loop):
+async def test_deploy_charm_assumes():
     async with base.CleanModel() as model:
         await model.deploy('postgresql', channel='14/edge')
 
 
 @base.bootstrapped
-async def test_deploy_local_charm_base_charmcraft_yaml(event_loop):
+async def test_deploy_local_charm_base_charmcraft_yaml():
     charm_path = INTEGRATION_TEST_DIR / 'charm-base-charmcraft-yaml'
 
     async with base.CleanModel() as model:
@@ -217,7 +217,7 @@ async def test_deploy_local_charm_base_charmcraft_yaml(event_loop):
 
 
 @base.bootstrapped
-async def test_deploy_local_charm_channel(event_loop):
+async def test_deploy_local_charm_channel():
     charm_path = TESTS_DIR / 'charm'
 
     async with base.CleanModel() as model:
@@ -226,7 +226,7 @@ async def test_deploy_local_charm_channel(event_loop):
 
 
 @base.bootstrapped
-async def test_wait_local_charm_blocked(event_loop):
+async def test_wait_local_charm_blocked():
     charm_path = TESTS_DIR / 'charm'
 
     async with base.CleanModel() as model:
@@ -240,7 +240,7 @@ async def test_wait_local_charm_blocked(event_loop):
 
 
 @base.bootstrapped
-async def test_wait_local_charm_waiting_timeout(event_loop):
+async def test_wait_local_charm_waiting_timeout():
     charm_path = TESTS_DIR / 'charm'
 
     async with base.CleanModel() as model:
@@ -253,7 +253,7 @@ async def test_wait_local_charm_waiting_timeout(event_loop):
 
 @base.bootstrapped
 @pytest.mark.bundle
-async def test_deploy_bundle(event_loop):
+async def test_deploy_bundle():
     async with base.CleanModel() as model:
         await model.deploy('anbox-cloud-core', channel='stable',
                            trust=True)
@@ -264,7 +264,7 @@ async def test_deploy_bundle(event_loop):
 
 @base.bootstrapped
 @pytest.mark.bundle
-async def test_deploy_local_bundle_with_overlay_multi(event_loop):
+async def test_deploy_local_bundle_with_overlay_multi():
     async with base.CleanModel() as model:
         bundle_with_overlay_path = OVERLAYS_DIR / 'bundle-with-overlay-multi.yaml'
         await model.deploy(bundle_with_overlay_path)
@@ -277,7 +277,7 @@ async def test_deploy_local_bundle_with_overlay_multi(event_loop):
 
 @base.bootstrapped
 @pytest.mark.bundle
-async def test_deploy_bundle_with_overlay_as_argument(event_loop):
+async def test_deploy_bundle_with_overlay_as_argument():
     async with base.CleanModel() as model:
         overlay_path = OVERLAYS_DIR / 'test-overlay.yaml'
 
@@ -298,7 +298,7 @@ async def test_deploy_bundle_with_overlay_as_argument(event_loop):
 
 @base.bootstrapped
 @pytest.mark.bundle
-async def test_deploy_bundle_with_multi_overlay_as_argument(event_loop):
+async def test_deploy_bundle_with_multi_overlay_as_argument():
     async with base.CleanModel() as model:
         overlay_path = OVERLAYS_DIR / 'test-multi-overlay.yaml'
 
@@ -310,7 +310,7 @@ async def test_deploy_bundle_with_multi_overlay_as_argument(event_loop):
 
 @base.bootstrapped
 @pytest.mark.bundle
-async def test_deploy_bundle_with_multiple_overlays_with_include_files(event_loop):
+async def test_deploy_bundle_with_multiple_overlays_with_include_files():
     async with base.CleanModel() as model:
         bundle_yaml_path = TESTS_DIR / 'integration' / 'bundle' / 'bundle.yaml'
         overlay1_path = OVERLAYS_DIR / 'test-overlay2.yaml'
@@ -329,7 +329,7 @@ async def test_deploy_bundle_with_multiple_overlays_with_include_files(event_loo
 
 
 @base.bootstrapped
-async def test_deploy_local_charm_folder_symlink(event_loop):
+async def test_deploy_local_charm_folder_symlink():
     charm_path = TESTS_DIR / 'charm-folder-symlink'
 
     async with base.CleanModel() as model:
@@ -345,7 +345,7 @@ async def test_deploy_local_charm_folder_symlink(event_loop):
 
 
 @base.bootstrapped
-async def test_deploy_from_ch_channel_revision_success(event_loop):
+async def test_deploy_from_ch_channel_revision_success():
     async with base.CleanModel() as model:
         # Ensure we're able to resolve charm these with channel and revision,
         # or channel without revision (note that revision requires channel,
@@ -356,7 +356,7 @@ async def test_deploy_from_ch_channel_revision_success(event_loop):
 
 @base.bootstrapped
 @pytest.mark.bundle
-async def test_deploy_trusted_bundle(event_loop):
+async def test_deploy_trusted_bundle():
     pytest.skip("skip until we have a deployable bundle available. Right now the landscape-dense fails because postgresql is broken")
     async with base.CleanModel() as model:
         await model.deploy('landscape-dense', channel='stable', trust=True)
@@ -370,7 +370,7 @@ async def test_deploy_trusted_bundle(event_loop):
 
 
 @base.bootstrapped
-async def test_deploy_from_ch_with_series(event_loop):
+async def test_deploy_from_ch_with_series():
     charm = 'ch:ubuntu'
     for series in ['focal']:
         async with base.CleanModel() as model:
@@ -388,7 +388,7 @@ async def test_deploy_from_ch_with_series(event_loop):
 
 
 @base.bootstrapped
-async def test_deploy_from_ch_with_invalid_series(event_loop):
+async def test_deploy_from_ch_with_invalid_series():
     async with base.CleanModel() as model:
         charm = 'ch:ubuntu'
         try:
@@ -399,14 +399,14 @@ async def test_deploy_from_ch_with_invalid_series(event_loop):
 
 
 @base.bootstrapped
-async def test_deploy_with_base(event_loop):
+async def test_deploy_with_base():
     async with base.CleanModel() as model:
         await model.deploy("ubuntu", base="ubuntu@22.04")
         await model.wait_for_idle(status='active')
 
 
 @base.bootstrapped
-async def test_add_machine(event_loop):
+async def test_add_machine():
     from juju.machine import Machine
 
     async with base.CleanModel() as model:
@@ -443,7 +443,7 @@ async def test_add_machine(event_loop):
         assert len(model.machines) == 0
 
 
-async def add_manual_machine_ssh(event_loop, is_root=False):
+async def add_manual_machine_ssh(is_root=False):
 
     # Verify controller is localhost
     async with base.CleanController() as controller:
@@ -588,23 +588,23 @@ async def add_manual_machine_ssh(event_loop, is_root=False):
 
 
 @base.bootstrapped
-async def test_add_manual_machine_ssh(event_loop):
+async def test_add_manual_machine_ssh():
     """Test manual machine provisioning with a non-root user
 
     Tests manual machine provisioning using a randomized username with sudo access.
     """
-    await add_manual_machine_ssh(event_loop, is_root=False)
+    await add_manual_machine_ssh(is_root=False)
 
 
 @base.bootstrapped
-async def test_add_manual_machine_ssh_root(event_loop):
+async def test_add_manual_machine_ssh_root():
     """Test manual machine provisioning with the root user"""
 
-    await add_manual_machine_ssh(event_loop, is_root=True)
+    await add_manual_machine_ssh(is_root=True)
 
 
 @base.bootstrapped
-async def test_relate(event_loop):
+async def test_relate():
     from juju.relation import Relation
 
     async with base.CleanModel() as model:
@@ -631,7 +631,7 @@ async def test_relate(event_loop):
                 if set(new.key.split()) == {'nrpe:general-info',
                                             'ubuntu:juju-info'}:
                     relation_added.set()
-                    event_loop.call_later(10, timeout.set)
+                    jasyncio.get_running_loop().call_later(10, timeout.set)
 
         model.add_observer(TestObserver())
 
@@ -658,7 +658,7 @@ async def test_relate(event_loop):
 
 
 @base.bootstrapped
-async def test_store_resources_charm(event_loop):
+async def test_store_resources_charm():
     pytest.skip('Revise: test_store_resources_charm intermittent test failure')
     async with base.CleanModel() as model:
         ghost = await model.deploy('ghost', channel='stable')
@@ -676,7 +676,7 @@ async def test_store_resources_charm(event_loop):
 
 
 @base.bootstrapped
-async def test_local_oci_image_resource_charm(event_loop):
+async def test_local_oci_image_resource_charm():
     charm_path = TESTS_DIR / 'integration' / 'oci-image-charm'
     async with base.CleanModel() as model:
         resources = {"oci-image": "ubuntu/latest"}
@@ -693,7 +693,7 @@ async def test_local_oci_image_resource_charm(event_loop):
 
 
 @base.bootstrapped
-async def test_local_file_resource_charm(event_loop):
+async def test_local_file_resource_charm():
     charm_path = INTEGRATION_TEST_DIR / 'file-resource-charm'
     async with base.CleanModel() as model:
         resources = {"file-res": "test.file"}
@@ -709,7 +709,7 @@ async def test_local_file_resource_charm(event_loop):
 
 
 @base.bootstrapped
-async def test_attach_resource(event_loop):
+async def test_attach_resource():
     charm_path = TESTS_DIR / 'integration' / 'file-resource-charm'
     async with base.CleanModel() as model:
         resources = {"file-res": "test.file"}
@@ -728,7 +728,7 @@ async def test_attach_resource(event_loop):
 
 @base.bootstrapped
 @pytest.mark.bundle
-async def test_store_resources_bundle(event_loop):
+async def test_store_resources_bundle():
     pytest.skip('test_store_resources_bundle intermittent test failure')
     async with base.CleanModel() as model:
         bundle = INTEGRATION_TEST_DIR / 'bundle'
@@ -750,7 +750,7 @@ async def test_store_resources_bundle(event_loop):
 
 @base.bootstrapped
 @pytest.mark.bundle
-async def test_store_resources_bundle_revs(event_loop):
+async def test_store_resources_bundle_revs():
     pytest.skip('test_store_resources_bundle_revs intermittent test failure')
     async with base.CleanModel() as model:
         bundle = INTEGRATION_TEST_DIR / 'bundle/bundle-resource-rev.yaml'
@@ -771,7 +771,7 @@ async def test_store_resources_bundle_revs(event_loop):
 
 
 @base.bootstrapped
-async def test_ssh_key(event_loop):
+async def test_ssh_key():
     async with base.CleanModel() as model:
         await model.add_ssh_key('admin', SSH_KEY)
         result = await model.get_ssh_key(True)
@@ -784,7 +784,7 @@ async def test_ssh_key(event_loop):
 
 
 @base.bootstrapped
-async def test_get_machines(event_loop):
+async def test_get_machines():
     async with base.CleanModel() as model:
         result = await model.get_machines()
         assert isinstance(result, list)
@@ -792,7 +792,7 @@ async def test_get_machines(event_loop):
 
 @base.bootstrapped
 @pytest.mark.wait_for_idle
-async def test_wait_for_idle_without_units(event_loop):
+async def test_wait_for_idle_without_units():
     async with base.CleanModel() as model:
         await model.deploy(
             'ubuntu',
@@ -806,7 +806,7 @@ async def test_wait_for_idle_without_units(event_loop):
 
 @base.bootstrapped
 @pytest.mark.wait_for_idle
-async def test_wait_for_idle_with_not_enough_units(event_loop):
+async def test_wait_for_idle_with_not_enough_units():
     async with base.CleanModel() as model:
         await model.deploy(
             'ubuntu',
@@ -820,7 +820,7 @@ async def test_wait_for_idle_with_not_enough_units(event_loop):
 
 @base.bootstrapped
 @pytest.mark.wait_for_idle
-async def test_wait_for_idle_more_units_than_needed(event_loop):
+async def test_wait_for_idle_more_units_than_needed():
     async with base.CleanModel() as model:
         charm_path = TESTS_DIR / 'charm'
 
@@ -842,7 +842,7 @@ async def test_wait_for_idle_more_units_than_needed(event_loop):
 
 @base.bootstrapped
 @pytest.mark.wait_for_idle
-async def test_wait_for_idle_with_enough_units(event_loop):
+async def test_wait_for_idle_with_enough_units():
     pytest.skip("This is testing juju functionality")
     async with base.CleanModel() as model:
         await model.deploy(
@@ -856,7 +856,7 @@ async def test_wait_for_idle_with_enough_units(event_loop):
 
 @base.bootstrapped
 @pytest.mark.wait_for_idle
-async def test_wait_for_idle_with_exact_units(event_loop):
+async def test_wait_for_idle_with_exact_units():
     pytest.skip("This is testing juju functionality")
     async with base.CleanModel() as model:
         await model.deploy(
@@ -870,7 +870,7 @@ async def test_wait_for_idle_with_exact_units(event_loop):
 
 @base.bootstrapped
 @pytest.mark.wait_for_idle
-async def test_wait_for_idle_with_exact_units_scale_down(event_loop):
+async def test_wait_for_idle_with_exact_units_scale_down():
     """Deploys 3 units, waits for them to be idle, then removes 2 of them,
     then waits for exactly 1 unit to be left.
 
@@ -899,7 +899,7 @@ async def test_wait_for_idle_with_exact_units_scale_down(event_loop):
 
 
 @base.bootstrapped
-async def test_wait_for_idle_with_exact_units_scale_down_zero(event_loop):
+async def test_wait_for_idle_with_exact_units_scale_down_zero():
     """Deploys 3 units, waits for them to be idle, then removes 3 of them,
     then waits for exactly 0 unit to be left.
 
@@ -928,7 +928,7 @@ async def test_wait_for_idle_with_exact_units_scale_down_zero(event_loop):
 
 
 @base.bootstrapped
-async def test_destroy_units(event_loop):
+async def test_destroy_units():
     async with base.CleanModel() as model:
         app = await model.deploy(
             'ubuntu',
@@ -944,14 +944,14 @@ async def test_destroy_units(event_loop):
 
 
 @base.bootstrapped
-async def test_watcher_reconnect(event_loop):
+async def test_watcher_reconnect():
     async with base.CleanModel() as model:
         await model.connection().close()
         await block_until(model.is_connected, timeout=3)
 
 
 @base.bootstrapped
-async def test_config(event_loop):
+async def test_config():
     async with base.CleanModel() as model:
         # first test get_config with nothing.
         result = await model.get_config()
@@ -967,7 +967,7 @@ async def test_config(event_loop):
 
 
 @base.bootstrapped
-async def test_config_with_json(event_loop):
+async def test_config_with_json():
     async with base.CleanModel() as model:
         # first test get_config with nothing.
         result = await model.get_config()
@@ -986,14 +986,14 @@ async def test_config_with_json(event_loop):
 
 
 @base.bootstrapped
-async def test_set_constraints(event_loop):
+async def test_set_constraints():
     async with base.CleanModel() as model:
         await model.set_constraints({'cpu-power': 1})
         cons = await model.get_constraints()
         assert cons['cpu_power'] == 1
 
 # @base.bootstrapped
-# # async def test_grant(event_loop)
+# # async def test_grant()
 #    async with base.CleanController() as controller:
 #        await controller.add_user('test-model-grant')
 #        await controller.grant('test-model-grant', 'superuser')
@@ -1005,7 +1005,7 @@ async def test_set_constraints(event_loop):
 
 
 @base.bootstrapped
-async def test_model_annotations(event_loop):
+async def test_model_annotations():
 
     async with base.CleanModel() as model:
         annotations = await model.get_annotations()
@@ -1019,7 +1019,7 @@ async def test_model_annotations(event_loop):
 
 
 @base.bootstrapped
-async def test_machine_annotations(event_loop):
+async def test_machine_annotations():
 
     async with base.CleanModel() as model:
         machine = await model.add_machine()
@@ -1035,7 +1035,7 @@ async def test_machine_annotations(event_loop):
 
 
 @base.bootstrapped
-async def test_application_annotations(event_loop):
+async def test_application_annotations():
 
     async with base.CleanModel() as model:
         app = await model.deploy('ubuntu', channel="stable")
@@ -1051,7 +1051,7 @@ async def test_application_annotations(event_loop):
 
 
 @base.bootstrapped
-async def test_unit_annotations(event_loop):
+async def test_unit_annotations():
 
     async with base.CleanModel() as model:
         app = await model.deploy('ubuntu')
@@ -1069,7 +1069,7 @@ async def test_unit_annotations(event_loop):
 
 
 @base.bootstrapped
-async def test_backups(event_loop):
+async def test_backups():
     pytest.skip('Revise: mongodb issues')
     m = Model()
     await m.connect(model_name='controller')
@@ -1095,7 +1095,7 @@ async def test_backups(event_loop):
 
 
 @base.bootstrapped
-async def test_connect_to_connection(event_loop):
+async def test_connect_to_connection():
     async with base.CleanModel() as test_model:
         # get the connection from test_model
         conn = test_model.connection()
@@ -1117,7 +1117,7 @@ async def test_connect_to_connection(event_loop):
 
 
 @base.bootstrapped
-async def test_connect_current(event_loop):
+async def test_connect_current():
     pytest.skip("This assumes that we have a model to connect to...")
     m = Model()
     await m.connect_current()
@@ -1125,7 +1125,7 @@ async def test_connect_current(event_loop):
 
 
 @base.bootstrapped
-async def test_model_cache_update(event_loop):
+async def test_model_cache_update():
     """Connecting to a new model shouldn't fail because the cache is not
     updated yet
 
@@ -1157,7 +1157,7 @@ async def test_model_cache_update(event_loop):
 
 
 @base.bootstrapped
-async def test_add_storage(event_loop):
+async def test_add_storage():
     pytest.skip('skip in favour of test_add_and_list_storage')
     async with base.CleanModel() as model:
         app = await model.deploy('postgresql')
@@ -1168,7 +1168,7 @@ async def test_add_storage(event_loop):
 
 
 @base.bootstrapped
-async def test_model_attach_storage_at_deploy(event_loop):
+async def test_model_attach_storage_at_deploy():
     pytest.skip('detach/attach_storage inconsistent on Juju side, unable to test')
     async with base.CleanModel() as model:
         # The attach_storage needs to be an existing storage,
@@ -1209,7 +1209,7 @@ async def test_model_attach_storage_at_deploy(event_loop):
 
 
 @base.bootstrapped
-async def test_detach_storage(event_loop):
+async def test_detach_storage():
     pytest.skip('detach/attach_storage inconsistent on Juju side, unable to test')
     async with base.CleanModel() as model:
         app = await model.deploy('postgresql')
@@ -1239,7 +1239,7 @@ async def test_detach_storage(event_loop):
 
 
 @base.bootstrapped
-async def test_add_and_list_storage(event_loop):
+async def test_add_and_list_storage():
     async with base.CleanModel() as model:
         app = await model.deploy('postgresql', base='ubuntu@22.04')
         # TODO (cderici):
@@ -1259,7 +1259,7 @@ async def test_add_and_list_storage(event_loop):
 
 
 @base.bootstrapped
-async def test_storage_pools_on_lxd(event_loop):
+async def test_storage_pools_on_lxd():
     # This will fail when ran on anything but lxd
     async with base.CleanModel() as model:
         await model.deploy('ubuntu')

--- a/tests/integration/test_secrets.py
+++ b/tests/integration/test_secrets.py
@@ -8,7 +8,7 @@ from ..utils import TESTS_DIR
 
 @base.bootstrapped
 @pytest.mark.bundle
-async def test_add_secret(event_loop):
+async def test_add_secret():
     async with base.CleanModel() as model:
         secret = await model.add_secret(name='my-apitoken', data_args=['token=34ae35facd4'])
         assert secret.startswith('secret:')
@@ -21,7 +21,7 @@ async def test_add_secret(event_loop):
 # This test can only work if we can fully upgrade the whole charm
 # with the corresponding logic :)
 @base.bootstrapped
-async def test_list_secrets(event_loop):
+async def test_list_secrets():
     """Use the charm-secret charm definition and see if the
     arguments defined in the secret are correct or not."""
 
@@ -40,7 +40,7 @@ async def test_list_secrets(event_loop):
 
 @base.bootstrapped
 @pytest.mark.bundle
-async def test_update_secret(event_loop):
+async def test_update_secret():
     async with base.CleanModel() as model:
         secret = await model.add_secret(name='my-apitoken', data_args=['token=34ae35facd4'])
         assert secret.startswith('secret:')
@@ -54,7 +54,7 @@ async def test_update_secret(event_loop):
 
 @base.bootstrapped
 @pytest.mark.bundle
-async def test_remove_secret(event_loop):
+async def test_remove_secret():
     async with base.CleanModel() as model:
         secret = await model.add_secret(name='my-apitoken', data_args=['token=34ae35facd4'])
         assert secret.startswith('secret:')
@@ -67,7 +67,7 @@ async def test_remove_secret(event_loop):
 
 @base.bootstrapped
 @pytest.mark.bundle
-async def test_grant_secret(event_loop):
+async def test_grant_secret():
     async with base.CleanModel() as model:
         secret = await model.add_secret(name='my-apitoken', data_args=['token=34ae35facd4'])
         assert secret.startswith('secret:')
@@ -79,7 +79,7 @@ async def test_grant_secret(event_loop):
 
 @base.bootstrapped
 @pytest.mark.bundle
-async def test_revoke_secret(event_loop):
+async def test_revoke_secret():
     async with base.CleanModel() as model:
         secret = await model.add_secret(name='my-apitoken', data_args=['token=34ae35facd4'])
         assert secret.startswith('secret:')

--- a/tests/integration/test_unit.py
+++ b/tests/integration/test_unit.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 import pytest
 
-from juju import utils
+from juju import utils, jasyncio
 
 from .. import base
 
@@ -160,7 +160,7 @@ async def test_run_action():
 async def test_scp():
     # ensure that asyncio.subprocess will work;
     try:
-        asyncio.get_child_watcher().attach_loop()
+        asyncio.get_child_watcher().attach_loop(jasyncio.get_running_loop())
     except RuntimeError:
         pytest.skip('test_scp will always fail outside of MainThread')
     async with base.CleanModel() as model:
@@ -193,7 +193,7 @@ async def test_scp():
 async def test_ssh():
     # ensure that asyncio.subprocess will work;
     try:
-        asyncio.get_child_watcher().attach_loop()
+        asyncio.get_child_watcher().attach_loop(jasyncio.get_running_loop())
     except RuntimeError:
         pytest.skip('test_ssh will always fail outside of MainThread')
     async with base.CleanModel() as model:

--- a/tests/integration/test_unit.py
+++ b/tests/integration/test_unit.py
@@ -12,7 +12,7 @@ from .. import base
 
 
 @base.bootstrapped
-async def test_block_coroutine(event_loop):
+async def test_block_coroutine():
     async with base.CleanModel() as model:
         app = await model.deploy(
             'ubuntu',
@@ -31,7 +31,7 @@ async def test_block_coroutine(event_loop):
 
 
 @base.bootstrapped
-async def test_unit_public_address(event_loop):
+async def test_unit_public_address():
     async with base.CleanModel() as model:
         app = await model.deploy(
             'ubuntu',
@@ -63,7 +63,7 @@ async def test_unit_public_address(event_loop):
 
 
 @base.bootstrapped
-async def test_run(event_loop):
+async def test_run():
     from juju.action import Action
 
     async with base.CleanModel() as model:
@@ -109,7 +109,7 @@ async def test_run(event_loop):
 
 
 @base.bootstrapped
-async def test_run_action(event_loop):
+async def test_run_action():
     pytest.skip('Find a better charm for this test')
 
     async def run_action(unit):
@@ -157,10 +157,10 @@ async def test_run_action(event_loop):
 
 
 @base.bootstrapped
-async def test_scp(event_loop):
+async def test_scp():
     # ensure that asyncio.subprocess will work;
     try:
-        asyncio.get_child_watcher().attach_loop(event_loop)
+        asyncio.get_child_watcher().attach_loop()
     except RuntimeError:
         pytest.skip('test_scp will always fail outside of MainThread')
     async with base.CleanModel() as model:
@@ -190,10 +190,10 @@ async def test_scp(event_loop):
 
 
 @base.bootstrapped
-async def test_ssh(event_loop):
+async def test_ssh():
     # ensure that asyncio.subprocess will work;
     try:
-        asyncio.get_child_watcher().attach_loop(event_loop)
+        asyncio.get_child_watcher().attach_loop()
     except RuntimeError:
         pytest.skip('test_ssh will always fail outside of MainThread')
     async with base.CleanModel() as model:
@@ -217,7 +217,7 @@ async def test_ssh(event_loop):
 
 
 @base.bootstrapped
-async def test_resolve_local(event_loop):
+async def test_resolve_local():
     charm_file = Path(__file__).absolute().parent / 'charm.charm'
 
     async with base.CleanModel() as model:
@@ -241,7 +241,7 @@ async def test_resolve_local(event_loop):
 
 
 @base.bootstrapped
-async def test_unit_introspect(event_loop):
+async def test_unit_introspect():
     async with base.CleanModel() as model:
         await model.deploy('ubuntu', series='jammy')
         await model.wait_for_idle(status="active")
@@ -254,7 +254,7 @@ async def test_unit_introspect(event_loop):
 
 
 @base.bootstrapped
-async def test_subordinate_units(event_loop):
+async def test_subordinate_units():
     async with base.CleanModel() as model:
         u_app = await model.deploy('ubuntu')
         n_app = await model.deploy('ntp')
@@ -283,7 +283,7 @@ async def test_subordinate_units(event_loop):
 
 
 @base.bootstrapped
-async def test_destroy_unit(event_loop):
+async def test_destroy_unit():
     async with base.CleanModel() as model:
         app = await model.deploy(
             'juju-qa-test',

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -122,7 +122,7 @@ class TestAddApplicationChange(unittest.TestCase):
 
 class TestAddApplicationChangeRun:
 
-    async def test_run_with_charmhub_charm(self, event_loop):
+    async def test_run_with_charmhub_charm(self):
         change = AddApplicationChange(1, [], params={"charm": "charm",
                                                      "series": "series",
                                                      "application": "application",
@@ -166,7 +166,7 @@ class TestAddApplicationChangeRun:
                                          charm_origin=ANY,
                                          num_units="num_units")
 
-    async def test_run_with_charmhub_charm_no_channel(self, event_loop):
+    async def test_run_with_charmhub_charm_no_channel(self):
         """Test to verify if when the given channel is None, the channel defaults to "local/stable", which
             is the default channel value for the Charm Hub
         """
@@ -214,7 +214,7 @@ class TestAddApplicationChangeRun:
                                          charm_origin=ANY,
                                          num_units="num_units")
 
-    async def test_run_local(self, event_loop):
+    async def test_run_local(self):
         change = AddApplicationChange(1, [], params={"charm": "local:charm",
                                                      "series": "series",
                                                      "application": "application",
@@ -252,7 +252,7 @@ class TestAddApplicationChangeRun:
                                          channel="",
                                          charm_origin=ANY)
 
-    async def test_run_no_series(self, event_loop):
+    async def test_run_no_series(self):
         change = AddApplicationChange(1, [], params={"charm": "ch:charm1",
                                                      "series": "",
                                                      "application": "application",
@@ -333,7 +333,7 @@ class TestAddCharmChange(unittest.TestCase):
 
 class TestAddCharmChangeRun:
 
-    async def test_run(self, event_loop):
+    async def test_run(self):
         change = AddCharmChange(1, [], params={"charm": "ch:charm",
                                                "series": "jammy",
                                                "channel": "channel"})
@@ -388,7 +388,7 @@ class TestAddMachineChange(unittest.TestCase):
 
 class TestAddMachineChangeRun:
 
-    async def test_run(self, event_loop):
+    async def test_run(self):
         change = AddMachineChange(1, [], params={"series": "series",
                                                  "constraints": "cores=1",
                                                  "container-type": "container_type",
@@ -436,7 +436,7 @@ class TestAddRelationChange(unittest.TestCase):
 
 
 class TestAddRelationChangeRun:
-    async def test_run(self, event_loop):
+    async def test_run(self):
         change = AddRelationChange(1, [], params={"endpoint1": "endpoint1",
                                                   "endpoint2": "endpoint2"})
 
@@ -500,7 +500,7 @@ class MockModel:
 
 class TestAddUnitChangeRun:
 
-    async def test_run(self, event_loop):
+    async def test_run(self):
         change = AddUnitChange(1, [], params={"application": "application",
                                               "to": "to"})
 
@@ -548,7 +548,7 @@ class TestCreateOfferChange(unittest.TestCase):
 
 class TestCreateOfferChangeRun:
 
-    async def test_run(self, event_loop):
+    async def test_run(self):
         change = CreateOfferChange(1, [], params={"application": "application",
                                                   "endpoints": ["endpoints"],
                                                   "offer-name": "offer_name"})
@@ -592,7 +592,7 @@ class TestConsumeOfferChange(unittest.TestCase):
 
 class TestConsumeOfferChangeRun:
 
-    async def test_run(self, event_loop):
+    async def test_run(self):
         change = ConsumeOfferChange(1, [], params={"url": "url",
                                                    "application-name": "application_name"})
 
@@ -662,7 +662,7 @@ class TestExposeChange(unittest.TestCase):
 
 class TestExposeChangeRun:
 
-    async def test_run(self, event_loop):
+    async def test_run(self):
         params = {
             "application": "application",
             "exposed-endpoints": {
@@ -726,7 +726,7 @@ class TestScaleChange(unittest.TestCase):
 
 class TestScaleChangeRun:
 
-    async def test_run(self, event_loop):
+    async def test_run(self):
         change = ScaleChange(1, [], params={"application": "application",
                                             "scale": 1})
 
@@ -773,7 +773,7 @@ class TestSetAnnotationsChange(unittest.TestCase):
 
 class TestSetAnnotationsChangeRun:
 
-    async def test_run(self, event_loop):
+    async def test_run(self):
         change = SetAnnotationsChange(1, [], params={"id": "id",
                                                      "entity-type": "entity_type",
                                                      "annotations": "annotations"})
@@ -799,7 +799,7 @@ class TestSetAnnotationsChangeRun:
 
 
 class TestBundleHandler:
-    async def test_fetch_plan_local_k8s_bundle(self, event_loop):
+    async def test_fetch_plan_local_k8s_bundle(self):
         class AsyncMock(mock.MagicMock):
             async def __call__(self, *args, **kwargs):
                 return super(AsyncMock, self).__call__(*args, **kwargs)

--- a/tests/unit/test_connection.py
+++ b/tests/unit/test_connection.py
@@ -34,7 +34,7 @@ class WebsocketMock:
         self.closed = True
 
 
-async def test_out_of_order(event_loop):
+async def test_out_of_order():
     ws = WebsocketMock([
         {'request-id': 1},
         {'request-id': 3},
@@ -69,7 +69,7 @@ async def test_out_of_order(event_loop):
             await con.close()
 
 
-async def test_bubble_redirect_exception(event_loop):
+async def test_bubble_redirect_exception():
     ca_cert = """
 -----BEGIN CERTIFICATE-----
 SOMECERT
@@ -112,7 +112,7 @@ SOMECERT
     ]
 
 
-async def test_follow_redirect(event_loop):
+async def test_follow_redirect():
     ca_cert = """
 -----BEGIN CERTIFICATE-----
 SOMECERT
@@ -170,7 +170,7 @@ SOMECERT
             await con.close()
 
 
-async def test_rpc_none_results(event_loop):
+async def test_rpc_none_results():
     ws = WebsocketMock([
         {'request-id': 1, 'response': {'results': None}},
     ])


### PR DESCRIPTION
#### Description

This clears up from the test output the flood of warnings from pytest that looks like (e.g. [example](https://github.com/juju/python-libjuju/actions/runs/7463235016/job/20307443804#step:5:982)):

```
tests/unit/test_bundle.py:738
  tests/unit/test_bundle.py:738: PytestDeprecationWarning: test_run is asynchronous and explicitly requests the "event_loop" fixture. Asynchronous fixtures and test functions should use "asyncio.get_running_loop()" instead.
    @pytest.mark.asyncio
```

#### QA Steps

No functionality changes. Though there were a couple of tests that I needed to manually get the running loop (where the test actually was using the `event_loop`), so we need to make sure those are still passing.

#### Notes & Discussions

Maybe need to be back-ported? I'm not sure yet.