### PR TITLE
chore: reenable testing against 3.6 for Ian

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -114,7 +114,7 @@ jobs:
           # * test_destroy_unit
           # * test_ssh
           # * ...
-          - "3.6/beta"
+          - "3.6/edge"
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -114,7 +114,7 @@ jobs:
           # * test_destroy_unit
           # * test_ssh
           # * ...
-          # - "3.6/beta"
+          - "3.6/beta"
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
@wallyworld feel free to use this branch

I hope that the github actions integration test fails correctly here