### PR TITLE
ci: integration tests against multiple juju versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -188,3 +188,4 @@ jobs:
           juju-channel: ${{ matrix.juju }}
       - name: Run integration
         run: tox -e integration-quarantine
+        continue-on-error: true  # so that other juju versions are tested

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -110,6 +110,7 @@ jobs:
           # * test_ssh
           # * ...
           # - "3.6/beta"
+    continue-on-error: false  # don't ignore if tests against some juju version fail
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -153,6 +154,7 @@ jobs:
       - name: Run integration
         # Force one single concurrent test
         run: tox -e integration
+        continue-on-error: true  # so that other juju versions are tested
 
   integration-quarantine:
     name: Quarantined Integration Tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,10 @@ name: Testing
 
 on: [push, pull_request, workflow_dispatch]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Linter
@@ -98,6 +102,9 @@ jobs:
         juju:
           - "3.1/stable"
           - "3.3/stable"
+          - "3.4/stable"
+          - "3.5/stable"
+          - "3.6/beta"
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -109,7 +116,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
-          juju-channel: 3.4/stable
+          juju-channel: ${{ matrix.juju }}
       # 2023-01-11 Commented until we discover a
       # clear approach for this.
       # - name: Set proxy in controller

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -114,7 +114,7 @@ jobs:
           # * test_ssh
           # * ...
           # - "3.6/beta"
-    continue-on-error: false  # don't ignore if tests against some juju version fail
+    continue-on-error: false  # ultimately fail a run if one of the matrix combinations fails
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -158,7 +158,7 @@ jobs:
       - name: Run integration
         # Force one single concurrent test
         run: tox -e integration
-        continue-on-error: true  # so that other juju versions are tested
+        continue-on-error: true  # don't fail early, let other matrix combinations get tested
 
   integration-quarantine:
     name: Quarantined Integration Tests
@@ -174,6 +174,7 @@ jobs:
           - "3.3/stable"
           - "3.4/stable"
           - "3.5/stable"
+    continue-on-error: false  # ultimately fail the run if one of the matrix combinations fails
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -188,4 +189,4 @@ jobs:
           juju-channel: ${{ matrix.juju }}
       - name: Run integration
         run: tox -e integration-quarantine
-        continue-on-error: true  # so that other juju versions are tested
+        continue-on-error: true  # don't fail early, let other matrix combinations get tested

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -95,6 +95,9 @@ jobs:
           # save some resources for now.
           # - "3.9"
           - "3.10"
+        juju:
+          - "3.1/stable"
+          - "3.3/stable"
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,8 +73,12 @@ jobs:
     strategy:
       matrix:
         python:
+          - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -165,6 +169,11 @@ jobs:
       matrix:
         python:
           - "3.10"
+        juju:
+          - "3.1/stable"
+          - "3.3/stable"
+          - "3.4/stable"
+          - "3.5/stable"
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -176,6 +185,6 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
-          juju-channel: 3.4/stable
+          juju-channel: ${{ matrix.juju }}
       - name: Run integration
         run: tox -e integration-quarantine

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -104,7 +104,12 @@ jobs:
           - "3.3/stable"
           - "3.4/stable"
           - "3.5/stable"
-          - "3.6/beta"
+          # A bunch of tests fail with juju.errors.JujuError: base: ubuntu@15.04/stable
+          # * test_subordinate_units
+          # * test_destroy_unit
+          # * test_ssh
+          # * ...
+          # - "3.6/beta"
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
Integration tests against Juju 3.1, 3.3, 3.4, 3.5 (was: 3.4)
Unit tests against Python 3.8~3.13 (was: 3.9~3.10)

Notes: Juju 3.6 deprecated some bases (?) and many integration tests fail. Given that it's in beta, deferring that to a separate PR.