### PR TITLE
fix: use version sorting in codegen, not lexical

### DIFF
--- a/juju/client/facade.py
+++ b/juju/client/facade.py
@@ -954,18 +954,13 @@ def generate_facades(schemas: Dict[str, List[Schema]]) -> Dict[str, Dict[int, co
 
 def load_schemas(options):
     schemas = {}
-
     for p in sorted(glob(options.schema)):
-        if 'latest' in p:
-            juju_version = 'latest'
-        else:
-            try:
-                juju_version = re.search(JUJU_VERSION, p).group()
-            except AttributeError:
-                print("Cannot extract a juju version from {}".format(p))
-                print("Schemas must include a juju version in the filename")
-                raise SystemExit(1)
-
+        try:
+            juju_version = re.search(JUJU_VERSION, p).group()
+        except AttributeError:
+            print("Cannot extract a juju version from {}".format(p))
+            print("Schemas must include a juju version in the filename")
+            raise SystemExit(1)
         new_schemas = json.loads(Path(p).read_text("utf-8"))
         schemas[juju_version] = [Schema(s) for s in new_schemas]
     return schemas


### PR DESCRIPTION
Cherry-picked from #1168 and simplified.

Rationale Juju micro versions can get larger than 9, e.g. 2.9.51.

When 3.5.10 comes around, we want it to take precedence over 3.5.9 and not get wedged between 3.5.1 and 3.5.2

Keeping the current codegen mode of operation where it starts with the oldest version and whacks some internal state on encountering a latter version.

(We'll deal with that in a separate PR)