### PR TITLE
add missing "revision" parameter to addModel step.

### DIFF
--- a/juju/bundle.py
+++ b/juju/bundle.py
@@ -659,6 +659,7 @@ class AddCharmChange(ChangeInfo):
     _toPy = {'charm': 'charm',
              'series': 'series',
              'channel': 'channel',
+             'revision': 'revision',
              'architecture': 'architecture'}
 
     """AddCharmChange holds a change for adding a charm to the environment.
@@ -675,6 +676,7 @@ class AddCharmChange(ChangeInfo):
         :series: series of the charm to be added if the charm default is
            not sufficient.
         :channel: preferred channel for obtaining the charm.
+        :revision: specified revision of the charm to be added if specified.
     """
     @staticmethod
     def method():
@@ -710,6 +712,7 @@ class AddCharmChange(ChangeInfo):
                                         architecture=arch,
                                         risk=ch.risk,
                                         track=ch.track,
+                                        revision=self.revision,
                                         base=base)
             identifier, origin = await context.model._resolve_charm(url, origin)
 

--- a/tests/integration/bundle/bundle-with-charm-revision.yaml
+++ b/tests/integration/bundle/bundle-with-charm-revision.yaml
@@ -2,6 +2,6 @@ applications:
   hello-juju:
     charm: "hello-juju"
     channel: latest/stable
-    revision: 8
+    revision: 7
     num_units: 1
     series: focal

--- a/tests/integration/bundle/bundle-with-charm-revision.yaml
+++ b/tests/integration/bundle/bundle-with-charm-revision.yaml
@@ -1,0 +1,7 @@
+applications:
+  hello-juju:
+    charm: "hello-juju"
+    channel: latest/stable
+    revision: 8
+    num_units: 1
+    series: focal

--- a/tests/integration/bundle/bundle-with-charm-revision.yaml
+++ b/tests/integration/bundle/bundle-with-charm-revision.yaml
@@ -4,4 +4,3 @@ applications:
     channel: latest/stable
     revision: 7
     num_units: 1
-    series: focal

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -1,6 +1,7 @@
 # Copyright 2023 Canonical Ltd.
 # Licensed under the Apache V2, see LICENCE file for details.
 
+
 import json
 import os
 import random
@@ -10,31 +11,18 @@ import uuid
 
 import mock
 import paramiko
+
 import pylxd
 import pytest
-
 from juju import jasyncio, tag, url
-from juju.application import Application
 from juju.client import client
 from juju.client._definitions import FullStatus
-from juju.errors import (
-    JujuConnectionError,
-    JujuError,
-    JujuModelError,
-    JujuUnitError
-)
+from juju.errors import JujuError, JujuModelError, JujuUnitError, JujuConnectionError
 from juju.model import Model, ModelObserver
-from juju.utils import (
-    base_channel_to_series,
-    block_until,
-    run_with_interrupt,
-    wait_for_bundle
-)
+from juju.utils import block_until, run_with_interrupt, wait_for_bundle, base_channel_to_series
 
 from .. import base
-from ..utils import (GB, INTEGRATION_TEST_DIR, MB, OVERLAYS_DIR, SSH_KEY,
-                     TESTS_DIR)
-
+from ..utils import MB, GB, TESTS_DIR, OVERLAYS_DIR, SSH_KEY, INTEGRATION_TEST_DIR
 
 @base.bootstrapped
 async def test_model_name():

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -17,11 +17,19 @@ from juju import jasyncio, tag, url
 from juju.application import Application
 from juju.client import client
 from juju.client._definitions import FullStatus
-from juju.errors import (JujuConnectionError, JujuError, JujuModelError,
-                         JujuUnitError)
+from juju.errors import (
+    JujuConnectionError,
+    JujuError,
+    JujuModelError,
+    JujuUnitError
+)
 from juju.model import Model, ModelObserver
