### PR TITLE
Avoid installing signal handlers to the event loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ run-unit-tests: lint .tox
 	tox -e py3
 
 .PHONY: run-integration-tests
-run-unit-tests: lint .tox
+run-integration-tests: lint .tox
 	tox -e integration
 
 .PHONY: run-all-tests

--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -5,7 +5,6 @@ import base64
 import json
 import logging
 import ssl
-import signal
 import urllib.request
 import weakref
 from http.client import HTTPSConnection
@@ -425,10 +424,6 @@ class Connection:
             for task in jasyncio.all_tasks():
                 task.cancel()
 
-        loop = jasyncio.get_running_loop()
-        for sig in (signal.SIGINT, signal.SIGTERM):
-            loop.add_signal_handler(sig, _exit_tasks)
-
         return (await websockets.connect(
             url,
             ssl=self._get_ssl(cacert),
@@ -472,11 +467,6 @@ class Connection:
 
         if self.proxy is not None:
             self.proxy.close()
-
-        # Remove signal handlers
-        loop = jasyncio.get_running_loop()
-        for sig in (signal.SIGINT, signal.SIGTERM):
-            loop.remove_signal_handler(sig)
 
     async def _recv(self, request_id):
         if not self.is_open:


### PR DESCRIPTION
#### Description

In #1010 it's reported that running pylibjuju in an off-main thread blows up the `add_signal_handler` (for a good reason). Also per the discussion in the #1011 about signal handlers, this PR removes the code that installs signal handlers to the event loop at the connection creation. See [my comment](https://github.com/juju/python-libjuju/pull/1011#issuecomment-1906871005) in #1011 for details about reasoning.

Fixes #1010 