### PR TITLE
chore: disable failing integration test

### DIFF
--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -309,7 +309,7 @@ async def test_deploy_local_bundle_with_overlay_multi():
 
 @base.bootstrapped
 @pytest.mark.bundle
-@pytest.mark.xfail("The `ghost` charm is hopelessly out of date")
+@pytest.mark.xfail(reason="The `ghost` charm is hopelessly out of date")
 async def test_deploy_bundle_with_overlay_as_argument():
     async with base.CleanModel() as model:
         overlay_path = OVERLAYS_DIR / 'test-overlay.yaml'

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -309,6 +309,7 @@ async def test_deploy_local_bundle_with_overlay_multi():
 
 @base.bootstrapped
 @pytest.mark.bundle
+@pytest.mark.xfail("The `ghost` charm is hopelessly out of date")
 async def test_deploy_bundle_with_overlay_as_argument():
     async with base.CleanModel() as model:
         overlay_path = OVERLAYS_DIR / 'test-overlay.yaml'


### PR DESCRIPTION
#### Description

This test uses the `ghost` charm:

https://charmhub.io/ghost?channel=latest/edge
https://charmhub.io/ghost

Which has not been updated since 2020 and only supports 16.04 and 14.04 bases.

I think that requires Juju 2.8, doesn't it?

I'll open a separate ticket to update the test.