### PR TITLE
fix(connection): wrap reconnect in a task

### DIFF
--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -656,7 +656,7 @@ class Connection:
                 # if it is triggered by the pinger, then this RPC call will
                 # be cancelled when the pinger is cancelled by the reconnect,
                 # and we don't want the reconnect to be aborted halfway through
-                await jasyncio.wait([self.reconnect()])
+                await jasyncio.wait([jasyncio.create_task(self.reconnect())])
                 if self.monitor.status != Monitor.CONNECTED:
                     # reconnect failed; abort and shutdown
                     log.error('RPC: Automatic reconnect failed')


### PR DESCRIPTION
#### Description

Wrap reconnect coroutine in a task. This is due to a breaking change in python stdlib 3.11. Before 3.11 it only emitted a warning.

Fixes: #1102


All places calling asyncio.wait are already wrapping into a task:
https://github.com/juju/python-libjuju/blob/7d2107f882e5f7927001004dc2dac74a286740eb/juju/model.py#L757
https://github.com/juju/python-libjuju/blob/7d2107f882e5f7927001004dc2dac74a286740eb/juju/utils.py#L179
