### PR TITLE
chore(cla): add cla check action

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,16 @@
+name: "CLA check"
+on: [pull_request, workflow_dispatch]
+
+permissions:
+  contents: read
+
+jobs:
+  cla-check:
+    permissions:
+      pull-requests: write  # for canonical/has-signed-canonical-cla to create & update comments
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if CLA signed
+        uses: canonical/has-signed-canonical-cla@1.2.3
+        with:
+          accept-existing-contributors: true


### PR DESCRIPTION
#### Description

The cla check verifies that someone contributing to a Canonical project has signed the Canonical CLA agreement

#### QA Steps

CLA github action check runs and is successful