-from juju.utils import (base_channel_to_series, block_until,
-                        run_with_interrupt, wait_for_bundle)
+from juju.utils import (
+    base_channel_to_series,
+    block_until,
+    run_with_interrupt,
+    wait_for_bundle
+)
 
 from .. import base
 from ..utils import (GB, INTEGRATION_TEST_DIR, MB, OVERLAYS_DIR, SSH_KEY,

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -195,7 +195,7 @@ async def test_deploy_bundle_with_pinned_charm_revision():
     async with base.CleanModel() as model:
         await model.deploy(str(bundle_yaml_path))
 
-        application: Application = model.applications.get('hello-juju', None)
+        application = model.applications.get('hello-juju', None)
         status: FullStatus = await model.get_status([application.name])
         # the 'charm' field of application status should be of this format:
         # ch:amd64/{series}/{name}-{revision}

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -189,7 +189,7 @@ async def test_deploy_bundle_with_pinned_charm_revision():
     bundle_yaml_path = bundle_dir / 'bundle-with-charm-revision.yaml'
     # Revision of the hello-juju charm defined in the bundle yaml
     # We can also read the yaml to get the revision but we are hard-coding it for now for simplicity
-    pinned_revision = 8
+    pinned_revision = 7
 
     async with base.CleanModel() as model:
         await model.deploy(str(bundle_yaml_path))

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -188,7 +188,7 @@ async def test_deploy_bundle_with_pinned_charm_revision():
     bundle_dir = INTEGRATION_TEST_DIR / 'bundle-with-charm-revision.yaml'
     bundle_yaml_path = bundle_dir / 'bundle-include-file.yaml'
     # Revision of the hello-juju charm defined in the bundle yaml
-    # We can also read the yaml to get the revision but wr're hard-coding it for now for simplicity
+    # We can also read the yaml to get the revision but we are hard-coding it for now for simplicity
     pinned_revision = 8
 
     async with base.CleanModel() as model:

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -1,7 +1,6 @@
 # Copyright 2023 Canonical Ltd.
 # Licensed under the Apache V2, see LICENCE file for details.
 
-
 import json
 import os
 import random

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -24,6 +24,7 @@ from juju.utils import block_until, run_with_interrupt, wait_for_bundle, base_ch
 from .. import base
 from ..utils import MB, GB, TESTS_DIR, OVERLAYS_DIR, SSH_KEY, INTEGRATION_TEST_DIR
 
+
 @base.bootstrapped
 async def test_model_name():
     model = Model()

--- a/tests/unit/test_bundle.py
+++ b/tests/unit/test_bundle.py
@@ -312,12 +312,14 @@ class TestAddCharmChange(unittest.TestCase):
         change = AddCharmChange(1, [], params={"charm": "charm",
                                                "series": "series",
                                                "channel": "channel",
+                                               "revision": "revision",
                                                "architecture": "architecture"})
         self.assertEqual({"change_id": 1,
                           "requires": [],
                           "charm": "charm",
                           "series": "series",
                           "channel": "channel",
+                          "revision": "revision",
                           "architecture": "architecture"}, change.__dict__)
 
     def test_dict_params_missing_data(self):
@@ -328,6 +330,7 @@ class TestAddCharmChange(unittest.TestCase):
                           "charm": "charm",
                           "series": "series",
                           "channel": None,
+                          "revision": None,
                           "architecture": None}, change.__dict__)
 
 


### PR DESCRIPTION
#### Description

Fixes #1042.

When deploying a bundle, although the plan is properly generated with the correct revision for the charms in the bundle, and the change steps are generated with the correct parameter. I believe that the `addCharm` step does not take into account the specified "revision" of the charm to deploy, as a result the revision deployed is the latest revision instead of the specified revision. ref: https://github.com/juju/python-libjuju/blob/5ed5ae461514feb84dc0f96c2e46b6fab9f35861/juju/bundle.py#L709-L713

This PR simply adds the missing parameter to the `AddCharmChange` step and propagate the value to `client.CharmOrigin` to add the correct revision.

#### QA Steps
1. Create a bundle containing one or more charms with revision
2. Deploy the bundle with `model.deploy`
3. The deployed charms in the bundle should have the revision specified in the bundle.

- [x] Code style: imports ordered, good names, simple structure, etc
- [x] Comments saying why design decisions were made
- [x] Go unit tests, with comments saying what you're testing
- [x] [Integration tests](https://github.com/juju/juju/tree/main/tests), with comments saying what you're testing
- ~~[doc.go](https://discourse.charmhub.io/t/readme-in-packages/451) added or updated in changed package~~ (I think this is too small of a change to warrant a doc update)