### PR TITLE
test: bump series and pin revision for local charm refresh tests

### DIFF
--- a/tests/integration/charm/metadata.yaml
+++ b/tests/integration/charm/metadata.yaml
@@ -1,5 +1,5 @@
 name: charm
-series: ["focal"]
+series: ["jammy"]
 summary: "test"
 description: "test"
 maintainers: ["test"]

--- a/tests/integration/test_application.py
+++ b/tests/integration/test_application.py
@@ -261,11 +261,21 @@ async def test_upgrade_charm_resource_same_rev_no_update():
 async def test_refresh_charmhub_to_local():
     charm_path = INTEGRATION_TEST_DIR / 'charm'
     async with base.CleanModel() as model:
-        app = await model.deploy('ubuntu', application_name='ubu-path')
+        app = await model.deploy(
+            'ubuntu',
+            application_name='ubu-path',
+            channel='stable',
+            revision=24,  # revision 25 requires v2 format for local charm
+        )
         await app.refresh(path=str(charm_path))
         assert app.data['charm-url'].startswith('local:')
 
-        app = await model.deploy('ubuntu', application_name='ubu-switch')
+        app = await model.deploy(
+            'ubuntu',
+            application_name='ubu-switch',
+            channel='stable',
+            revision=24,  # revision 25 requires v2 format for local charm
+        )
         await app.refresh(switch=str(charm_path))
         assert app.data['charm-url'].startswith('local:')
 
@@ -275,7 +285,11 @@ async def test_refresh_charmhub_to_local():
 async def test_local_refresh():
     charm_path = INTEGRATION_TEST_DIR / 'charm'
     async with base.CleanModel() as model:
-        app = await model.deploy('ubuntu')
+        app = await model.deploy(
+            'ubuntu',
+            channel='stable',
+            revision=24,  # revision 25 requires v2 format for local charm
+        )
         origin = client.CharmOrigin(source="charm-hub", track="20.04", risk="stable",
                                     branch="deadbeef", hash_="hash", id_="id", revision=12,
                                     base=client.Base("20.04", "ubuntu"))


### PR DESCRIPTION
#### Description

A recent update to the 'ubuntu' charm requires the use of the v2 metadata format when refreshing from a local charm. The v2 format replaces series with bases, among other changes. Properly supporting this will need to wait on updating python-libjuju to handle bases as well as (or instead of) series -- see issue #1156.

In the meantime, fix the test breakage by pinning the install of 'ubuntu' in broken tests to the previous revision (24). This revision has a mismatch with the specification of the "focal" series (20.04), so also bump the series in the local charm to "jammy".


#### QA Steps

CI tests should now pass again.