### PR TITLE
fix: Application.local_refresh method signature

### DIFF
--- a/juju/bundle.py
+++ b/juju/bundle.py
@@ -440,7 +440,7 @@ class BundleHandler:
         return reference
 
 
-def is_local_charm(charm_url):
+def is_local_charm(charm_url: str):
     return charm_url.startswith('.') or charm_url.startswith('local:') or os.path.isabs(charm_url)
 
 

--- a/juju/model.py
+++ b/juju/model.py
@@ -2013,8 +2013,8 @@ class Model:
         :param str application: the name of the application
         :param client.CharmURL entity_url: url for the charm that we add resources for
         :param [string]string metadata: metadata for the charm that we add resources for
-        :param [string] resources: the paths for the local files (or oci-images) to be added as
-        local resources
+        :param dict[str, str] resources: the paths for the local files (or oci-images) to
+        be added as local resources
 
         :returns [string]string resource_map that is a map of resources to their assigned
         pendingIDs.

--- a/juju/origin.py
+++ b/juju/origin.py
@@ -69,7 +69,7 @@ class Channel:
         self.risk = risk
 
     @staticmethod
-    def parse(s):
+    def parse(s: str):
         """parse a channel from a given string.
         Parse does not take into account branches.
 

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -280,7 +280,14 @@ async def test_local_refresh():
                                     branch="deadbeef", hash_="hash", id_="id", revision=12,
                                     base=client.Base("20.04", "ubuntu"))
 
-        await app.local_refresh(charm_origin=origin, path=charm_path)
+        await app.local_refresh(
+            charm_origin=origin,
+            force=False,
+            force_series=False,
+            force_units=False,
+            path=charm_path,
+            resources=None,
+        )
 
         assert origin == client.CharmOrigin(source="local", revision=0,
                                             base=client.Base("20.04", "ubuntu"))


### PR DESCRIPTION
Fixes #1100 

Closes #881 

Charmers already pass a Path to refresh() in integration tests.
This PR standardises that.

Making arguments to local_refresh() explicit, as charmer don't get the default values.

Existing integration test is updated.

Jira: https://warthogs.atlassian.net/browse/CHARMTECH-309