### PR TITLE
Fixing cookie based authentication

### DIFF
--- a/juju/client/connector.py
+++ b/juju/client/connector.py
@@ -65,6 +65,8 @@ class Connector:
         """
         kwargs.setdefault('max_frame_size', self.max_frame_size)
         kwargs.setdefault('bakery_client', self.bakery_client)
+        kwargs.setdefault('cookie_domain', self.jujudata.cookie_domain_for_controller(endpoint=kwargs.get("endpoints")))
+
         account = kwargs.pop('account', {})
         # Prioritize the username and password that user provided
         # If not enough, try to patch it with info from accounts.yaml
@@ -73,18 +75,19 @@ class Connector:
         if 'password' not in kwargs and account.get('password'):
             kwargs.update(password=account.get('password'))
 
-        if 'macaroons' in kwargs:
-            if not kwargs['bakery_client']:
-                kwargs['bakery_client'] = httpbakery.Client()
-            if not kwargs['bakery_client'].cookies:
-                kwargs['bakery_client'].cookies = GoCookieJar()
-            jar = kwargs['bakery_client'].cookies
-            for macaroon in kwargs.pop('macaroons'):
-                jar.set_cookie(go_to_py_cookie(macaroon))
-        else:
-            if not ({'username', 'password'}.issubset(kwargs)):
-                required = {'username', 'password'}.difference(kwargs)
-                raise ValueError(f'Some authentication parameters are required : {",".join(required)}')
+        if not kwargs["bakery_client"]:
+            if 'macaroons' in kwargs:
+                if not kwargs['bakery_client']:
+                    kwargs['bakery_client'] = httpbakery.Client()
+                if not kwargs['bakery_client'].cookies:
+                    kwargs['bakery_client'].cookies = GoCookieJar()
+                jar = kwargs['bakery_client'].cookies
+                for macaroon in kwargs.pop('macaroons'):
+                    jar.set_cookie(go_to_py_cookie(macaroon))
+            else:
+                if not ({'username', 'password'}.issubset(kwargs)):
+                    required = {'username', 'password'}.difference(kwargs)
+                    raise ValueError(f'Some authentication parameters are required : {",".join(required)}')
 
         if 'debug_log_conn' in kwargs:
             assert self._connection

--- a/juju/client/connector.py
+++ b/juju/client/connector.py
@@ -63,17 +63,30 @@ class Connector:
 
         kwargs are passed through to Connection.connect()
         """
-        kwargs.setdefault("max_frame_size", self.max_frame_size)
-        kwargs.setdefault("bakery_client", self.bakery_client)
-        if "macaroons" in kwargs:
-            if not kwargs["bakery_client"]:
-                kwargs["bakery_client"] = httpbakery.Client()
-            if not kwargs["bakery_client"].cookies:
-                kwargs["bakery_client"].cookies = GoCookieJar()
-            jar = kwargs["bakery_client"].cookies
-            for macaroon in kwargs.pop("macaroons"):
+        kwargs.setdefault('max_frame_size', self.max_frame_size)
+        kwargs.setdefault('bakery_client', self.bakery_client)
+        account = kwargs.pop('account', {})
+        # Prioritize the username and password that user provided
+        # If not enough, try to patch it with info from accounts.yaml
+        if 'username' not in kwargs and account.get('user'):
+            kwargs.update(username=account.get('user'))
+        if 'password' not in kwargs and account.get('password'):
+            kwargs.update(password=account.get('password'))
+
+        if 'macaroons' in kwargs:
+            if not kwargs['bakery_client']:
+                kwargs['bakery_client'] = httpbakery.Client()
+            if not kwargs['bakery_client'].cookies:
+                kwargs['bakery_client'].cookies = GoCookieJar()
+            jar = kwargs['bakery_client'].cookies
+            for macaroon in kwargs.pop('macaroons'):
                 jar.set_cookie(go_to_py_cookie(macaroon))
-        if "debug_log_conn" in kwargs:
+        else:
+            if not ({'username', 'password'}.issubset(kwargs)):
+                required = {'username', 'password'}.difference(kwargs)
+                raise ValueError(f'Some authentication parameters are required : {",".join(required)}')
+
+        if 'debug_log_conn' in kwargs:
             assert self._connection
             self._log_connection = await Connection.connect(**kwargs)
         else:
@@ -85,18 +98,6 @@ class Connector:
             # connected to.
             if self._connection:
                 await self._connection.close()
