### PR TITLE
Drop use of Monitor._ws.open and Connection._ws.closed

### DIFF
--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -17,6 +17,7 @@ import macaroonbakery.httpbakery as httpbakery
 import websockets
 from dateutil.parser import parse
 from typing_extensions import Self, TypeAlias, overload
+from websockets.protocol import State
 
 from juju import errors, jasyncio, tag, utils
 from juju.client import client
@@ -92,7 +93,7 @@ class Monitor:
                 and connection._receiver_task.cancelled()
             )
 
-        if stopped or not connection._ws.open:
+        if stopped or connection._ws.state is not State.OPEN:
             return self.ERROR
 
         # everything is fine!
@@ -357,7 +358,7 @@ class Connection:
             tasks_need_to_be_gathered.append(self._debug_log_task)
             self._debug_log_task.cancel()
 
-        if self._ws and not self._ws.closed:
+        if self._ws and self._ws.state is not State.CLOSED:
             await self._ws.close()
 
         if not to_reconnect:


### PR DESCRIPTION
The websockets library has dropped the properties "open" and "closed" since websockets-13.0[0], this patch makes the changes needed to check for the connection's state as suggested by the documentation.

[0] https://github.com/python-websockets/websockets/commit/7c8e0b9d6246cd7bdd304f630f719fc55620f89a

Fixes #1207