### PR TITLE
fix(makefile): run .tox before lint in makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,11 @@ client:
 	$(PY) -m juju.client.facade -s "juju/client/schemas*" -o juju/client/
 
 .PHONY: run-unit-tests
-run-unit-tests: lint .tox
+run-unit-tests: .tox lint
 	tox -e py3
 
 .PHONY: run-integration-tests
-run-integration-tests: lint .tox
+run-integration-tests: .tox lint
 	tox -e integration
 
 .PHONY: run-all-tests


### PR DESCRIPTION
#### Description

Tests run the linter before running .tox which crashes because tox wants to see the lint environment already generated. This swaps the operations so .tox target is run first to make sure the environments are generated before running anything.

