### PR TITLE
fix parsing of storage constraints

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -29,6 +29,7 @@ from .charmhub import CharmHub
 from .client import client, connector
 from .client.overrides import Caveat, Macaroon
 from .constraints import parse as parse_constraints
+from .constraints import parse_storage_constraint
 from .controller import Controller, ConnectedController
 from .delta import get_entity_class, get_entity_delta
 from .errors import JujuAPIError, JujuError, JujuModelConfigError, JujuBackupError
@@ -2115,7 +2116,7 @@ class Model:
                 devices=devices,
                 dryrun=False,
                 placement=placement,
-                storage=storage,
+                storage={k: parse_storage_constraint(v) for k, v in (storage or dict()).items()},
                 trust=trust,
                 base=charm_origin.base,
                 channel=channel,
@@ -2150,7 +2151,7 @@ class Model:
                 endpoint_bindings=endpoint_bindings,
                 num_units=num_units,
                 resources=resources,
-                storage=storage,
+                storage={k: parse_storage_constraint(v) for k, v in (storage or dict()).items()},
                 placement=placement,
                 devices=devices,
                 attach_storage=attach_storage,

--- a/tests/integration/bundle/bundle-with-storage-constraint.yaml
+++ b/tests/integration/bundle/bundle-with-storage-constraint.yaml
@@ -1,0 +1,11 @@
+name: bundle-with-storage-constraint
+
+series: jammy
+
+applications:
+  postgresql:
+    charm: postgresql
+    num_units: 1
+    channel: 14/stable
+    storage:
+      pgdata: lxd,8G

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -210,6 +210,7 @@ async def test_deploy_invalid_bundle():
         with pytest.raises(JujuError):
             await model.deploy(str(bundle_path))
 
+
 @base.bootstrapped
 @pytest.mark.bundle
 async def test_deploy_bundle_with_storage_constraint():

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -210,6 +210,17 @@ async def test_deploy_invalid_bundle():
         with pytest.raises(JujuError):
             await model.deploy(str(bundle_path))
 
+@base.bootstrapped
+@pytest.mark.bundle
+async def test_deploy_bundle_with_storage_constraint():
+    bundle_path = INTEGRATION_TEST_DIR / 'bundle' / 'bundle-with-storage-constraint.yaml'
+
+    async with base.CleanModel() as model:
+        await model.deploy(bundle_path)
+        await wait_for_bundle(model, bundle_path)
+        storage = await model.list_storage()
+        assert len(storage) == 1
+
 
 @base.bootstrapped
 async def test_deploy_local_charm():


### PR DESCRIPTION
#### Description

Fixes: #1052. Parses the storage constraints when deploying applications. Before this change the storage constraints where not parsing, resulting in an error when deploying bundles that contained applications with storage definitions.

#### QA Steps

The following python script can be used to verify both the bug in the current version as well as the fix implemented:

```python
import asyncio
from juju.model import Model

bundle_file = "./bundle.yaml"

bundle = """
name: sample-bundle

series: jammy

machines:
  "0":
    constraints: instance-type=type1

applications:
  swift-storage:
    charm: swift-storage
    channel: yoga/stable
    num_units: 1
    to:
      - "0"
    storage:
      block-devices: cinder,1,5G
"""

async def main():
    with open(bundle_file, "w") as f:
        f.write(bundle)

    model = Model()
    await model.connect()
    await model.deploy(bundle_file)

asyncio.run(main())
```

All CI tests need to pass.

#### Notes & Discussion

I wasn't able to add a regression test for this fix since the `juju-qa-test` charm does not support the addition of storage devices. With that said, I'm open to suggestions on how to test this behavior to make sure it's correct and that it stays that way on future changes.