### PR TITLE
ci: bring the unit tests back from the dead

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,16 +31,12 @@ jobs:
         python:
           - "3.10"
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Setup Python
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-      - name: Install dependencies
-        run: pip install tox
-      - name: Run validation tests
-        run: tox -e validate
+      - uses: astral-sh/setup-uv@v3.2.2
+      - run: uvx -p ${{ matrix.python }} tox -e validate
 
   unit-tests:
     name: Unit tests
@@ -56,16 +52,12 @@ jobs:
           - "3.12"
           - "3.13"
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Setup Python
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-      - name: Install dependencies
-        run: pip install tox
-      - name: Run unit tests
-        run: tox -e py3
+      - uses: astral-sh/setup-uv@v3.2.2
+      - run: uvx -p ${{ matrix.python }} tox -e unit
 
   integration:
     name: Integration
@@ -85,21 +77,14 @@ jobs:
           - "3.3/stable"
           - "3.4/stable"
           - "3.5/stable"
-          # A bunch of tests fail with juju.errors.JujuError: base: ubuntu@15.04/stable
-          # * test_subordinate_units
-          # * test_destroy_unit
-          # * test_ssh
-          # * ...
-          # - "3.6/beta"
+          - "3.6/candidate"
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Setup Python
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
+      - uses: astral-sh/setup-uv@v3.2.2
+      - uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
           juju-channel: ${{ matrix.juju }}
@@ -131,9 +116,7 @@ jobs:
       #     # set model defaults
       #     juju model-defaults apt-http-proxy=$PROXY apt-https-proxy=$PROXY  juju-http-proxy=$PROXY juju-https-proxy=$PROXY  snap-http-proxy=$PROXY snap-https-proxy=$PROXY
       #     juju model-defaults
-      - name: Run integration
-        # Force one single concurrent test
-        run: tox -e integration
+      - run: uvx -p ${{ matrix.python }} tox -e integration
 
   integration-quarantine:
     name: Quarantined Integration Tests
@@ -151,16 +134,13 @@ jobs:
           - "3.4/stable"
           - "3.5/stable"
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Setup Python
-        uses: actions/setup-python@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
+      - uses: astral-sh/setup-uv@v3.2.2
+      - uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
           juju-channel: ${{ matrix.juju }}
-      - name: Run integration
-        run: tox -e integration-quarantine
+      - run: uvx -p ${{ matrix.python }} tox -e integration-quarantine

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,7 @@ clean:
 	find . -name __pycache__ -type d -exec rm -r {} +
 	find . -name *.pyc -delete
 	rm -rf .tox
-	rm -rf docs/_build/
-
-.PHONY: .tox
-.tox:
-	tox -r --notest
+	rm -rf build dist docs/_build/
 
 .PHONY: client
 client:
@@ -21,19 +17,19 @@ client:
 	pre-commit run --files $(shell echo juju/client/_[cd]*.py)
 
 .PHONY: run-unit-tests
-run-unit-tests: .tox
-	tox -e py3
+run-unit-tests:
+	uvx tox -e unit
 
 .PHONY: run-integration-tests
-run-integration-tests: .tox
-	tox -e integration
+run-integration-tests:
+	uvx tox -e integration
 
 .PHONY: run-all-tests
 test: run-unit-tests run-integration-tests
 
 .PHONY: docs
 docs:
-	tox -e docs
+	uvx tox -e docs
 
 .PHONY: build-test
 build-test:

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,6 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py3,py38,py39,py310,py311,docs
 skipsdist=True
 
 [testenv]


### PR DESCRIPTION
A few changes interplayed badly and we were running `tox -e py3` in github actions, which only installed the dependencies and didn't run the unit tests 😱 

This PR:
- run unit tests again
- run integration tests against Juju 3.6