### PR TITLE
Fix multiline description in textarea in bug template GH workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/BugReport.yml
+++ b/.github/ISSUE_TEMPLATE/BugReport.yml
@@ -50,7 +50,7 @@ body:
       label: "Reproduce / Test"
       description: "Please add valid Python code to reproduce the bug. This will be used as a test for QAing later on.
 
-      Please provide a simplified reproducer, and if it's possible please refrain from providing a "clone this repository and run the integration tests to see the problem" type of a reproducer. Thanks!"
+        Please provide a simplified reproducer, and if it's possible please refrain from providing a 'clone this repository and run the integration tests to see the problem' type of a reproducer. Thanks!"
       render: python
     validations:
       required: true


### PR DESCRIPTION
#### Description

Fixes the bug in the bug template yml. Apparently the indentation + the quotes in the message caused the yml parser to interpret the line as a new field and barf.

#### QA Steps

No functional changes. Just updating the bug template. 

I tried to put the yaml in an [online validator](https://jsonformatter.org/yaml-validator/) and was able to see the same parsing issue. The issue went away after I applied the changes here and revalidated. Maybe that would help QA it as well.