### PR TITLE
fix(refresh): bug with revisions

### DIFF
--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -288,6 +288,18 @@ async def test_local_refresh():
 
 @base.bootstrapped
 @pytest.mark.asyncio
+async def test_refresh_revision():
+    async with base.CleanModel() as model:
+        app = await model.deploy('juju-qa-test', channel="latest/stable", revision=23)
+        # NOTE: juju-qa-test revision 26 has been released to this channel
+        await app.refresh(revision=25)
+
+        charm_url = URL.parse(app.data['charm-url'])
+        assert charm_url.revision == 25
+
+
+@base.bootstrapped
+@pytest.mark.asyncio
 async def test_trusted():
     async with base.CleanModel() as model:
         await model.deploy('ubuntu', trust=True)


### PR DESCRIPTION
#### Description

We are incorrectly refreshing charms. The current method queries the controller for the charm's current origin and charm url

In pylibjuju, we then just overwrite the appropriate fields. However, this leaves behind id_ and hash_

This means when we later refresh, we are always returned the most recent revision by charmhub, no matter what revision we specify.

The way we handle this in the Juju CLI is by reconstructing the charm origin using MakeOrigin:
https://github.com/juju/juju/blob/a03ade4d358b1b0f135374b15b1bcd6b46d0ba0f/cmd/juju/application/utils/origin.go#L20-L75

This ensures only the fields we expect are present.

Do something similar in pylibjuju, ensuring we behave the same as the CLI.

Fixes: https://github.com/juju/python-libjuju/issues/1057

#### QA Steps

Unit tests
```
tox -e unit
```

Integration tests
```
tox -e integration -- tests/integration/test_application.py::test_refresh_revision
```

Manual tests
```
$ juju bootstrap lxd lxd
$ juju add-model m
$ juju deploy opensearch --revision 90 --channel=2/edge
$ python -m asyncio
>>> from juju.model import Model
>>> m = Model()
>>> await m.connect()
>>> app = m.applicatyions["opensearch"]
>>> await app.refresh(revision=91)
>>> exit()
$ juju status
Model  Controller  Cloud/Region         Version    SLA          Timestamp
m      lxd1        localhost/localhost  3.6-beta1  unsupported  13:32:44+01:00

App         Version  Status       Scale  Charm       Channel  Rev  Exposed  Message
opensearch           maintenance      1  opensearch  2/edge    91  no       Installing OpenSearch...

Unit           Workload     Agent      Machine  Public address  Ports  Message
opensearch/0*  maintenance  executing  0        10.219.211.254         (install) Installing OpenSearch...

Machine  State    Address         Inst id        Base          AZ  Message
0        started  10.219.211.254  juju-56bc09-0  ubuntu@22.04      Running
```