### PR TITLE
feat: use base argument instead of series

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,12 +84,7 @@ jobs:
           - "3.3/stable"
           - "3.4/stable"
           - "3.5/stable"
-          # A bunch of tests fail with juju.errors.JujuError: base: ubuntu@15.04/stable
-          # * test_subordinate_units
-          # * test_destroy_unit
-          # * test_ssh
-          # * ...
-          # - "3.6/beta"
+          - "3.6/candidate"
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -149,6 +144,7 @@ jobs:
           - "3.3/stable"
           - "3.4/stable"
           - "3.5/stable"
+          - "3.6/candidate"
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/juju/client/facade_versions.py
+++ b/juju/client/facade_versions.py
@@ -17,7 +17,7 @@ client_facade_versions = {
     "Backups": (3,),
     "Block": (2,),
     "Bundle": (6,),
-    "Charms": (6,),
+    "Charms": (6, 7),
     "Client": (6, 7, 8),
     "Cloud": (7,),
     "Controller": (11, 12),
@@ -45,7 +45,7 @@ client_facade_versions = {
 }
 
 # Manual list of facades present in schemas + codegen which python-libjuju does not yet support
-excluded_facade_versions: Dict[str, Sequence[int]] = {"Charms": (7,)}
+excluded_facade_versions: Dict[str, Sequence[int]] = {}
 
 
 # We don't generate code for these, as we can never use them.

--- a/juju/utils.py
+++ b/juju/utils.py
@@ -516,7 +516,11 @@ def user_requested(series_arg, supported_series, force):
 
 
 def series_selector(
-    series_arg="", charm_url=None, model_config=None, supported_series=[], force=False
+    series_arg: str | None = "",
+    charm_url=None,
+    model_config=None,
+    supported_series=[],
+    force=False,
 ):
     """Select series to deploy on.
 

--- a/juju/version.py
+++ b/juju/version.py
@@ -2,7 +2,22 @@
 # Licensed under the Apache V2, see LICENCE file for details.
 """Client version definitions."""
 
-LTS_RELEASES = ["jammy", "focal", "bionic", "xenial", "trusty", "precise"]
+LTS_RELEASES = ["noble", "jammy", "focal", "bionic", "xenial", "trusty", "precise"]
+
+SERIES_TO_BASE = {
+    "noble": "ubuntu@24.04",
+    "jammy": "ubuntu@22.04",
+    "focal": "ubuntu@20.04",
+    "bionic": "ubuntu@18.04",
+    "xenial": "ubuntu@16.04",
+    "trusty": "ubuntu@14.04",
+    "precise": "ubuntu@12.04",
+    "groovy": "ubuntu@20.10",
+    "disco": "ubuntu@19.04",
+    "cosmic": "ubuntu@18.10",
+    "artful": "ubuntu@17.10",
+    "vivid": "ubuntu@15.04",
+}
 
 DEFAULT_ARCHITECTURE = "amd64"
 


### PR DESCRIPTION
#### Description

- support both 6 and 7 versions of Charms facade.
- deprecate the `series=` argument
- [to do] introduce `base=` argument

#### QA Steps

- [to do] validate using existing integration tests

Fixes #1156