### PR TITLE
fix(model): fix wrong instanciation of list-secrets facade

### DIFF
--- a/juju/model.py
+++ b/juju/model.py
@@ -2704,15 +2704,15 @@ class Model:
         if result_error.error is not None:
             raise JujuAPIError(result_error.error)
 
-    async def list_secrets(self, filter="", show_secrets=False):
+    async def list_secrets(self, filter=None, show_secrets=False):
         """
         Returns the list of available secrets.
         """
         facade = client.SecretsFacade.from_connection(self.connection())
-        results = await facade.ListSecrets({
-            'filter': filter,
-            'show-secrets': show_secrets,
-        })
+        results = await facade.ListSecrets(
+            filter_=filter,
+            show_secrets=show_secrets,
+        )
         return results.results
 
     async def remove_secret(self, secret_name, revision=-1):


### PR DESCRIPTION

#### Description

ListSecrets facade takes 2 arguments: `filter_`, and `show_secrets`. Previous instanciation passed a dict, which then landed in `filter_` field.

Fixes: #947


#### QA Steps

*\<Commands / tests / steps to run to verify that the change works:\>*

await f.ListSecrets(filter_={"uri": <secret_id>}, show_secrets=True)

All CI tests need to pass.

*\<Please note that most likely an additional test will be required by the reviewers for any change that's not a one liner to land.\>*

#### Notes & Discussion

*\<Additional notes for the reviewers if needed. Please delete section if not applicable.\>*