### PR TITLE
Release notes for 3.5.0.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,19 @@
 Changelog
 ---------
 
+3.5.0.0
+^^^^^^^
+
+Thursday 30th May 2024
+
+## What's Changed
+
+* Make consume respect the controller name in the url by @Aflynn50 in https://github.com/juju/python-libjuju/pull/1038
+* Fix multiline description in textarea in bug template GH workflow by @cderici in https://github.com/juju/python-libjuju/pull/1041
+* Fix issue with microk8s proxy by @Aflynn50 in https://github.com/juju/python-libjuju/pull/1044
+* add missing "revision" parameter to addModel step. by @Thanhphan1147 in https://github.com/juju/python-libjuju/pull/1043
+* Add user api to pylibjuju documentation by @cderici in https://github.com/juju/python-libjuju/pull/1049
+
 3.4.0.0
 ^^^^^^^
 

--- a/juju/version.py
+++ b/juju/version.py
@@ -5,4 +5,4 @@ LTS_RELEASES = ["jammy", "focal", "bionic", "xenial", "trusty", "precise"]
 
 DEFAULT_ARCHITECTURE = 'amd64'
 
-CLIENT_VERSION = "3.4.0.0"
+CLIENT_VERSION = "3.5.0.0"


### PR DESCRIPTION
## What's Changed
* Make consume respect the controller name in the url by @Aflynn50 in https://github.com/juju/python-libjuju/pull/1038
* Fix multiline description in textarea in bug template GH workflow by @cderici in https://github.com/juju/python-libjuju/pull/1041
* Fix issue with microk8s proxy by @Aflynn50 in https://github.com/juju/python-libjuju/pull/1044
* add missing "revision" parameter to addModel step. by @Thanhphan1147 in https://github.com/juju/python-libjuju/pull/1043
* Add user api to pylibjuju documentation by @cderici in https://github.com/juju/python-libjuju/pull/1049

## New Contributors
* @Thanhphan1147 made their first contribution in https://github.com/juju/python-libjuju/pull/1043

**Full Changelog**: https://github.com/juju/python-libjuju/compare/3.4.0.0...3.5.0.0
