### PR TITLE
chore: dump gha for node deprecation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,9 +13,9 @@ jobs:
           - "3.10"
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
@@ -34,9 +34,9 @@ jobs:
           - "3.10"
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: Run build test target
@@ -54,9 +54,9 @@ jobs:
           - "3.10"
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
@@ -78,7 +78,7 @@ jobs:
           - "3.10"
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -113,7 +113,7 @@ jobs:
       #     juju model-defaults apt-http-proxy=$PROXY apt-https-proxy=$PROXY  juju-http-proxy=$PROXY juju-https-proxy=$PROXY  snap-http-proxy=$PROXY snap-https-proxy=$PROXY
       #     juju model-defaults
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies

--- a/.github/workflows/test_candidate.yaml
+++ b/.github/workflows/test_candidate.yaml
@@ -47,7 +47,7 @@ jobs:
           echo "next-test=$next_test" >> $GITHUB_ENV
           echo "$next_test" > ~/juju-last-candidate-version
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: ${{ env.next-test != 'NA' }}
       - name: Setup operator environment
         if: ${{ env.next-test != 'NA' }}
@@ -57,7 +57,7 @@ jobs:
           juju-channel: 3.4/candidate
       - name: Setup Python
         if: ${{ env.next-test != 'NA' }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
@@ -69,7 +69,7 @@ jobs:
         run: tox -e integration -- -n 1
       - name: Upload artifact
         if: ${{ env.next-test != 'NA' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: juju-last-candidate-version
           path: ~/juju-last-candidate-version

--- a/.github/workflows/test_edge.yaml
+++ b/.github/workflows/test_edge.yaml
@@ -47,7 +47,7 @@ jobs:
           echo "next-test=$next_test" >> $GITHUB_ENV
           echo "$next_test" > ~/juju-last-edge-version
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: ${{ env.next-test != 'NA' }}
       - name: Setup operator environment
         if: ${{ env.next-test != 'NA' }}
@@ -57,7 +57,7 @@ jobs:
           juju-channel: 3.4/edge
       - name: Setup Python
         if: ${{ env.next-test != 'NA' }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
@@ -69,7 +69,7 @@ jobs:
         run: tox -e integration -- -n 1
       - name: Upload artifact
         if: ${{ env.next-test != 'NA' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: juju-last-edge-version
           path: ~/juju-last-edge-version


### PR DESCRIPTION
Bump the versions of 1st party github actions in CI.

Fixes #1115

Fixes warnings like this: `Linter (3.10) The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3, actions/setup-python@v4. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/`

And this: `Warning actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024. Learn more. Similarly, v1/v2 are scheduled for deprecation on June 30, 2024. Please update your workflow to use v4 of the artifact actions. This deprecation will not impact any existing versions of GitHub Enterprise Server being used by customers.`

Not touching download-artifact as that's sourced from someone's private repo; would have to actually check what changed there.