### PR TITLE
chore: restrict websockets library version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         'macaroonbakery>=1.1,<2.0',
         'pyRFC3339>=1.0,<2.0',
         'pyyaml>=5.1.2',
-        'websockets>=8.1',
+        'websockets>=8.1,<14.0',
         'paramiko>=2.4.0',
         'pyasn1>=0.4.4',
         'toposort>=1.5,<2',

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ deps =
     pytest-asyncio
     pytest-xdist
     Twine
-    websockets
+    websockets<14.0
     kubernetes<31.0.0
     hvac
     packaging


### PR DESCRIPTION
#### Description

Restricts the websockets library version to only install releases before 14.0. This is needed since websockets 14 introduces a number of breaking changes that are not compatible with python-libjuju.

Resolves
- #1184

#### QA Steps

```
tox -e integration
```

#### Notes & Discussion

@luissimas said:

I've noticed this problem when my integration tests started failing today without any apparent reason. The version 14.0 of websockets was released yesterday. You can check the changelog at: https://websockets.readthedocs.io/en/stable/project/changelog.html.  It's worth noting that this new version of websockets drops support for Python 3.8.

For the sake of completeness, I was getting this error on my integration tests:

```
 Traceback (most recent call last):
  File "/home/runner/actions-runner/_work/my-charm/my-charm/.tox/integration/lib/python3.10/site-packages/juju/client/connection.py", line 873, in _connect_with_login
    result = (await self.login())['response']
  File "/home/runner/actions-runner/_work/my-charm/my-charm/.tox/integration/lib/python3.10/site-packages/juju/client/connection.py", line 970, in login
    return await self.rpc({
  File "/home/runner/actions-runner/_work/my-charm/my-charm/.tox/integration/lib/python3.10/site-packages/juju/client/connection.py", line 643, in rpc
    if self.monitor.status == Monitor.DISCONNECTED:
  File "/home/runner/actions-runner/_work/my-charm/my-charm/.tox/integration/lib/python3.10/site-packages/juju/client/connection.py", line 224, in status
    if stopped or not connection._ws.open:
AttributeError: 'ClientConnection' object has no attribute 'open'
```