### PR TITLE
Add user api to pylibjuju documentation

### DIFF
--- a/docs/api/juju.user.rst
+++ b/docs/api/juju.user.rst
@@ -1,0 +1,13 @@
+juju.user
+==========
+
+.. rubric:: Summary
+
+.. automembersummary:: juju.user
+
+.. rubric:: Reference
+
+.. automodule:: juju.user
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -23,6 +23,7 @@ If you need helpers to manage the asyncio loop, try :doc:`juju.loop`.
     juju.relation
     juju.tag
     juju.unit
+    juju.user
     juju.utils
 
 .. automodule:: juju


### PR DESCRIPTION
#### Description

Apparently we don't have the user api in [pylibjuju documentation](https://pythonlibjuju.readthedocs.io/en/latest/api/modules.html). This adds `juju.user` module to the Sphinx build for the User api to be auto generated among all the other modules.


#### QA Steps

No functionality changes. Watch the doc build and make sure the `juju.user` page is within the Public API section, containing docstrings for all the functions in `juju.user` module.

You can also locally test this, get the changes, and run `make docs`, and check the `docs/_build/api` and make sure you have the `juju.user.html` generated.
