### PR TITLE
Bugfix none type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ pytestdebug.log
 .vscode/
 deb_dist
 *.tar.gz
+.idea/

--- a/juju/controller.py
+++ b/juju/controller.py
@@ -828,7 +828,8 @@ class Controller:
                     try:
                         results = await utils.run_with_interrupt(
                             watcher.Next(),
-                            stop_event)
+                            stop_event,
+                            log=log)
                     except JujuAPIError as e:
                         if 'watcher was stopped' not in str(e):
                             raise

--- a/juju/model.py
+++ b/juju/model.py
@@ -1115,7 +1115,8 @@ class Model:
                     try:
                         results = await utils.run_with_interrupt(
                             allwatcher.Next(),
-                            self._watch_stopping)
+                            self._watch_stopping,
+                            log=log)
                     except JujuAPIError as e:
                         if 'watcher was stopped' not in str(e):
                             raise

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_action(event_loop):
+async def test_action():
     async with base.CleanModel() as model:
         ubuntu_app = await model.deploy(
             'percona-cluster',
@@ -57,7 +57,7 @@ async def test_action(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_get_set_config(event_loop):
+async def test_get_set_config():
     async with base.CleanModel() as model:
         ubuntu_app = await model.deploy(
             'percona-cluster',
@@ -82,7 +82,7 @@ async def test_get_set_config(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_status_is_not_unset(event_loop):
+async def test_status_is_not_unset():
     async with base.CleanModel() as model:
         app = await model.deploy(
             'ubuntu',
@@ -96,7 +96,7 @@ async def test_status_is_not_unset(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_status(event_loop):
+async def test_status():
     async with base.CleanModel() as model:
         app = await model.deploy('cs:~juju-qa/blocked-0')
 
@@ -111,7 +111,7 @@ async def test_status(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_add_units(event_loop):
+async def test_add_units():
     from juju.unit import Unit
 
     async with base.CleanModel() as model:
@@ -130,7 +130,7 @@ async def test_add_units(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_charmhub_charm(event_loop):
+async def test_deploy_charmhub_charm():
     async with base.CleanModel() as model:
         app = await model.deploy('ch:hello-juju')
         await model.block_until(lambda: (len(app.units) > 0 and
@@ -140,7 +140,7 @@ async def test_deploy_charmhub_charm(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_upgrade_charm_switch_channel(event_loop):
+async def test_upgrade_charm_switch_channel():
     # Note for future:
     # This test requires a charm that has different
     # revisions for different channels/risks.
@@ -184,7 +184,7 @@ async def test_upgrade_charm_switch_channel(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_upgrade_local_charm(event_loop):
+async def test_upgrade_local_charm():
     # Skip temporarily due to a known problem:
     pytest.skip('cannot upgrade application "ubuntu" to charm "local:focal/ubuntu-0": required storage "files" removed')
     async with base.CleanModel() as model:
@@ -201,7 +201,7 @@ async def test_upgrade_local_charm(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_upgrade_switch_charmstore_to_charmhub(event_loop):
+async def test_upgrade_switch_charmstore_to_charmhub():
     async with base.CleanModel() as model:
         app = await model.deploy('cs:ubuntu', series='focal')
         await model.wait_for_idle(status="active")
@@ -213,7 +213,7 @@ async def test_upgrade_switch_charmstore_to_charmhub(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_upgrade_charm_resource(event_loop):
+async def test_upgrade_charm_resource():
     async with base.CleanModel() as model:
         app = await model.deploy('cs:~juju-qa/bionic/upgrade-charm-resource-test-0')
 
@@ -233,7 +233,7 @@ async def test_upgrade_charm_resource(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_refresh_with_resource_argument(event_loop):
+async def test_refresh_with_resource_argument():
     async with base.CleanModel() as model:
         app = await model.deploy('juju-qa-test', resources={'foo-file': 2})
         res2 = await app.get_resources()
@@ -245,7 +245,7 @@ async def test_refresh_with_resource_argument(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_upgrade_charm_resource_same_rev_no_update(event_loop):
+async def test_upgrade_charm_resource_same_rev_no_update():
     async with base.CleanModel() as model:
         app = await model.deploy('keystone', channel='victoria/stable')
         ress = await app.get_resources()
@@ -256,7 +256,7 @@ async def test_upgrade_charm_resource_same_rev_no_update(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_refresh_charmhub_to_local(event_loop):
+async def test_refresh_charmhub_to_local():
     charm_path = INTEGRATION_TEST_DIR / 'charm'
     async with base.CleanModel() as model:
         app = await model.deploy('ubuntu', application_name='ubu-path')
@@ -270,7 +270,7 @@ async def test_refresh_charmhub_to_local(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_local_refresh(event_loop):
+async def test_local_refresh():
     charm_path = INTEGRATION_TEST_DIR / 'charm'
     async with base.CleanModel() as model:
         app = await model.deploy('ubuntu')
@@ -286,7 +286,7 @@ async def test_local_refresh(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_upgrade_local_charm_with_resource(event_loop):
+async def test_upgrade_local_charm_with_resource():
     charm_path = INTEGRATION_TEST_DIR / 'file-resource-charm'
     async with base.CleanModel() as model:
         app = await model.deploy(str(charm_path))
@@ -308,7 +308,7 @@ async def test_upgrade_local_charm_with_resource(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_trusted(event_loop):
+async def test_trusted():
     async with base.CleanModel() as model:
         await model.deploy('ubuntu', trust=True)
 
@@ -323,7 +323,7 @@ async def test_trusted(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_app_remove_wait_flag(event_loop):
+async def test_app_remove_wait_flag():
     async with base.CleanModel() as model:
         app = await model.deploy('ubuntu')
         a_name = app.name
@@ -335,7 +335,7 @@ async def test_app_remove_wait_flag(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_app_charm_name(event_loop):
+async def test_app_charm_name():
     async with base.CleanModel() as model:
         app = await model.deploy('ubuntu')
         await model.wait_for_idle(status="active")

--- a/tests/integration/test_charmhub.py
+++ b/tests/integration/test_charmhub.py
@@ -10,7 +10,7 @@ from juju import jasyncio
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_info(event_loop):
+async def test_info():
     async with base.CleanModel() as model:
         result = await model.charmhub.info("hello-juju")
 
@@ -19,7 +19,7 @@ async def test_info(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_info_with_channel(event_loop):
+async def test_info_with_channel():
     async with base.CleanModel() as model:
         result = await model.charmhub.info("hello-juju", "latest/stable")
 
@@ -29,7 +29,7 @@ async def test_info_with_channel(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_info_not_found(event_loop):
+async def test_info_not_found():
     async with base.CleanModel() as model:
         try:
             await model.charmhub.info("badnameforapp")
@@ -41,7 +41,7 @@ async def test_info_not_found(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_find(event_loop):
+async def test_find():
     async with base.CleanModel() as model:
         result = await model.charmhub.find("kube")
 
@@ -53,7 +53,7 @@ async def test_find(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_find_bundles(event_loop):
+async def test_find_bundles():
     async with base.CleanModel() as model:
         result = await model.charmhub.find("kube", charm_type="bundle")
 
@@ -65,7 +65,7 @@ async def test_find_bundles(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_find_all(event_loop):
+async def test_find_all():
     async with base.CleanModel() as model:
         result = await model.charmhub.find("")
 
@@ -77,7 +77,7 @@ async def test_find_all(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_subordinate_charm_zero_units(event_loop):
+async def test_subordinate_charm_zero_units():
     # normally in pylibjuju deploy num_units defaults to 1, we switch
     # that to 0 behind the scenes if we see that the charmhub charm
     # we're deploying is a subordinate charm
@@ -104,7 +104,7 @@ async def test_subordinate_charm_zero_units(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_list_resources(event_loop):
+async def test_list_resources():
     async with base.CleanModel() as model:
         resources = await model.charmhub.list_resources('hello-kubecon')
         assert isinstance(resources, list) and len(resources) > 0

--- a/tests/integration/test_client.py
+++ b/tests/integration/test_client.py
@@ -10,7 +10,7 @@ from .. import base
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_user_info(event_loop):
+async def test_user_info():
     async with base.CleanModel() as model:
         controller_conn = await model.connection().controller()
 

--- a/tests/integration/test_connection.py
+++ b/tests/integration/test_connection.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_connection_happy_path(event_loop):
+async def test_connection_happy_path():
     async with base.CleanController() as contr:
         conn = contr.connection()
         new_cont = Controller()
@@ -40,7 +40,7 @@ async def test_connection_happy_path(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_monitor(event_loop):
+async def test_monitor():
     async with base.CleanModel() as model:
         conn = model.connection()
         assert conn.monitor.status == 'connected'
@@ -51,7 +51,7 @@ async def test_monitor(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_monitor_catches_error(event_loop):
+async def test_monitor_catches_error():
 
     async with base.CleanModel() as model:
         conn = model.connection()
@@ -72,7 +72,7 @@ async def test_monitor_catches_error(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_full_status(event_loop):
+async def test_full_status():
     async with base.CleanModel() as model:
         await model.deploy(
             'ubuntu',
@@ -88,7 +88,7 @@ async def test_full_status(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_reconnect(event_loop):
+async def test_reconnect():
     async with base.CleanModel() as model:
         kwargs = model.connection().connect_params()
         conn = await Connection.connect(**kwargs)
@@ -105,7 +105,7 @@ async def test_reconnect(event_loop):
 @base.bootstrapped
 @pytest.mark.asyncio
 @pytest.mark.skip('tests the websocket protocol, not pylibjuju, needs to be revised')
-async def test_redirect(event_loop):
+async def test_redirect():
     controller = Controller()
     await controller.connect()
     kwargs = controller.connection().connect_params()
@@ -258,7 +258,7 @@ class RedirectServer:
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_verify_controller_cert(event_loop):
+async def test_verify_controller_cert():
     jujudata = FileJujuData()
     controller_name = jujudata.current_controller()
     endpoint = jujudata.controllers()[controller_name]['api-endpoints'][0]

--- a/tests/integration/test_controller.py
+++ b/tests/integration/test_controller.py
@@ -15,7 +15,7 @@ from .. import base
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_add_remove_user(event_loop):
+async def test_add_remove_user():
     async with base.CleanController() as controller:
         username = 'test{}'.format(uuid.uuid4())
         user = await controller.get_user(username)
@@ -35,7 +35,7 @@ async def test_add_remove_user(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_disable_enable_user(event_loop):
+async def test_disable_enable_user():
     async with base.CleanController() as controller:
         username = 'test-disable{}'.format(uuid.uuid4())
         user = await controller.add_user(username)
@@ -59,7 +59,7 @@ async def test_disable_enable_user(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_change_user_password(event_loop):
+async def test_change_user_password():
     async with base.CleanController() as controller:
         username = 'test-password{}'.format(uuid.uuid4())
         user = await controller.add_user(username)
@@ -80,7 +80,7 @@ async def test_change_user_password(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_reset_user_password(event_loop):
+async def test_reset_user_password():
     async with base.CleanController() as controller:
         username = 'test{}'.format(uuid.uuid4())
         user = await controller.add_user(username)
@@ -109,7 +109,7 @@ async def test_reset_user_password(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_grant_revoke(event_loop):
+async def test_grant_revoke():
     async with base.CleanController() as controller:
         username = 'test-grant{}'.format(uuid.uuid4())
         user = await controller.add_user(username)
@@ -129,7 +129,7 @@ async def test_grant_revoke(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_list_models(event_loop):
+async def test_list_models():
     async with base.CleanController() as controller:
         async with base.CleanModel() as model:
             result = await controller.list_models()
@@ -138,7 +138,7 @@ async def test_list_models(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_list_models_user_access(event_loop):
+async def test_list_models_user_access():
     async with base.CleanController() as controller:
         username = 'test-grant{}'.format(uuid.uuid4())
         user = await controller.add_user(username)
@@ -157,7 +157,7 @@ async def test_list_models_user_access(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_get_model(event_loop):
+async def test_get_model():
     async with base.CleanController() as controller:
         by_name, by_uuid = None, None
         model_name = 'test-{}'.format(uuid.uuid4())
@@ -191,7 +191,7 @@ async def _wait_for_model_gone(controller, model_name):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_destroy_model_by_name(event_loop):
+async def test_destroy_model_by_name():
     async with base.CleanController() as controller:
         model_name = 'test-{}'.format(uuid.uuid4())
         model = await controller.add_model(model_name)
@@ -207,7 +207,7 @@ async def test_destroy_model_by_name(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_add_destroy_model_by_uuid(event_loop):
+async def test_add_destroy_model_by_uuid():
     async with base.CleanController() as controller:
         model_name = 'test-{}'.format(uuid.uuid4())
         model = await controller.add_model(model_name)
@@ -224,7 +224,7 @@ async def test_add_destroy_model_by_uuid(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_add_remove_cloud(event_loop):
+async def test_add_remove_cloud():
     async with base.CleanController() as controller:
         cloud_name = 'test-{}'.format(uuid.uuid4())
         cloud = client.Cloud(

--- a/tests/integration/test_crossmodel.py
+++ b/tests/integration/test_crossmodel.py
@@ -12,7 +12,7 @@ from juju import jasyncio
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_offer(event_loop):
+async def test_offer():
     async with base.CleanModel() as model:
         await model.deploy(
             'cs:~jameinel/ubuntu-lite-7',
@@ -33,7 +33,7 @@ async def test_offer(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_consume(event_loop):
+async def test_consume():
     async with base.CleanModel() as model_1:
         await model_1.deploy(
             'cs:~jameinel/ubuntu-lite-7',
@@ -63,7 +63,7 @@ async def test_consume(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_remove_saas(event_loop):
+async def test_remove_saas():
     async with base.CleanModel() as model_1:
         await model_1.deploy(
             'cs:~jameinel/ubuntu-lite-7',
@@ -96,7 +96,7 @@ async def test_remove_saas(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_relate_with_offer(event_loop):
+async def test_relate_with_offer():
     pytest.skip('Revise: intermittent problem with the remove_saas call')
     async with base.CleanModel() as model_1:
         application = await model_1.deploy(
@@ -143,7 +143,7 @@ async def test_relate_with_offer(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_add_bundle(event_loop):
+async def test_add_bundle():
     pytest.skip("Skip until we find a faster alternative to this test")
     tests_dir = Path(__file__).absolute().parent
     bundle_path = tests_dir / 'bundle'

--- a/tests/integration/test_errors.py
+++ b/tests/integration/test_errors.py
@@ -11,7 +11,7 @@ GB = 1024
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_juju_api_error(event_loop):
+async def test_juju_api_error():
     '''
     Verify that we raise a JujuAPIError for responses with an error in
     a top level key (for completely invalid requests).
@@ -26,7 +26,7 @@ async def test_juju_api_error(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_juju_error_in_results_list(event_loop):
+async def test_juju_error_in_results_list():
     '''
     Replicate the code that caused
     https://github.com/juju/python-libjuju/issues/67, and verify that
@@ -55,7 +55,7 @@ async def test_juju_error_in_results_list(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_juju_error_in_result(event_loop):
+async def test_juju_error_in_result():
     '''
     Verify that we raise a JujuError when appropraite when we are
     looking at a single result coming back.

--- a/tests/integration/test_expose.py
+++ b/tests/integration/test_expose.py
@@ -10,7 +10,7 @@ from .. import base
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_expose_unexpose(event_loop):
+async def test_expose_unexpose():
     async with base.CleanModel() as model:
         app = await model.deploy(
             "cs:~jameinel/ubuntu-lite-7",

--- a/tests/integration/test_juju.py
+++ b/tests/integration/test_juju.py
@@ -10,7 +10,7 @@ from .. import base
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_get_controllers(event_loop):
+async def test_get_controllers():
     async with base.CleanController() as controller:
         j = Juju()
 

--- a/tests/integration/test_macaroon_auth.py
+++ b/tests/integration/test_macaroon_auth.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 @base.bootstrapped
 @pytest.mark.asyncio
 @pytest.mark.skip('one of old macaroon_auth tests, needs to be revised')
-async def test_macaroon_auth_serial(event_loop):
+async def test_macaroon_auth_serial():
     jujudata = FileJujuData()
     account = jujudata.accounts()[jujudata.current_controller()]
     with base.patch_file('~/.local/share/juju/accounts.yaml'):
@@ -53,7 +53,7 @@ async def test_macaroon_auth_serial(event_loop):
 @pytest.mark.asyncio
 # @pytest.mark.xfail
 @pytest.mark.skip('one of old macaroon_auth tests, needs to be revised')
-async def test_macaroon_auth(event_loop):
+async def test_macaroon_auth():
     auth_info, username = agent_auth_info()
     # Create a bakery client that can do agent authentication.
     client = httpbakery.Client(
@@ -75,7 +75,7 @@ async def test_macaroon_auth(event_loop):
 @pytest.mark.asyncio
 # @pytest.mark.xfail
 @pytest.mark.skip('one of old macaroon_auth tests, needs to be revised')
-async def test_macaroon_auth_with_bad_key(event_loop):
+async def test_macaroon_auth_with_bad_key():
     auth_info, username = agent_auth_info()
     # Use a random key rather than the correct key.
     auth_info = auth_info._replace(key=bakery.generate_key())
@@ -104,7 +104,7 @@ async def test_macaroon_auth_with_bad_key(event_loop):
 @pytest.mark.asyncio
 # @pytest.mark.xfail
 @pytest.mark.skip('one of old macaroon_auth tests, needs to be revised')
-async def test_macaroon_auth_with_unauthorized_user(event_loop):
+async def test_macaroon_auth_with_unauthorized_user():
     auth_info, username = agent_auth_info()
     # Create a bakery client can do agent authentication.
     client = httpbakery.Client(

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -26,7 +26,7 @@ from ..utils import MB, GB, TESTS_DIR, OVERLAYS_DIR, SSH_KEY, INTEGRATION_TEST_D
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_model_name(event_loop):
+async def test_model_name():
     model = Model()
     with pytest.raises(JujuError):
         model.name
@@ -39,7 +39,7 @@ async def test_model_name(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_local_bundle_dir(event_loop):
+async def test_deploy_local_bundle_dir():
     bundle_path = TESTS_DIR / 'bundle'
 
     async with base.CleanModel() as model:
@@ -59,7 +59,7 @@ async def test_deploy_local_bundle_dir(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_local_bundle_file(event_loop):
+async def test_deploy_local_bundle_file():
     bundle_path = TESTS_DIR / 'bundle'
     mini_bundle_file_path = bundle_path / 'mini-bundle.yaml'
 
@@ -76,7 +76,7 @@ async def test_deploy_local_bundle_file(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_bundle_local_resource_relative_path(event_loop):
+async def test_deploy_bundle_local_resource_relative_path():
     bundle_file_path = INTEGRATION_TEST_DIR / 'bundle-file-resource.yaml'
 
     async with base.CleanModel() as model:
@@ -90,7 +90,7 @@ async def test_deploy_bundle_local_resource_relative_path(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_by_revision(event_loop):
+async def test_deploy_by_revision():
     async with base.CleanModel() as model:
         app = await model.deploy('juju-qa-test',
                                  application_name='test',
@@ -103,7 +103,7 @@ async def test_deploy_by_revision(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_by_revision_validate_flags(event_loop):
+async def test_deploy_by_revision_validate_flags():
     # Make sure we fail gracefully when invalid --revision/--channel
     # flags are used
 
@@ -123,7 +123,7 @@ async def test_deploy_by_revision_validate_flags(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_local_bundle_include_file(event_loop):
+async def test_deploy_local_bundle_include_file():
     bundle_dir = INTEGRATION_TEST_DIR / 'bundle'
     bundle_yaml_path = bundle_dir / 'bundle-include-file.yaml'
 
@@ -140,7 +140,7 @@ async def test_deploy_local_bundle_include_file(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_local_bundle_include_base64(event_loop):
+async def test_deploy_local_bundle_include_base64():
     bundle_dir = INTEGRATION_TEST_DIR / 'bundle'
     bundle_yaml_path = bundle_dir / 'bundle-include-base64.yaml'
 
@@ -156,7 +156,7 @@ async def test_deploy_local_bundle_include_base64(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_bundle_local_charms(event_loop):
+async def test_deploy_bundle_local_charms():
     bundle_path = INTEGRATION_TEST_DIR / 'bundle' / 'local.yaml'
 
     async with base.CleanModel() as model:
@@ -171,7 +171,7 @@ async def test_deploy_bundle_local_charms(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_bundle_local_charm_series_manifest(event_loop):
+async def test_deploy_bundle_local_charm_series_manifest():
     bundle_path = TESTS_DIR / 'integration' / 'bundle' / 'local-manifest.yaml'
 
     async with base.CleanModel() as model:
@@ -184,7 +184,7 @@ async def test_deploy_bundle_local_charm_series_manifest(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_invalid_bundle(event_loop):
+async def test_deploy_invalid_bundle():
     pytest.skip('test_deploy_invalid_bundle intermittent test failure')
     bundle_path = TESTS_DIR / 'bundle' / 'invalid.yaml'
     async with base.CleanModel() as model:
@@ -194,7 +194,7 @@ async def test_deploy_invalid_bundle(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_local_charm(event_loop):
+async def test_deploy_local_charm():
     charm_path = TESTS_DIR / 'charm'
 
     async with base.CleanModel() as model:
@@ -206,14 +206,14 @@ async def test_deploy_local_charm(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_charm_assumes(event_loop):
+async def test_deploy_charm_assumes():
     async with base.CleanModel() as model:
         await model.deploy('postgresql', channel='14/edge')
 
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_local_charm_channel(event_loop):
+async def test_deploy_local_charm_channel():
     charm_path = TESTS_DIR / 'charm'
 
     async with base.CleanModel() as model:
@@ -225,7 +225,7 @@ async def test_deploy_local_charm_channel(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_wait_local_charm_blocked(event_loop):
+async def test_wait_local_charm_blocked():
     charm_path = TESTS_DIR / 'charm'
 
     async with base.CleanModel() as model:
@@ -240,7 +240,7 @@ async def test_wait_local_charm_blocked(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_wait_local_charm_waiting_timeout(event_loop):
+async def test_wait_local_charm_waiting_timeout():
     charm_path = TESTS_DIR / 'charm'
 
     async with base.CleanModel() as model:
@@ -253,7 +253,7 @@ async def test_wait_local_charm_waiting_timeout(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_bundle(event_loop):
+async def test_deploy_bundle():
     async with base.CleanModel() as model:
         await model.deploy('anbox-cloud-core', channel='stable',
                            trust=True)
@@ -264,7 +264,7 @@ async def test_deploy_bundle(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_local_bundle_with_overlay_multi(event_loop):
+async def test_deploy_local_bundle_with_overlay_multi():
     async with base.CleanModel() as model:
         bundle_with_overlay_path = OVERLAYS_DIR / 'bundle-with-overlay-multi.yaml'
         await model.deploy(bundle_with_overlay_path)
@@ -277,7 +277,7 @@ async def test_deploy_local_bundle_with_overlay_multi(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_bundle_with_overlay_as_argument(event_loop):
+async def test_deploy_bundle_with_overlay_as_argument():
     async with base.CleanModel() as model:
         overlay_path = OVERLAYS_DIR / 'test-overlay.yaml'
 
@@ -298,7 +298,7 @@ async def test_deploy_bundle_with_overlay_as_argument(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_bundle_with_multi_overlay_as_argument(event_loop):
+async def test_deploy_bundle_with_multi_overlay_as_argument():
     async with base.CleanModel() as model:
         overlay_path = OVERLAYS_DIR / 'test-multi-overlay.yaml'
 
@@ -310,7 +310,7 @@ async def test_deploy_bundle_with_multi_overlay_as_argument(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_bundle_with_multiple_overlays_with_include_files(event_loop):
+async def test_deploy_bundle_with_multiple_overlays_with_include_files():
     async with base.CleanModel() as model:
         bundle_yaml_path = TESTS_DIR / 'integration' / 'bundle' / 'bundle.yaml'
         overlay1_path = OVERLAYS_DIR / 'test-overlay2.yaml'
@@ -326,7 +326,7 @@ async def test_deploy_bundle_with_multiple_overlays_with_include_files(event_loo
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_local_charm_folder_symlink(event_loop):
+async def test_deploy_local_charm_folder_symlink():
     charm_path = TESTS_DIR / 'charm-folder-symlink'
 
     async with base.CleanModel() as model:
@@ -343,7 +343,7 @@ async def test_deploy_local_charm_folder_symlink(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_trusted_bundle(event_loop):
+async def test_deploy_trusted_bundle():
     pytest.skip("skip until we have a deployable bundle available. Right now the landscape-dense fails because postgresql is broken")
     async with base.CleanModel() as model:
         await model.deploy('landscape-dense', channel='stable', trust=True)
@@ -358,7 +358,7 @@ async def test_deploy_trusted_bundle(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_channels_revs(event_loop):
+async def test_deploy_channels_revs():
     pytest.skip('Revise to use local charms - shouldnt fail b/c of origin')
     async with base.CleanModel() as model:
         charm = 'cs:~johnsca/libjuju-test'
@@ -375,7 +375,7 @@ async def test_deploy_channels_revs(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_from_ch_with_series(event_loop):
+async def test_deploy_from_ch_with_series():
     charm = 'ch:ubuntu'
     for series in ['xenial', 'bionic', 'focal']:
         async with base.CleanModel() as model:
@@ -386,7 +386,7 @@ async def test_deploy_from_ch_with_series(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_deploy_from_ch_with_invalid_series(event_loop):
+async def test_deploy_from_ch_with_invalid_series():
     async with base.CleanModel() as model:
         charm = 'ch:ubuntu'
         try:
@@ -398,7 +398,7 @@ async def test_deploy_from_ch_with_invalid_series(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_add_machine(event_loop):
+async def test_add_machine():
     from juju.machine import Machine
 
     async with base.CleanModel() as model:
@@ -436,7 +436,7 @@ async def test_add_machine(event_loop):
         assert len(model.machines) == 0
 
 
-async def add_manual_machine_ssh(event_loop, is_root=False):
+async def add_manual_machine_ssh(is_root=False):
 
     # Verify controller is localhost
     async with base.CleanController() as controller:
@@ -582,25 +582,25 @@ async def add_manual_machine_ssh(event_loop, is_root=False):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_add_manual_machine_ssh(event_loop):
+async def test_add_manual_machine_ssh():
     """Test manual machine provisioning with a non-root user
 
     Tests manual machine provisioning using a randomized username with sudo access.
     """
-    await add_manual_machine_ssh(event_loop, is_root=False)
+    await add_manual_machine_ssh(is_root=False)
 
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_add_manual_machine_ssh_root(event_loop):
+async def test_add_manual_machine_ssh_root():
     """Test manual machine provisioning with the root user"""
 
-    await add_manual_machine_ssh(event_loop, is_root=True)
+    await add_manual_machine_ssh(is_root=True)
 
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_relate(event_loop):
+async def test_relate():
     from juju.relation import Relation
 
     async with base.CleanModel() as model:
@@ -627,7 +627,7 @@ async def test_relate(event_loop):
                 if set(new.key.split()) == {'nrpe:general-info',
                                             'ubuntu:juju-info'}:
                     relation_added.set()
-                    event_loop.call_later(10, timeout.set)
+                    jasyncio.get_running_loop().call_later(10, timeout.set)
 
         model.add_observer(TestObserver())
 
@@ -665,7 +665,7 @@ async def _deploy_in_loop(new_loop, model_name, jujudata):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_explicit_loop_threaded(event_loop):
+async def test_explicit_loop_threaded():
     async with base.CleanModel() as model:
         model_name = model.info.name
         new_loop = jasyncio.new_event_loop()
@@ -682,7 +682,7 @@ async def test_explicit_loop_threaded(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_store_resources_charm(event_loop):
+async def test_store_resources_charm():
     pytest.skip('Revise: test_store_resources_charm intermittent test failure')
     async with base.CleanModel() as model:
         ghost = await model.deploy('ghost', channel='stable')
@@ -701,7 +701,7 @@ async def test_store_resources_charm(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_local_oci_image_resource_charm(event_loop):
+async def test_local_oci_image_resource_charm():
     charm_path = TESTS_DIR / 'integration' / 'oci-image-charm'
     async with base.CleanModel() as model:
         resources = {"oci-image": "ubuntu/latest"}
@@ -719,7 +719,7 @@ async def test_local_oci_image_resource_charm(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_local_file_resource_charm(event_loop):
+async def test_local_file_resource_charm():
     charm_path = INTEGRATION_TEST_DIR / 'file-resource-charm'
     async with base.CleanModel() as model:
         resources = {"file-res": "test.file"}
@@ -736,7 +736,7 @@ async def test_local_file_resource_charm(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_attach_resource(event_loop):
+async def test_attach_resource():
     charm_path = TESTS_DIR / 'integration' / 'file-resource-charm'
     async with base.CleanModel() as model:
         resources = {"file-res": "test.file"}
@@ -755,7 +755,7 @@ async def test_attach_resource(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_store_resources_bundle(event_loop):
+async def test_store_resources_bundle():
     pytest.skip('test_store_resources_bundle intermittent test failure')
     async with base.CleanModel() as model:
         bundle = INTEGRATION_TEST_DIR / 'bundle'
@@ -777,7 +777,7 @@ async def test_store_resources_bundle(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_store_resources_bundle_revs(event_loop):
+async def test_store_resources_bundle_revs():
     pytest.skip('test_store_resources_bundle_revs intermittent test failure')
     async with base.CleanModel() as model:
         bundle = INTEGRATION_TEST_DIR / 'bundle/bundle-resource-rev.yaml'
@@ -799,7 +799,7 @@ async def test_store_resources_bundle_revs(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_ssh_key(event_loop):
+async def test_ssh_key():
     async with base.CleanModel() as model:
         await model.add_ssh_key('admin', SSH_KEY)
         result = await model.get_ssh_key(True)
@@ -813,7 +813,7 @@ async def test_ssh_key(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_get_machines(event_loop):
+async def test_get_machines():
     async with base.CleanModel() as model:
         result = await model.get_machines()
         assert isinstance(result, list)
@@ -822,7 +822,7 @@ async def test_get_machines(event_loop):
 @base.bootstrapped
 @pytest.mark.asyncio
 @pytest.mark.wait_for_idle
-async def test_wait_for_idle_without_units(event_loop):
+async def test_wait_for_idle_without_units():
     async with base.CleanModel() as model:
         await model.deploy(
             'ubuntu',
@@ -837,7 +837,7 @@ async def test_wait_for_idle_without_units(event_loop):
 @base.bootstrapped
 @pytest.mark.asyncio
 @pytest.mark.wait_for_idle
-async def test_wait_for_idle_with_not_enough_units(event_loop):
+async def test_wait_for_idle_with_not_enough_units():
     async with base.CleanModel() as model:
         await model.deploy(
             'ubuntu',
@@ -852,7 +852,7 @@ async def test_wait_for_idle_with_not_enough_units(event_loop):
 @base.bootstrapped
 @pytest.mark.asyncio
 @pytest.mark.wait_for_idle
-async def test_wait_for_idle_more_units_than_needed(event_loop):
+async def test_wait_for_idle_more_units_than_needed():
     async with base.CleanModel() as model:
         charm_path = TESTS_DIR / 'charm'
 
@@ -875,7 +875,7 @@ async def test_wait_for_idle_more_units_than_needed(event_loop):
 @base.bootstrapped
 @pytest.mark.asyncio
 @pytest.mark.wait_for_idle
-async def test_wait_for_idle_with_enough_units(event_loop):
+async def test_wait_for_idle_with_enough_units():
     async with base.CleanModel() as model:
         await model.deploy(
             'ubuntu',
@@ -889,7 +889,7 @@ async def test_wait_for_idle_with_enough_units(event_loop):
 @base.bootstrapped
 @pytest.mark.asyncio
 @pytest.mark.wait_for_idle
-async def test_wait_for_idle_with_exact_units(event_loop):
+async def test_wait_for_idle_with_exact_units():
     async with base.CleanModel() as model:
         await model.deploy(
             'ubuntu',
@@ -903,7 +903,7 @@ async def test_wait_for_idle_with_exact_units(event_loop):
 @base.bootstrapped
 @pytest.mark.asyncio
 @pytest.mark.wait_for_idle
-async def test_wait_for_idle_with_exact_units_scale_down(event_loop):
+async def test_wait_for_idle_with_exact_units_scale_down():
     """Deploys 3 units, waits for them to be idle, then removes 2 of them,
     then waits for exactly 1 unit to be left.
 
@@ -931,7 +931,7 @@ async def test_wait_for_idle_with_exact_units_scale_down(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_watcher_reconnect(event_loop):
+async def test_watcher_reconnect():
     async with base.CleanModel() as model:
         await model.connection().close()
         await block_until(model.is_connected, timeout=3)
@@ -939,7 +939,7 @@ async def test_watcher_reconnect(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_config(event_loop):
+async def test_config():
     async with base.CleanModel() as model:
         # first test get_config with nothing.
         result = await model.get_config()
@@ -956,7 +956,7 @@ async def test_config(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_config_with_json(event_loop):
+async def test_config_with_json():
     async with base.CleanModel() as model:
         # first test get_config with nothing.
         result = await model.get_config()
@@ -976,7 +976,7 @@ async def test_config_with_json(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_set_constraints(event_loop):
+async def test_set_constraints():
     async with base.CleanModel() as model:
         await model.set_constraints({'cpu-power': 1})
         cons = await model.get_constraints()
@@ -984,7 +984,7 @@ async def test_set_constraints(event_loop):
 
 # @base.bootstrapped
 # @pytest.mark.asyncio
-# async def test_grant(event_loop)
+# async def test_grant()
 #    async with base.CleanController() as controller:
 #        await controller.add_user('test-model-grant')
 #        await controller.grant('test-model-grant', 'superuser')
@@ -997,7 +997,7 @@ async def test_set_constraints(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_model_annotations(event_loop):
+async def test_model_annotations():
 
     async with base.CleanModel() as model:
         annotations = await model.get_annotations()
@@ -1012,7 +1012,7 @@ async def test_model_annotations(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_machine_annotations(event_loop):
+async def test_machine_annotations():
 
     async with base.CleanModel() as model:
         machine = await model.add_machine()
@@ -1029,7 +1029,7 @@ async def test_machine_annotations(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_application_annotations(event_loop):
+async def test_application_annotations():
 
     async with base.CleanModel() as model:
         app = await model.deploy('ubuntu', channel="stable")
@@ -1046,7 +1046,7 @@ async def test_application_annotations(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_unit_annotations(event_loop):
+async def test_unit_annotations():
 
     async with base.CleanModel() as model:
         app = await model.deploy('ubuntu', channel="stable")
@@ -1064,7 +1064,7 @@ async def test_unit_annotations(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_backups(event_loop):
+async def test_backups():
     pytest.skip('Revise: mongodb issues')
     m = Model()
     await m.connect(model_name='controller')
@@ -1091,7 +1091,7 @@ async def test_backups(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_connect_to_connection(event_loop):
+async def test_connect_to_connection():
     async with base.CleanModel() as test_model:
         # get the connection from test_model
         conn = test_model.connection()
@@ -1114,7 +1114,7 @@ async def test_connect_to_connection(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_model_cache_update(event_loop):
+async def test_model_cache_update():
     """Connecting to a new model shouldn't fail because the cache is not
     updated yet
 

--- a/tests/integration/test_unit.py
+++ b/tests/integration/test_unit.py
@@ -13,7 +13,7 @@ from .. import base
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_block_coroutine(event_loop):
+async def test_block_coroutine():
     async with base.CleanModel() as model:
         app = await model.deploy(
             'ch:ubuntu',
@@ -37,7 +37,7 @@ async def test_block_coroutine(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_unit_public_address(event_loop):
+async def test_unit_public_address():
     async with base.CleanModel() as model:
         app = await model.deploy(
             'ch:ubuntu',
@@ -70,7 +70,7 @@ async def test_unit_public_address(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_run(event_loop):
+async def test_run():
     from juju.action import Action
 
     async with base.CleanModel() as model:
@@ -102,7 +102,7 @@ async def test_run(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_run_action(event_loop):
+async def test_run_action():
     pytest.skip("This test takes so long that it fails in Github.")
 
     async def run_action(unit):
@@ -134,7 +134,7 @@ async def test_run_action(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_scp(event_loop):
+async def test_scp():
     # ensure that asyncio.subprocess will work;
     try:
         asyncio.get_child_watcher().attach_loop(jasyncio.get_running_loop())
@@ -168,7 +168,7 @@ async def test_scp(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_ssh(event_loop):
+async def test_ssh():
     # ensure that asyncio.subprocess will work;
     try:
         asyncio.get_child_watcher().attach_loop(jasyncio.get_running_loop())
@@ -196,7 +196,7 @@ async def test_ssh(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_resolve_local(event_loop):
+async def test_resolve_local():
     charm_file = Path(__file__).absolute().parent / 'charm.charm'
 
     async with base.CleanModel() as model:
@@ -221,7 +221,7 @@ async def test_resolve_local(event_loop):
 
 @base.bootstrapped
 @pytest.mark.asyncio
-async def test_subordinate_units(event_loop):
+async def test_subordinate_units():
     async with base.CleanModel() as model:
         u_app = await model.deploy('ubuntu')
         n_app = await model.deploy('ntp')

--- a/tests/integration/test_unit.py
+++ b/tests/integration/test_unit.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 import pytest
 
-from juju import utils
+from juju import utils, jasyncio
 
 from .. import base
 
@@ -137,7 +137,7 @@ async def test_run_action(event_loop):
 async def test_scp(event_loop):
     # ensure that asyncio.subprocess will work;
     try:
-        asyncio.get_child_watcher().attach_loop(event_loop)
+        asyncio.get_child_watcher().attach_loop(jasyncio.get_running_loop())
     except RuntimeError:
         pytest.skip('test_scp will always fail outside of MainThread')
     async with base.CleanModel() as model:
@@ -171,7 +171,7 @@ async def test_scp(event_loop):
 async def test_ssh(event_loop):
     # ensure that asyncio.subprocess will work;
     try:
-        asyncio.get_child_watcher().attach_loop(event_loop)
+        asyncio.get_child_watcher().attach_loop(jasyncio.get_running_loop())
     except RuntimeError:
         pytest.skip('test_ssh will always fail outside of MainThread')
     async with base.CleanModel() as model:

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -174,7 +174,7 @@ class TestAddApplicationChange(unittest.TestCase):
 class TestAddApplicationChangeRun:
 
     @pytest.mark.asyncio
-    async def test_run_with_charmstore_charm(self, event_loop):
+    async def test_run_with_charmstore_charm(self):
         change = AddApplicationChange(1, [], params={"charm": "cs:charm",
                                                      "series": "series",
                                                      "application": "application",
@@ -228,7 +228,7 @@ class TestAddApplicationChangeRun:
         model._deploy.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_run_with_charmstore_charm_no_channel(self, event_loop):
+    async def test_run_with_charmstore_charm_no_channel(self):
         """Test to verify if when the given channel is None, the channel defaults to "stable", which
             is the default channel value for the Chart Store
         """
@@ -286,7 +286,7 @@ class TestAddApplicationChangeRun:
         model._deploy.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_run_with_charmhub_charm(self, event_loop):
+    async def test_run_with_charmhub_charm(self):
         change = AddApplicationChange(1, [], params={"charm": "charm",
                                                      "series": "series",
                                                      "application": "application",
@@ -334,7 +334,7 @@ class TestAddApplicationChangeRun:
                                          num_units="num_units")
 
     @pytest.mark.asyncio
-    async def test_run_with_charmhub_charm_no_channel(self, event_loop):
+    async def test_run_with_charmhub_charm_no_channel(self):
         """Test to verify if when the given channel is None, the channel defaults to "local/stable", which
             is the default channel value for the Charm Hub
         """
@@ -386,7 +386,7 @@ class TestAddApplicationChangeRun:
                                          num_units="num_units")
 
     @pytest.mark.asyncio
-    async def test_run_local(self, event_loop):
+    async def test_run_local(self):
         change = AddApplicationChange(1, [], params={"charm": "local:charm",
                                                      "series": "series",
                                                      "application": "application",
@@ -425,7 +425,7 @@ class TestAddApplicationChangeRun:
                                          charm_origin=ANY)
 
     @pytest.mark.asyncio
-    async def test_run_no_series(self, event_loop):
+    async def test_run_no_series(self):
         change = AddApplicationChange(1, [], params={"charm": "cs:charm1",
                                                      "series": "",
                                                      "application": "application",
@@ -531,7 +531,7 @@ class TestAddCharmChange(unittest.TestCase):
 class TestAddCharmChangeRun:
 
     @pytest.mark.asyncio
-    async def test_run(self, event_loop):
+    async def test_run(self):
         change = AddCharmChange(1, [], params={"charm": "cs:charm",
                                                "series": "series",
                                                "channel": "channel"})
@@ -607,7 +607,7 @@ class TestAddMachineChange(unittest.TestCase):
 class TestAddMachineChangeRun:
 
     @pytest.mark.asyncio
-    async def test_run(self, event_loop):
+    async def test_run(self):
         change = AddMachineChange(1, [], params={"series": "series",
                                                  "constraints": "cores=1",
                                                  "container-type": "container_type",
@@ -664,7 +664,7 @@ class TestAddRelationChange(unittest.TestCase):
 class TestAddRelationChangeRun:
 
     @pytest.mark.asyncio
-    async def test_run(self, event_loop):
+    async def test_run(self):
         change = AddRelationChange(1, [], params={"endpoint1": "endpoint1",
                                                   "endpoint2": "endpoint2"})
 
@@ -736,7 +736,7 @@ class MockModel:
 class TestAddUnitChangeRun:
 
     @pytest.mark.asyncio
-    async def test_run(self, event_loop):
+    async def test_run(self):
         change = AddUnitChange(1, [], params={"application": "application",
                                               "to": "to"})
 
@@ -793,7 +793,7 @@ class TestCreateOfferChange(unittest.TestCase):
 class TestCreateOfferChangeRun:
 
     @pytest.mark.asyncio
-    async def test_run(self, event_loop):
+    async def test_run(self):
         change = CreateOfferChange(1, [], params={"application": "application",
                                                   "endpoints": ["endpoints"],
                                                   "offer-name": "offer_name"})
@@ -845,7 +845,7 @@ class TestConsumeOfferChange(unittest.TestCase):
 class TestConsumeOfferChangeRun:
 
     @pytest.mark.asyncio
-    async def test_run(self, event_loop):
+    async def test_run(self):
         change = ConsumeOfferChange(1, [], params={"url": "url",
                                                    "application-name": "application_name"})
 
@@ -923,7 +923,7 @@ class TestExposeChange(unittest.TestCase):
 class TestExposeChangeRun:
 
     @pytest.mark.asyncio
-    async def test_run(self, event_loop):
+    async def test_run(self):
         params = {
             "application": "application",
             "exposed-endpoints": {
@@ -995,7 +995,7 @@ class TestScaleChange(unittest.TestCase):
 class TestScaleChangeRun:
 
     @pytest.mark.asyncio
-    async def test_run(self, event_loop):
+    async def test_run(self):
         change = ScaleChange(1, [], params={"application": "application",
                                             "scale": 1})
 
@@ -1051,7 +1051,7 @@ class TestSetAnnotationsChange(unittest.TestCase):
 class TestSetAnnotationsChangeRun:
 
     @pytest.mark.asyncio
-    async def test_run(self, event_loop):
+    async def test_run(self):
         change = SetAnnotationsChange(1, [], params={"id": "id",
                                                      "entity-type": "entity_type",
                                                      "annotations": "annotations"})
@@ -1078,7 +1078,7 @@ class TestSetAnnotationsChangeRun:
 
 class TestBundleHandler:
     @pytest.mark.asyncio
-    async def test_fetch_plan_local_k8s_bundle(self, event_loop):
+    async def test_fetch_plan_local_k8s_bundle(self):
         class AsyncMock(mock.MagicMock):
             async def __call__(self, *args, **kwargs):
                 return super(AsyncMock, self).__call__(*args, **kwargs)


### PR DESCRIPTION
#### Description

*\<Please add why this change is needed and what it does.\>*
Fix for #1028 
The logger is not passed to calls of `utils.run_with_interupt` from model.py and controller.py. The default value is `None`, so when it is later used we get the error. 
*\<Fixes:  \>*


#### QA Steps
Added a `raise Exception("my random exception")` to the `Next` method of `ModelSummeryWatcherFacade`. This is hit by the `run_with_interupt` in controller and we can observe that when we run the file `modelsummaries.py`, if the log arguments added in this PR are not there then we get the None Type error and if they are there, we do not.

Jira: JUJU-5610