### PR TITLE
feat(workflows): update stalebot days and issue template labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/BugReport.yml
+++ b/.github/ISSUE_TEMPLATE/BugReport.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Something's not working right in python-libjuju? Use this template.
-labels: [bug]
+labels: [kind/bug]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/FeatureRequest.yml
+++ b/.github/ISSUE_TEMPLATE/FeatureRequest.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: You want something to be added to python-libjuju? Proceed with this one.
-labels: [wishlisted]
+labels: [kind/wishlist]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -13,12 +13,12 @@ jobs:
           stale-pr-message: 'This PR is marked as incomplete because it has been open 30 days with no activity. Please remove incomplete label or comment or this will be closed in 5 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
           close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
-          days-before-issue-stale: 30
-          days-before-pr-stale: 30
-          days-before-issue-close: 5
-          days-before-pr-close: 5
-          stale-issue-label: 'incomplete'
-          stale-pr-label: 'incomplete'
+          days-before-issue-stale: 60
+          days-before-pr-stale: 60
+          days-before-issue-close: 15
+          days-before-pr-close: 15
+          stale-issue-label: 'state/incomplete'
+          stale-pr-label: 'state/incomplete'
           exempt-issue-labels: 'awaiting-approval,work-in-progress,wishlisted'
           exempt-pr-labels: 'awaiting-approval,work-in-progress'
           remove-stale-when-updated: true


### PR DESCRIPTION
#### Description

This updates the days after which the stalebot considers an issue or a PR to be decaying to: 60 days for stale, 15 days for closing issue/pr if not updated.

This also fixes the labels used in the bug report and feature request issue templates. bug -> kind/bug, wishlisted --> kind/wishlist.