### PR TITLE
test: allow running tests on workflow_dispatch

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,6 @@
 name: Testing
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   lint:


### PR DESCRIPTION
To facilitate figuring out which integration tests (in)consistently fail, it would be nice to be able to run them multiple times. Tests are very inconsistent and slow on my (low end) machine, so running them on github seems preferable. To avoid having to push or make pull requests to trigger tests, let's allow them to be run manually via the `workflow_dispatch` event.