### PR TITLE
Fix issue with microk8s proxy

### DIFF
--- a/juju/client/proxy/kubernetes/proxy.py
+++ b/juju/client/proxy/kubernetes/proxy.py
@@ -1,6 +1,6 @@
 # Copyright 2023 Canonical Ltd.
 # Licensed under the Apache V2, see LICENCE file for details.
-
+import os
 import tempfile
 
 from juju.client.proxy.proxy import Proxy, ProxyNotConnectedError
@@ -33,7 +33,7 @@ class KubernetesProxy(Proxy):
             raise ValueError("Invalid port number: {}".format(remote_port))
 
         if ca_cert:
-            self.temp_ca_file = tempfile.NamedTemporaryFile()
+            self.temp_ca_file = tempfile.NamedTemporaryFile(delete=False)
             self.temp_ca_file.write(bytes(ca_cert, 'utf-8'))
             self.temp_ca_file.flush()
             config.ssl_ca_cert = self.temp_ca_file.name
@@ -60,6 +60,7 @@ class KubernetesProxy(Proxy):
 
     def __del__(self):
         self.close()
+        os.unlink(self.temp_ca_file.name)
 
     def close(self):
         try:

--- a/juju/client/proxy/kubernetes/proxy.py
+++ b/juju/client/proxy/kubernetes/proxy.py
@@ -2,10 +2,13 @@
 # Licensed under the Apache V2, see LICENCE file for details.
 import os
 import tempfile
+import logging
 
 from juju.client.proxy.proxy import Proxy, ProxyNotConnectedError
 from kubernetes import client
 from kubernetes.stream import portforward
+
+log = logging.getLogger('juju.client.connection')
 
 
 class KubernetesProxy(Proxy):
@@ -60,7 +63,10 @@ class KubernetesProxy(Proxy):
 
     def __del__(self):
         self.close()
-        os.unlink(self.temp_ca_file.name)
+        try:
+            os.unlink(self.temp_ca_file.name)
+        except FileNotFoundError:
+            log.debug(f"file {self.temp_ca_file.name} not found")
 
     def close(self):
         try:


### PR DESCRIPTION
The temporary file used to store the ca_cert was set to delete itself on close. This meant that when it was accessed multiple times it would no longer be present.

Set to not delete on close and to remove file when the proxy is deleted.

#### QA Steps
```
juju bootstrap microk8s
juju add-model default
juju deploy cos-lite
```
In python
```
from juju import model
m = model.Model()
await m.connect()
await m.create_offer("grafana:grafana-dashboard", "grafana-dashboards")
await m.disconnect()
```
Check all resource in /tmp have been cleaned up


Fixes #1040 