### PR TITLE
Add build test and update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BugReport.yml
+++ b/.github/ISSUE_TEMPLATE/BugReport.yml
@@ -48,7 +48,9 @@ body:
     id: info
     attributes:
       label: "Reproduce / Test"
-      description: "Please add valid Python code to reproduce the bug. This will be used as a test for QAing later on."
+      description: "Please add valid Python code to reproduce the bug. This will be used as a test for QAing later on.
+
+      Please provide a simplified reproducer, and if it's possible please refrain from providing a "clone this repository and run the integration tests to see the problem" type of a reproducer. Thanks!"
       render: python
     validations:
       required: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,6 +25,24 @@ jobs:
           tox -e lint
           ./scripts/copyright.sh
 
+  build-test:
+    name: Build test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python:
+          - "3.10"
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Run build test target
+        run: |
+          make build-test
+
   unit-tests:
     needs: lint
     name: Unit tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,8 +39,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
-      - name: Install dependencies
-        run: pip install tox
       - name: Run build test target
         run: |
           make build-test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,6 +39,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+      - name: Install dependencies
+        run: pip install tox
       - name: Run build test target
         run: |
           make build-test

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,16 @@ lint:
 docs:
 	tox -e docs
 
+.PHONY: build-test
+build-test:
+	rm -rf venv
+	python -m venv venv
+	. venv/bin/activate
+	$(PY) setup.py sdist
+	pip install dist/juju-${VERSION}.tar.gz
+	python3 -c "from juju.controller import Controller"
+	rm dist/juju-${VERSION}.tar.gz
+
 .PHONY: release
 release:
 	git fetch --tags

--- a/Makefile
+++ b/Makefile
@@ -41,13 +41,13 @@ docs:
 	tox -e docs
 
 .PHONY: build-test
-build-test: .tox
+build-test:
 	rm -rf venv
-	$(PY) -m venv venv
+	python3 -m venv venv
 	. venv/bin/activate
-	$(PY) setup.py sdist
+	python3 setup.py sdist
 	pip install ./dist/juju-${VERSION}.tar.gz
-	$(PY) -c "from juju.controller import Controller"
+	python3 -c "from juju.controller import Controller"
 	rm ./dist/juju-${VERSION}.tar.gz
 
 .PHONY: release

--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,9 @@ build-test: .tox
 	$(PY) -m venv venv
 	. venv/bin/activate
 	$(PY) setup.py sdist
-	pip install dist/juju-${VERSION}.tar.gz
+	pip install ./dist/juju-${VERSION}.tar.gz
 	$(PY) -c "from juju.controller import Controller"
-	rm dist/juju-${VERSION}.tar.gz
+	rm ./dist/juju-${VERSION}.tar.gz
 
 .PHONY: release
 release:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 BIN := .tox/py3/bin
 PY := $(BIN)/python3
 PIP := $(BIN)/pip3
-VERSION := $(shell $(PY) -c "from juju.version import CLIENT_VERSION; print(CLIENT_VERSION)")
+VERSION := $(shell python3 -c "from juju.version import CLIENT_VERSION; print(CLIENT_VERSION)")
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -41,13 +41,13 @@ docs:
 	tox -e docs
 
 .PHONY: build-test
-build-test:
+build-test: .tox
 	rm -rf venv
-	python -m venv venv
+	$(PY) -m venv venv
 	. venv/bin/activate
 	$(PY) setup.py sdist
 	pip install dist/juju-${VERSION}.tar.gz
-	python3 -c "from juju.controller import Controller"
+	$(PY) -c "from juju.controller import Controller"
 	rm dist/juju-${VERSION}.tar.gz
 
 .PHONY: release


### PR DESCRIPTION
#### Description

This does two things:

1. Adds a Makefile target called `build-test` that runs the `setup.py sdist` and installs the artifact in a virtual environment and runs a very simple command on it. The purpose of this is to catch the build and runtime dependency problems early on whenever a change is made that'll effect the release down the road (i.e. before it blows up when a new version is released). We add it into a GH action job as well to automatically catch these issues. 
For example, having something like this would've saved us from hitting https://github.com/juju/python-libjuju/issues/1025 on the `3.3.1.0` release, which is the sole reason we had to make a new release https://github.com/juju/python-libjuju/releases/tag/3.3.1.1 afterwards.

2. Updates the bug report template and adds `Please provide a simplified reproducer, and if it's possible please refrain from providing a "clone this repository and run the integration tests to see the problem" type of a reproducer. Thanks!`, which is pretty self-explanatory.

#### QA Steps

Just running the make target to see if it succeeds locally should be sufficient to QA this:

```
make build-test
```

And maybe some manual checking for typos in the template message (b/c user-facing) could help.