### PR TITLE
fix: use newer websockets API to check that connection is open

### DIFF
--- a/juju/client/connection.py
+++ b/juju/client/connection.py
@@ -17,6 +17,7 @@ import macaroonbakery.httpbakery as httpbakery
 import websockets
 from dateutil.parser import parse
 from typing_extensions import Self, TypeAlias, overload
+from websockets.protocol import State
 
 from juju import errors, jasyncio, tag, utils
 from juju.client import client
@@ -92,7 +93,7 @@ class Monitor:
                 and connection._receiver_task.cancelled()
             )
 
-        if stopped or not connection._ws.open:
+        if stopped or connection._ws.state is not State.OPEN:
             return self.ERROR
 
         # everything is fine!
@@ -357,8 +358,7 @@ class Connection:
             tasks_need_to_be_gathered.append(self._debug_log_task)
             self._debug_log_task.cancel()
 
-        if self._ws and not self._ws.closed:
-            await self._ws.close()
+        await self._ws.close()
 
         if not to_reconnect:
             try:


### PR DESCRIPTION
Continuing @freyes #1208

I've validated that there's an integration test for this path: `test_monitor_catches_error`

I've checked what websockets versions should be supported: at least 12.0 through 14.1
