### PR TITLE
chore: remove pytest-xdist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ usedevelop=True
 commands =
     pip install urllib3<2
     pip install pylxd
-    python -m pytest --tb native -ra -v -s -n auto -k 'not integration' -m 'not serial' {posargs}
+    python -m pytest --tb native -ra -v -s -k 'not integration' -m 'not serial' {posargs}
 passenv =
     HOME
     TEST_AGENTS
@@ -36,7 +36,6 @@ deps =
     mock
     pytest
     pytest-asyncio
-    pytest-xdist
     Twine
     websockets<14.0
     kubernetes<31.0.0
@@ -60,7 +59,7 @@ commands =
     pip install pylxd
     python -m pytest \
         --tb native \
-        -ra -v -n 1 \
+        -ra -v \
         -k 'integration' \
         --ignore {toxinidir}/tests/integration/test_crossmodel.py \
         --ignore {toxinidir}/tests/integration/test_model.py \
@@ -74,7 +73,7 @@ commands =
     pip install pylxd
     python -m pytest \
         --tb native \
-        -ra -v -n 1 \
+        -ra -v \
         -m 'not serial' \
         {posargs} \
         {toxinidir}/tests/integration/test_crossmodel.py \
@@ -85,7 +84,7 @@ envdir = {toxworkdir}/py3
 commands =
     pip install urllib3<2
     pip install pylxd
-    python -m pytest --tb native -ra -v -n auto {toxinidir}/tests/unit {posargs}
+    python -m pytest --tb native -ra -v {toxinidir}/tests/unit {posargs}
 
 [testenv:serial]
 # tests that can't be run in parallel


### PR DESCRIPTION
pytest-xdist somehow eats live logs.

to test, run something like: `uvx tox -e unit -- --log-cli-level=INFO`