### PR TITLE
fix(jenkins): pin python kubernetes version to fix recent breakage in tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         'pyasn1>=0.4.4',
         'toposort>=1.5,<2',
         'typing_inspect>=0.6.0',
-        'kubernetes>=12.0.1',
+        'kubernetes>=12.0.1,<31.0.0',
         'hvac',
         'packaging',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ deps =
     pytest-xdist
     Twine
     websockets
-    kubernetes
+    kubernetes<31.0.0
     hvac
     packaging
     setuptools


### PR DESCRIPTION
#### Description

Pin python kubernetes version to fix recent breakage in jenkins tests.

The latest update to the python kubernetes library (v31, 3 days ago) breaks the Jenkins `github-check-merge-juju-python-libjuju` test due to failure to build a new dependency (durationpy).

I thought this might be the fix for issue #1088, but that's been open since August 9. Should we switch to stricter dependency versioning across the board here to avoid breakages of this nature? In setup.py, 4 dependencies now specify both minimum and maximum versions, 5 only specify a minimum, and 2 have no version specification. In tox.ini, only 1 dependency (kubernetes) specifies a (maximum) version. tox.ini should probably have the same version constraints as setup.py.


#### QA Steps

All tests pass, except for integration tests, which are flaky (see issue #1108).