### PR TITLE
fix(series): add noble support

### DIFF
--- a/juju/utils.py
+++ b/juju/utils.py
@@ -301,6 +301,7 @@ JAMMY = "jammy"
 KINETIC = "kinetic"
 LUNAR = "lunar"
 MANTIC = "mantic"
+NOBLE = "noble"
 
 UBUNTU_SERIES = {
     PRECISE: "12.04",
@@ -327,6 +328,7 @@ UBUNTU_SERIES = {
     KINETIC: "22.10",
     LUNAR: "23.04",
     MANTIC: "23.10",
+    NOBLE: "24.04",
 }
 
 KUBERNETES = "kubernetes"

--- a/tests/integration/charm-manifest/manifest.yaml
+++ b/tests/integration/charm-manifest/manifest.yaml
@@ -9,5 +9,9 @@ bases:
   - amd64
   channel: '20.04'
   name: ubuntu
+- architectures:
+  - amd64
+  channel: '24.04'
+  name: ubuntu
 charmcraft-started-at: '2021-08-20T08:09:00.639806Z'
 charmcraft-version: 1.2.1

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -438,6 +438,15 @@ async def test_deploy_with_base():
 
 
 @base.bootstrapped
+async def test_deploy_noble():
+    charm_path = INTEGRATION_TEST_DIR / 'charm-manifest'
+
+    async with base.CleanModel() as model:
+        await model.deploy(str(charm_path), base="ubuntu@24.04")
+        await model.wait_for_idle(status='active')
+
+
+@base.bootstrapped
 async def test_add_machine():
     from juju.machine import Machine
 


### PR DESCRIPTION
The pylibjuju client hardcodes a mapping between series codename and the base channel.

Noble was absent from this mapping, meaning pylibjuju doesn't know know to deploy to noble.

Add noble to this mapping.

After noble, we will only support deploying by base. Noble will be the last series added to this map

Fixes: https://github.com/juju/python-libjuju/issues/1062

#### QA Steps

Download a local charm `juju download ubuntu`, unzip, and amend the `manifest,yaml` to support ubuntu@24.04

Place the charm dir at `./ubuntu`

You will see 
```
$ cat ./ubuntu/manifest.yaml
bases:
- architectures:
  - amd64
  channel: '20.04'
  name: ubuntu
- architectures:
  - amd64
  channel: '22.04'
  name: ubuntu
- architectures:
  - amd64
  channel: '24.04'
  name: ubuntu
```

Then:
```
$ juju bootstrap lxd lxd
$ juju add-model
$ python -m asyncio
>>> from juju.model import Model
>>> m = Model()
>>> await m.connect()
>>> await m.deploy("./ubuntu", series="noble")
<Application entity_id="ubuntu">
>>> exit
(wait)
$ juju status
 Model  Controller  Cloud/Region         Version      SLA          Timestamp
m      lxd         localhost/localhost  3.6-beta1.1  unsupported  12:03:15+01:00

App     Version  Status  Scale  Charm   Channel  Rev  Exposed  Message
ubuntu  24.04    active      1  ubuntu             0  no       

Unit       Workload  Agent  Machine  Public address  Ports  Message
ubuntu/0*  active    idle   0        10.219.211.77          

Machine  State    Address        Inst id        Base          AZ  Message
0        started  10.219.211.77  juju-742671-0  ubuntu@24.04      Running
```

All CI tests need to pass.