### PR TITLE
fix(labels): change stalebot exempt labels

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -19,6 +19,6 @@ jobs:
           days-before-pr-close: 5
           stale-issue-label: 'incomplete'
           stale-pr-label: 'incomplete'
-          exempt-issue-labels: 'awaiting-approval,work-in-progress,wishlisted'
-          exempt-pr-labels: 'awaiting-approval,work-in-progress'
+          exempt-issue-labels: 'stalebot/disabled,kind/wishlist'
+          exempt-pr-labels: 'stalebot/disabled,state/awaiting-approval'
           remove-stale-when-updated: true


### PR DESCRIPTION
#### Description

Changes the exempt labels for the stalebot:

- use `stalebot/disabled` and `kind/wishlist` for issues
- use `stalebot/disabled` and `state/awaiting-approval` for PRs