### PR TITLE
fix zones constrains list parsing

### DIFF
--- a/juju/constraints.py
+++ b/juju/constraints.py
@@ -54,7 +54,7 @@ SUPPORTED_KEYS = [
     "zones",
     "allocate_public_ip"]
 
-LIST_KEYS = {'tags', 'spaces'}
+LIST_KEYS = {'tags', 'spaces', 'zones'}
 
 SNAKE1 = re.compile(r'(.)([A-Z][a-z]+)')
 SNAKE2 = re.compile('([a-z0-9])([A-Z])')

--- a/tests/unit/test_constraints.py
+++ b/tests/unit/test_constraints.py
@@ -60,7 +60,7 @@ class TestConstraints(unittest.TestCase):
         self.assertEqual(
             _("mem=10G zones=bar,baz tags=tag1 spaces=space1,space2"),
             {"mem": 10 * 1024,
-             "zones": "bar,baz",
+             "zones": ["bar", "baz"],
              "tags": ["tag1"],
              "spaces": ["space1", "space2"]}
         )


### PR DESCRIPTION
#### Description

Closes #1050. This fixes the parsing of the `zones` constraint in bundles. The format in the Juju API is defined in: https://github.com/juju/juju/blob/3.6/core/constraints/constraints.go#L107.

#### QA Steps

The following python script can be used to verify both the bug in the current version as well as the fix implemented:

```python
import asyncio
from juju.model import Model

bundle_file = "./bundle.yaml"

bundle = """
name: sample-bundle

series: jammy

machines:
  "0":
    constraints: zones=z-1

applications:
  postgresql:
    charm: postgresql
    channel: 14/stable
    num_units: 1
    to:
      - lxd:0
"""

async def main():
    with open(bundle_file, "w") as f:
        f.write(bundle)

    model = Model()
    await model.connect()
    await model.deploy(bundle_file)

asyncio.run(main())
```

All CI tests need to pass.