### PR TITLE
ci: use apt instead of pip to install tox

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
-        run: apt install tox
+        run: sudo apt install tox
       - name: Run linter
         run: |
           tox -e lint
@@ -60,7 +60,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
-        run: apt install tox
+        run: sudo apt install tox
       - name: Run unit tests
         run: tox -e py3
 
@@ -117,7 +117,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
-        run: apt install tox
+        run: sudo apt install tox
       - name: Run integration
         # Force one single concurrent test
         run: tox -e integration
@@ -144,6 +144,6 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
-        run: apt install tox
+        run: sudo apt install tox
       - name: Run integration
         run: tox -e integration-quarantine

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
-        run: pip install tox
+        run: apt install tox
       - name: Run linter
         run: |
           tox -e lint
@@ -60,7 +60,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
-        run: pip install tox
+        run: apt install tox
       - name: Run unit tests
         run: tox -e py3
 
@@ -117,7 +117,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
-        run: pip install tox
+        run: apt install tox
       - name: Run integration
         # Force one single concurrent test
         run: tox -e integration
@@ -144,6 +144,6 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
-        run: pip install tox
+        run: apt install tox
       - name: Run integration
         run: tox -e integration-quarantine

--- a/.github/workflows/test_candidate.yaml
+++ b/.github/workflows/test_candidate.yaml
@@ -62,7 +62,7 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
         if: ${{ env.next-test != 'NA' }}
-        run: pip install tox
+        run: apt install tox
       - name: Run integration
         if: ${{ env.next-test != 'NA' }}
         # Force one single concurrent test

--- a/.github/workflows/test_candidate.yaml
+++ b/.github/workflows/test_candidate.yaml
@@ -62,7 +62,7 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
         if: ${{ env.next-test != 'NA' }}
-        run: apt install tox
+        run: sudo apt install tox
       - name: Run integration
         if: ${{ env.next-test != 'NA' }}
         # Force one single concurrent test

--- a/.github/workflows/test_edge.yaml
+++ b/.github/workflows/test_edge.yaml
@@ -62,7 +62,7 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
         if: ${{ env.next-test != 'NA' }}
-        run: pip install tox
+        run: apt install tox
       - name: Run integration
         if: ${{ env.next-test != 'NA' }}
         # Force one single concurrent test

--- a/.github/workflows/test_edge.yaml
+++ b/.github/workflows/test_edge.yaml
@@ -62,7 +62,7 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install dependencies
         if: ${{ env.next-test != 'NA' }}
-        run: apt install tox
+        run: sudo apt install tox
       - name: Run integration
         if: ${{ env.next-test != 'NA' }}
         # Force one single concurrent test

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 # Tox (http://tox.testrun.org/) is a tool for running tests
 # in multiple virtualenvs. This configuration file will run the
 # test suite on all supported python versions. To use it, "pip install tox"
+# (pre ubuntu 24.04, otherwise consider "apt install tox" or "pipx install tox")
 # and then run "tox" from this directory.
 
 [tox]


### PR DESCRIPTION
#### Description

Github's rollout of 24.04 for ubuntu-latest has now reached python-libjuju, so `pip install tox` no longer works -- 24.04 prevents installing packages using pip.

This PR switches all our `run: pip install tox` lines in github actions to `run: sudo apt install tox`.

#### QA Steps

Tests no longer fail when trying to install tox, as they started doing in the last 12 hours.