-
-            account = kwargs.pop('account', {})
-            # Prioritize the username and password that user provided
-            # If not enough, try to patch it with info from accounts.yaml
-            if 'username' not in kwargs and account.get('user'):
-                kwargs.update(username=account.get('user'))
-            if 'password' not in kwargs and account.get('password'):
-                kwargs.update(password=account.get('password'))
-
-            if not ({'username', 'password'}.issubset(kwargs)):
-                required = {'username', 'password'}.difference(kwargs)
-                raise ValueError(f'Some authentication parameters are required : {",".join(required)}')
             self._connection = await Connection.connect(**kwargs)
 
         # Check if we support the target controller

--- a/juju/client/jujudata.py
+++ b/juju/client/jujudata.py
@@ -182,3 +182,28 @@ class FileJujuData(JujuData):
         jar = GoCookieJar(str(f))
         jar.load()
         return jar
+
+    def cookie_domain_for_controller(self, controller_name=None, endpoint=None):
+        '''Returns the correct cookie domain.
+
+        The cookie domain used by the controller is either the
+        field public-hostname in the controllers.yaml file, or the uuid if this is
+        not available. If neither controller_name nor endpoint are specified, assume
+        the current controller.
+
+        :param str controller_name: The name of the controller.
+        :param str endpoint: The endpoint of the controller.
+        '''
+        if all([controller_name, endpoint]):
+            raise ValueError('Specify either controller_name or endpoint, not both')
+        if controller_name:
+            controller = controller_name
+        elif endpoint:
+            controller = self.controller_name_by_endpoint(endpoint)
+        else:
+            controller = self.current_controller()
+
+        controllers = self.controllers()
+        controller_data = controllers.get(controller)
+
+        return controller_data.get('public-hostname', controller_data.get('uuid'))


### PR DESCRIPTION
#### Description

At present, cookie based authentication does not work in pylibjuju. This is due to a number of bugs. This PR intends to fix many of these issues so that pylibjuju can use the juju client's cookies for authentication.

Fixes:
* The library now detects the appropriate cookie domain from jujudata.
* The library now adds correct user tags for external and local users.
* The library now correctly detects when a discharge is required due to third party caveats.
* The library now attempts to use cookies if no password has been provided and cookies are available.
* A subtle implementation difference between juju's cookie jar and `http.cookiejar.DefaultPolicy` was fixed with monkey patching.

I have also cherry picked a commit from @Aflynn50 from a different ongoing PR.

Fixes: #1061 #1081

#### QA Steps

I have had some difficulty with running the tests locally. I am not sure what sort of setup they want to run in.

What I have tested manually is the following:

* Creating connections and logging into controllers with username and password
* Creating connections and logging into controllers with an external user and identity provider using cookies from the juju client.
* Creating connections and logging into controllers with a local user using cookies from the juju client.
* Various commands such as listing models and checking model statuses.

Things I have been unable to test that are affected by this PR:

* Anything to do with proxied controllers.
* Anything to do with controllers with proper certificates (all I have access to are self signed). There is potential for issues with the cookie domain for these since I have not tested whether it works. It might require trivial modifications.
* Juju 2.X

#### Notes & Discussion

The monkey patches in `gocookies.py` are not a good look and they are somewhat brittle, but I believe it will take a lot more work to fix the `CookiePolicy` if we wish to retain all the other sane behaviors from `http.cookiejar.DefaultCookiePolicy`. An alternative is to use an empty `CookiePolicy` and subclass it to only check for domain equality and path. The problem the monkey patch fixes is caused by incompatible cookiejars. The juju client uses https://github.com/juju/persistent-cookiejar which permits domain fields without dots under the condition that the domain matches exactly with the request's host. Python's implementation instead rewrites the request's host by appending ".local", which makes the comparison fail. 

There are still issues with CA certificates when requiring discharges from the juju controller. This is due to intricacies of the HTTP handling in pymacaroonbakery. It may require substantial changes in pymacaroonbakery, but due to a number of bugfixes in this PR it is not essential for most uses (self signed external identity providers are the exception). The lack of a fix does mean that if a user is not logged in on a local user, and tries to connect to the controller, then they will be met with the wrong exception. The intended outcome is to require an interaction to enter a password, but this is not implemented in pymacaroonbakery. In any case, allowing self signed certificates requires either a hack where pylibjuju sets an environment variable and writes a cacert to a temporary file, or making changes in pymacaroonbakery.

