### PR TITLE
Fix deploy bundle tests

### DIFF
--- a/tests/bundle/bundle.yaml
+++ b/tests/bundle/bundle.yaml
@@ -1,12 +1,9 @@
 series: jammy
 applications:
-  grafana:
-    charm: "grafana"
-    channel: stable
+  juju-qa-test:
+    charm: "juju-qa-test"
     num_units: 1
-  prometheus:
-    charm: "prometheus"
-    channel: stable
-    num_units: 1
+  nrpe:
+    charm: "nrpe"
 relations:
-  - ["prometheus:grafana-source", "grafana:grafana-source"]
+  - ["nrpe:general-info", "juju-qa-test:juju-info"]

--- a/tests/bundle/mini-bundle.yaml
+++ b/tests/bundle/mini-bundle.yaml
@@ -1,12 +1,9 @@
 series: jammy
 applications:
-  grafana:
-    charm: "grafana"
-    channel: stable
+  juju-qa-test:
+    charm: "juju-qa-test"
     num_units: 1
-  prometheus:
-    charm: "prometheus"
-    channel: stable
-    num_units: 1
+  nrpe:
+    charm: "nrpe"
 relations:
-  - ["prometheus:grafana-source", "grafana:grafana-source"]
+  - ["nrpe:general-info", "juju-qa-test:juju-info"]

--- a/tests/integration/bundle/bundle.yaml
+++ b/tests/integration/bundle/bundle.yaml
@@ -1,14 +1,11 @@
 series: jammy
 applications:
-  grafana:
-    charm: "grafana"
-    channel: stable
+  juju-qa-test:
+    charm: "juju-qa-test"
     num_units: 1
-  prometheus:
-    charm: "prometheus"
-    channel: stable
-    num_units: 1
+  nrpe:
+    charm: "nrpe"
   test:
     charm: "./tests/integration/charm"
 relations:
-  - ["prometheus:grafana-source", "grafana:grafana-source"]
+  - ["nrpe:general-info", "juju-qa-test:juju-info"]

--- a/tests/integration/bundle/test-overlays/test-multi-overlay.yaml
+++ b/tests/integration/bundle/test-overlays/test-multi-overlay.yaml
@@ -1,6 +1,6 @@
 description: An overlay for test multi-overlay
 applications:
-  ntp:
+  nrpe:
   memcached:
     charm: "memcached"
     channel: stable
@@ -10,6 +10,6 @@ description: Another overlay for test multi-overlay
 applications:
   memcached:
   mysql:
-    charm: "prometheus"
-    channel: stable
-    num_units: 1
+    charm: "mysql"
+    channel: candidate
+    num_units: 1  

--- a/tests/integration/bundle/test-overlays/test-overlay.yaml
+++ b/tests/integration/bundle/test-overlays/test-overlay.yaml
@@ -1,11 +1,7 @@
 description: An overlay for tests
 applications:
-  ntp:
-  ghost:
-    charm: "prometheus"
-    channel: stable
-    num_units: 1
+  nrpe:
   mysql:
-    charm: "prometheus"
-    channel: stable
-    num_units: 1
+    charm: "mysql"
+    channel: candidate
+    num_units: 1  

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -45,8 +45,8 @@ async def test_deploy_local_bundle_dir():
     async with base.CleanModel() as model:
         await model.deploy(str(bundle_path))
 
-        app1 = model.applications.get('grafana')
-        app2 = model.applications.get('prometheus')
+        app1 = model.applications.get('juju-qa-test')
+        app2 = model.applications.get('nrpe')
         with open("/tmp/output", "w") as writer:
             writer.write(str(bundle_path) + "\n")
             for (k, v) in model.applications.items():
@@ -66,8 +66,8 @@ async def test_deploy_local_bundle_file():
     async with base.CleanModel() as model:
         await model.deploy(str(mini_bundle_file_path))
 
-        app1 = model.applications.get('grafana')
-        app2 = model.applications.get('prometheus')
+        app1 = model.applications.get('juju-qa-test')
+        app2 = model.applications.get('nrpe')
         assert app1 and app2
         await model.block_until(lambda: (len(app1.units) == 1 and
                                 len(app2.units) == 1),
@@ -272,7 +272,6 @@ async def test_deploy_local_bundle_with_overlay_multi():
         # this bundle deploys mysql and ghost apps and relates them,
         # but the overlay attached removes ghost, so
         assert 'mysql' in model.applications
-        assert 'ghost' not in model.applications
 
 
 @base.bootstrapped
@@ -280,19 +279,14 @@ async def test_deploy_local_bundle_with_overlay_multi():
 async def test_deploy_bundle_with_overlay_as_argument():
     async with base.CleanModel() as model:
         overlay_path = OVERLAYS_DIR / 'test-overlay.yaml'
+        bundle_path = TESTS_DIR / "bundle" / "bundle.yaml"
 
-        await model.deploy('juju-qa-bundle-test', overlays=[overlay_path])
-        # juju-qa-bundle-test installs the applications
-        #   - juju-qa-test
-        #   - juju-qa-test-focal
-        #   - ntp
-        #   - ntp-focal
+        await model.deploy(bundle_path, overlays=[overlay_path])
 
-        # our overlay requests to remove ntp and add ghost and mysql
+        # our overlay requests to remove ntp and add mysql
         # and relate them, so
         assert 'juju-qa-test' in model.applications
-        assert 'ntp' not in model.applications
-        assert 'ghost' in model.applications
+        assert 'nrpe' not in model.applications
         assert 'mysql' in model.applications
 
 
@@ -301,9 +295,12 @@ async def test_deploy_bundle_with_overlay_as_argument():
 async def test_deploy_bundle_with_multi_overlay_as_argument():
     async with base.CleanModel() as model:
         overlay_path = OVERLAYS_DIR / 'test-multi-overlay.yaml'
+        bundle_path = TESTS_DIR / "bundle" / "bundle.yaml"
 
-        await model.deploy('juju-qa-bundle-test', overlays=[overlay_path])
-        assert 'ntp' not in model.applications
+        await model.deploy(bundle_path, overlays=[overlay_path])
+
+        assert 'juju-qa-test' in model.applications
+        assert 'nrpe' not in model.applications
         assert 'memcached' not in model.applications
         assert 'mysql' in model.applications
 
@@ -321,7 +318,7 @@ async def test_deploy_bundle_with_multiple_overlays_with_include_files():
         assert 'influxdb' not in model.applications
         assert 'test' not in model.applications
         assert 'memcached' not in model.applications
-        assert 'grafana' in model.applications
+        assert 'juju-qa-test' in model.applications
 
 
 @base.bootstrapped


### PR DESCRIPTION
#### Description

It turns out a number of our test bundles were invalid, something only caught out by stricter param validating by juju controllers in 2.9.47

Fix these bundles + overlays to be valid

#### QA Steps

All CI tests need to pass.
