### PR TITLE
ci: run integration tests serially

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -63,7 +63,7 @@ envdir = {toxworkdir}/py3
 commands =
     pip install urllib3<2
     pip install pylxd
-    python -m pytest --tb native -ra -v -n auto -k 'integration' -m 'not serial' {posargs}
+    python -m pytest --tb native -ra -v -n 1 -k 'integration' -m 'not serial' {posargs}
 
 [testenv:unit]
 envdir = {toxworkdir}/py3


### PR DESCRIPTION
#### Description

Integration tests are incredibly flakey currently. Perhaps this is related to the parallel execution of the tests. Certainly the fact that the tests are randomly distributed across threads doesn't help with figuring out what works and what doesn't.

#### QA Steps

Run integration tests and see.