### PR TITLE
ci: run setup-python before actions-operator to fix tox install

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -79,6 +79,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
@@ -112,12 +116,6 @@ jobs:
       #     # set model defaults
       #     juju model-defaults apt-http-proxy=$PROXY apt-https-proxy=$PROXY  juju-http-proxy=$PROXY juju-https-proxy=$PROXY  snap-http-proxy=$PROXY snap-https-proxy=$PROXY
       #     juju model-defaults
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Install dependencies
-        run: pip install tox
       - name: Run integration
         # Force one single concurrent test
         run: tox -e integration
@@ -134,16 +132,14 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
           juju-channel: 3.4/stable
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Install dependencies
-        run: pip install tox
       - name: Run integration
         run: tox -e integration-quarantine

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -133,7 +133,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: Setup operator environment

--- a/.github/workflows/test_candidate.yaml
+++ b/.github/workflows/test_candidate.yaml
@@ -49,20 +49,17 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         if: ${{ env.next-test != 'NA' }}
+      - name: Setup Python
+        if: ${{ env.next-test != 'NA' }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
       - name: Setup operator environment
         if: ${{ env.next-test != 'NA' }}
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
           juju-channel: 3.4/candidate
-      - name: Setup Python
-        if: ${{ env.next-test != 'NA' }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Install dependencies
-        if: ${{ env.next-test != 'NA' }}
-        run: pip install tox
       - name: Run integration
         if: ${{ env.next-test != 'NA' }}
         # Force one single concurrent test

--- a/.github/workflows/test_edge.yaml
+++ b/.github/workflows/test_edge.yaml
@@ -49,20 +49,17 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
         if: ${{ env.next-test != 'NA' }}
+      - name: Setup Python
+        if: ${{ env.next-test != 'NA' }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
       - name: Setup operator environment
         if: ${{ env.next-test != 'NA' }}
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
           juju-channel: 3.4/edge
-      - name: Setup Python
-        if: ${{ env.next-test != 'NA' }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Install dependencies
-        if: ${{ env.next-test != 'NA' }}
-        run: pip install tox
       - name: Run integration
         if: ${{ env.next-test != 'NA' }}
         # Force one single concurrent test

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 # Tox (http://tox.testrun.org/) is a tool for running tests
 # in multiple virtualenvs. This configuration file will run the
 # test suite on all supported python versions. To use it, "pip install tox"
+# (pre ubuntu 24.04 -- otherwise consider using pipx or apt instead of pip)
 # and then run "tox" from this directory.
 
 [tox]


### PR DESCRIPTION
#### Description

Github's rollout of `24.04` for `ubuntu-latest` has now reached `python-libjuju`, so `pip install tox` no longer works -- `24.04` prevents installing packages using `pip`. This causes an error in 'Setup operator environment' using `charmed-kubernetes/actions-operator@main`. The fix is to run our 'Setup Python' step using `actions/setup-python` before `actions-operator` instead of after.

Since this takes care of installing `tox`, we can remove `pip install tox` for the jobs using these steps.

Also bump `setup-python` to `v5` for integration-quarantine, matching the recent PR bumping the version for other jobs.

#### QA Steps

Tests no longer fail when trying to install `tox`, as they started doing in the last 12 hours.

#### Notes

Fix documented in charmed-kubernetes/actions-operator [here](https://github.com/charmed-kubernetes/actions-operator/issues/82#issuecomment-2368992683).