### PR TITLE
chore: add 3.5.5 schema and update SCHEMAS.md

### DIFF
--- a/juju/client/SCHEMAS.md
+++ b/juju/client/SCHEMAS.md
@@ -39,3 +39,7 @@ Please see docs/CONTRIBUTING.md for the process for updating this file.
 3.5.2 (identical to 3.5.0)
 3.5.3 (identical to 3.5.0)
 3.5.4 (identical to 3.5.0)
+3.5.5
+
+# 3.6
+3.6.0

--- a/juju/client/schemas-juju-3.5.5.json
+++ b/juju/client/schemas-juju-3.5.5.json
@@ -1,0 +1,18026 @@
+[
+    {
+        "Name": "Action",
+        "Description": "APIv7 provides the Action API facade for version 7.",
+        "Version": 7,
+        "AvailableTo": [
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "Actions": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ActionResults"
+                        }
+                    },
+                    "description": "Actions takes a list of ActionTags, and returns the full Action for\neach ID."
+                },
+                "ApplicationsCharmsActions": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ApplicationsCharmActionsResults"
+                        }
+                    },
+                    "description": "ApplicationsCharmsActions returns a slice of charm Actions for a slice of\nservices."
+                },
+                "Cancel": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ActionResults"
+                        }
+                    },
+                    "description": "Cancel attempts to cancel enqueued Actions from running."
+                },
+                "EnqueueOperation": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Actions"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/EnqueuedActions"
+                        }
+                    },
+                    "description": "EnqueueOperation takes a list of Actions and queues them up to be executed as\nan operation, each action running as a task on the designated ActionReceiver.\nWe return the ID of the overall operation and each individual task."
+                },
+                "ListOperations": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/OperationQueryArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/OperationResults"
+                        }
+                    },
+                    "description": "ListOperations fetches the called actions for specified apps/units."
+                },
+                "Operations": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/OperationResults"
+                        }
+                    },
+                    "description": "Operations fetches the specified operation ids."
+                },
+                "Run": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/RunParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/EnqueuedActions"
+                        }
+                    },
+                    "description": "Run the commands specified on the machines identified through the\nlist of machines, units and services."
+                },
+                "RunOnAllMachines": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/RunParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/EnqueuedActions"
+                        }
+                    },
+                    "description": "RunOnAllMachines attempts to run the specified command on all the machines."
+                },
+                "WatchActionsProgress": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringsWatchResults"
+                        }
+                    },
+                    "description": "WatchActionsProgress creates a watcher that reports on action log messages."
+                }
+            },
+            "definitions": {
+                "Action": {
+                    "type": "object",
+                    "properties": {
+                        "execution-group": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "parallel": {
+                            "type": "boolean"
+                        },
+                        "parameters": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "receiver": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "receiver",
+                        "name"
+                    ]
+                },
+                "ActionMessage": {
+                    "type": "object",
+                    "properties": {
+                        "message": {
+                            "type": "string"
+                        },
+                        "timestamp": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "timestamp",
+                        "message"
+                    ]
+                },
+                "ActionResult": {
+                    "type": "object",
+                    "properties": {
+                        "action": {
+                            "$ref": "#/definitions/Action"
+                        },
+                        "completed": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "enqueued": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "log": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ActionMessage"
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        },
+                        "output": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "started": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "status": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ActionResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ActionResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ActionSpec": {
+                    "type": "object",
+                    "properties": {
+                        "description": {
+                            "type": "string"
+                        },
+                        "params": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "description",
+                        "params"
+                    ]
+                },
+                "Actions": {
+                    "type": "object",
+                    "properties": {
+                        "actions": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Action"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ApplicationCharmActionsResult": {
+                    "type": "object",
+                    "properties": {
+                        "actions": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/ActionSpec"
+                                }
+                            }
+                        },
+                        "application-tag": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ApplicationsCharmActionsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ApplicationCharmActionsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "EnqueuedActions": {
+                    "type": "object",
+                    "properties": {
+                        "actions": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ActionResult"
+                            }
+                        },
+                        "operation": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "operation"
+                    ]
+                },
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "OperationQueryArgs": {
+                    "type": "object",
+                    "properties": {
+                        "actions": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "applications": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "limit": {
+                            "type": "integer"
+                        },
+                        "machines": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "offset": {
+                            "type": "integer"
+                        },
+                        "status": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "units": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "OperationResult": {
+                    "type": "object",
+                    "properties": {
+                        "actions": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ActionResult"
+                            }
+                        },
+                        "completed": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "enqueued": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "fail": {
+                            "type": "string"
+                        },
+                        "operation": {
+                            "type": "string"
+                        },
+                        "started": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "summary": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "operation",
+                        "summary"
+                    ]
+                },
+                "OperationResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/OperationResult"
+                            }
+                        },
+                        "truncated": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "RunParams": {
+                    "type": "object",
+                    "properties": {
+                        "applications": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "commands": {
+                            "type": "string"
+                        },
+                        "execution-group": {
+                            "type": "string"
+                        },
+                        "machines": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "parallel": {
+                            "type": "boolean"
+                        },
+                        "timeout": {
+                            "type": "integer"
+                        },
+                        "units": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "workload-context": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "commands",
+                        "timeout"
+                    ]
+                },
+                "StringsWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "watcher-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "watcher-id"
+                    ]
+                },
+                "StringsWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StringsWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "Admin",
+        "Description": "admin is the only object that unlogged-in clients can access. It holds any\nmethods that are needed to log in.",
+        "Version": 3,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "controller-user",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "Login": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/LoginRequest"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/LoginResult"
+                        }
+                    },
+                    "description": "Login logs in with the provided credentials.  All subsequent requests on the\nconnection will act as the authenticated user."
+                },
+                "RedirectInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/RedirectInfoResult"
+                        }
+                    },
+                    "description": "RedirectInfo returns redirected host information for the model.\nIn Juju it always returns an error because the Juju controller\ndoes not multiplex controllers."
+                }
+            },
+            "definitions": {
+                "Address": {
+                    "type": "object",
+                    "properties": {
+                        "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
+                            "type": "string"
+                        },
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "space-id": {
+                            "type": "string"
+                        },
+                        "space-name": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "value",
+                        "type",
+                        "scope"
+                    ]
+                },
+                "AuthUserInfo": {
+                    "type": "object",
+                    "properties": {
+                        "controller-access": {
+                            "type": "string"
+                        },
+                        "credentials": {
+                            "type": "string"
+                        },
+                        "display-name": {
+                            "type": "string"
+                        },
+                        "identity": {
+                            "type": "string"
+                        },
+                        "last-connection": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "model-access": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "display-name",
+                        "identity",
+                        "controller-access",
+                        "model-access"
+                    ]
+                },
+                "FacadeVersions": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "versions": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "versions"
+                    ]
+                },
+                "HostPort": {
+                    "type": "object",
+                    "properties": {
+                        "Address": {
+                            "$ref": "#/definitions/Address"
+                        },
+                        "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
+                            "type": "string"
+                        },
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "space-id": {
+                            "type": "string"
+                        },
+                        "space-name": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "value",
+                        "type",
+                        "scope",
+                        "Address",
+                        "port"
+                    ]
+                },
+                "LoginRequest": {
+                    "type": "object",
+                    "properties": {
+                        "auth-tag": {
+                            "type": "string"
+                        },
+                        "bakery-version": {
+                            "type": "integer"
+                        },
+                        "cli-args": {
+                            "type": "string"
+                        },
+                        "client-version": {
+                            "type": "string"
+                        },
+                        "credentials": {
+                            "type": "string"
+                        },
+                        "macaroons": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/Macaroon"
+                                }
+                            }
+                        },
+                        "nonce": {
+                            "type": "string"
+                        },
+                        "token": {
+                            "type": "string"
+                        },
+                        "user-data": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "auth-tag",
+                        "credentials",
+                        "nonce",
+                        "macaroons",
+                        "user-data"
+                    ]
+                },
+                "LoginResult": {
+                    "type": "object",
+                    "properties": {
+                        "bakery-discharge-required": {
+                            "$ref": "#/definitions/Macaroon"
+                        },
+                        "controller-tag": {
+                            "type": "string"
+                        },
+                        "discharge-required": {
+                            "$ref": "#/definitions/Macaroon"
+                        },
+                        "discharge-required-error": {
+                            "type": "string"
+                        },
+                        "facades": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/FacadeVersions"
+                            }
+                        },
+                        "model-tag": {
+                            "type": "string"
+                        },
+                        "public-dns-name": {
+                            "type": "string"
+                        },
+                        "server-version": {
+                            "type": "string"
+                        },
+                        "servers": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/HostPort"
+                                }
+                            }
+                        },
+                        "user-info": {
+                            "$ref": "#/definitions/AuthUserInfo"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "Macaroon": {
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "RedirectInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "ca-cert": {
+                            "type": "string"
+                        },
+                        "servers": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/HostPort"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "servers",
+                        "ca-cert"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "AllModelWatcher",
+        "Description": "SrvAllWatcher defines the API methods on a state.Multiwatcher.\nwhich watches any changes to the state. Each client has its own\ncurrent set of watchers, stored in resources. It is used by both\nthe AllWatcher and AllModelWatcher facades.",
+        "Version": 4,
+        "AvailableTo": [
+            "controller-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "Next": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/AllWatcherNextResults"
+                        }
+                    },
+                    "description": "Next will return the current state of everything on the first call\nand subsequent calls will"
+                },
+                "Stop": {
+                    "type": "object",
+                    "description": "Stop stops the watcher."
+                }
+            },
+            "definitions": {
+                "AllWatcherNextResults": {
+                    "type": "object",
+                    "properties": {
+                        "deltas": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Delta"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "deltas"
+                    ]
+                },
+                "Delta": {
+                    "type": "object",
+                    "properties": {
+                        "entity": {
+                            "type": "object",
+                            "additionalProperties": true
+                        },
+                        "removed": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "removed",
+                        "entity"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "AllWatcher",
+        "Description": "SrvAllWatcher defines the API methods on a state.Multiwatcher.\nwhich watches any changes to the state. Each client has its own\ncurrent set of watchers, stored in resources. It is used by both\nthe AllWatcher and AllModelWatcher facades.",
+        "Version": 3,
+        "AvailableTo": [
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "Next": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/AllWatcherNextResults"
+                        }
+                    },
+                    "description": "Next will return the current state of everything on the first call\nand subsequent calls will"
+                },
+                "Stop": {
+                    "type": "object",
+                    "description": "Stop stops the watcher."
+                }
+            },
+            "definitions": {
+                "AllWatcherNextResults": {
+                    "type": "object",
+                    "properties": {
+                        "deltas": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Delta"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "deltas"
+                    ]
+                },
+                "Delta": {
+                    "type": "object",
+                    "properties": {
+                        "entity": {
+                            "type": "object",
+                            "additionalProperties": true
+                        },
+                        "removed": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "removed",
+                        "entity"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "Annotations",
+        "Description": "API implements the service interface and is the concrete\nimplementation of the api end point.",
+        "Version": 2,
+        "AvailableTo": [
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "Get": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/AnnotationsGetResults"
+                        }
+                    },
+                    "description": "Get returns annotations for given entities.\nIf annotations cannot be retrieved for a given entity, an error is returned.\nEach entity is treated independently and, hence, will fail or succeed independently."
+                },
+                "Set": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/AnnotationsSet"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "Set stores annotations for given entities"
+                }
+            },
+            "definitions": {
+                "AnnotationsGetResult": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "entity": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/ErrorResult"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entity",
+                        "annotations"
+                    ]
+                },
+                "AnnotationsGetResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AnnotationsGetResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "AnnotationsSet": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EntityAnnotations"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "annotations"
+                    ]
+                },
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "EntityAnnotations": {
+                    "type": "object",
+                    "properties": {
+                        "annotations": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "entity": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entity",
+                        "annotations"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "Application",
+        "Description": "APIv20 provides the Application API facade for version 20.",
+        "Version": 20,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "AddRelation": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/AddRelation"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/AddRelationResults"
+                        }
+                    },
+                    "description": "AddRelation adds a relation between the specified endpoints and returns the relation info."
+                },
+                "AddUnits": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/AddApplicationUnits"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/AddApplicationUnitsResults"
+                        }
+                    },
+                    "description": "AddUnits adds a given number of units to an application."
+                },
+                "ApplicationsInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ApplicationInfoResults"
+                        }
+                    },
+                    "description": "ApplicationsInfo returns applications information."
+                },
+                "CharmConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ApplicationGetArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ApplicationGetConfigResults"
+                        }
+                    },
+                    "description": "CharmConfig returns charm config for the input list of applications and\nmodel generations."
+                },
+                "CharmRelations": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ApplicationCharmRelations"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ApplicationCharmRelationsResults"
+                        }
+                    },
+                    "description": "CharmRelations implements the server side of Application.CharmRelations."
+                },
+                "Consume": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ConsumeApplicationArgsV5"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "Consume adds remote applications to the model without creating any\nrelations."
+                },
+                "Deploy": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ApplicationsDeploy"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "Deploy fetches the charms from the charm store and deploys them\nusing the specified placement directives."
+                },
+                "DeployFromRepository": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/DeployFromRepositoryArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/DeployFromRepositoryResults"
+                        }
+                    },
+                    "description": "DeployFromRepository is a one-stop deployment method for repository\ncharms. Only a charm name is required to deploy. If argument validation\nfails, a list of all errors found in validation will be returned. If a\nlocal resource is provided, details required for uploading the validated\nresource will be returned."
+                },
+                "DestroyApplication": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/DestroyApplicationsParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/DestroyApplicationResults"
+                        }
+                    },
+                    "description": "DestroyApplication removes a given set of applications."
+                },
+                "DestroyConsumedApplications": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/DestroyConsumedApplicationsParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "DestroyConsumedApplications removes a given set of consumed (remote) applications."
+                },
+                "DestroyRelation": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/DestroyRelation"
+                        }
+                    },
+                    "description": "DestroyRelation removes the relation between the\nspecified endpoints or an id."
+                },
+                "DestroyUnit": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/DestroyUnitsParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/DestroyUnitResults"
+                        }
+                    },
+                    "description": "DestroyUnit removes a given set of application units."
+                },
+                "Expose": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ApplicationExpose"
+                        }
+                    },
+                    "description": "Expose changes the juju-managed firewall to expose any ports that\nwere also explicitly marked by units as open."
+                },
+                "Get": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ApplicationGet"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ApplicationGetResults"
+                        }
+                    },
+                    "description": "Get returns the charm configuration for an application."
+                },
+                "GetCharmURLOrigin": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ApplicationGet"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/CharmURLOriginResult"
+                        }
+                    },
+                    "description": "GetCharmURLOrigin returns the charm URL and charm origin the given\napplication is running at present."
+                },
+                "GetConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ApplicationGetConfigResults"
+                        }
+                    },
+                    "description": "GetConfig returns the charm config for each of the input applications."
+                },
+                "GetConstraints": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ApplicationGetConstraintsResults"
+                        }
+                    },
+                    "description": "GetConstraints returns the constraints for a given application."
+                },
+                "Leader": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entity"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringResult"
+                        }
+                    },
+                    "description": "Leader returns the unit name of the leader for the given application."
+                },
+                "MergeBindings": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ApplicationMergeBindingsArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "MergeBindings merges operator-defined bindings with the current bindings for\none or more applications."
+                },
+                "ResolveUnitErrors": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/UnitsResolved"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "ResolveUnitErrors marks errors on the specified units as resolved."
+                },
+                "ScaleApplications": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ScaleApplicationsParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ScaleApplicationResults"
+                        }
+                    },
+                    "description": "ScaleApplications scales the specified application to the requested number of units."
+                },
+                "SetCharm": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ApplicationSetCharm"
+                        }
+                    },
+                    "description": "SetCharm sets the charm for a given for the application."
+                },
+                "SetConfigs": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ConfigSetArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "SetConfigs implements the server side of Application.SetConfig.  Both\napplication and charm config are set. It does not unset values in\nConfig map that are set to an empty string. Unset should be used for that."
+                },
+                "SetConstraints": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetConstraints"
+                        }
+                    },
+                    "description": "SetConstraints sets the constraints for a given application."
+                },
+                "SetMetricCredentials": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ApplicationMetricCredentials"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "SetMetricCredentials sets credentials on the application.\nTODO (cderici) only used for metered charms in cmd MeteredDeployAPI,\nkept for client compatibility, remove in juju 4.0"
+                },
+                "SetRelationsSuspended": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/RelationSuspendedArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "SetRelationsSuspended sets the suspended status of the specified relations."
+                },
+                "Unexpose": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ApplicationUnexpose"
+                        }
+                    },
+                    "description": "Unexpose changes the juju-managed firewall to unexpose any ports that\nwere also explicitly marked by units as open."
+                },
+                "UnitsInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/UnitInfoResults"
+                        }
+                    },
+                    "description": "UnitsInfo returns unit information for the given entities (units or\napplications)."
+                },
+                "UnsetApplicationsConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ApplicationConfigUnsetArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "UnsetApplicationsConfig implements the server side of Application.UnsetApplicationsConfig."
+                },
+                "UpdateApplicationBase": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/UpdateChannelArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "UpdateApplicationBase updates the application base.\nBase for subordinates is updated too."
+                }
+            },
+            "definitions": {
+                "AddApplicationUnits": {
+                    "type": "object",
+                    "properties": {
+                        "application": {
+                            "type": "string"
+                        },
+                        "attach-storage": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "num-units": {
+                            "type": "integer"
+                        },
+                        "placement": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Placement"
+                            }
+                        },
+                        "policy": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application",
+                        "num-units",
+                        "placement"
+                    ]
+                },
+                "AddApplicationUnitsResults": {
+                    "type": "object",
+                    "properties": {
+                        "units": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "units"
+                    ]
+                },
+                "AddRelation": {
+                    "type": "object",
+                    "properties": {
+                        "endpoints": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "via-cidrs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "endpoints"
+                    ]
+                },
+                "AddRelationResults": {
+                    "type": "object",
+                    "properties": {
+                        "endpoints": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/CharmRelation"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "endpoints"
+                    ]
+                },
+                "ApplicationCharmRelations": {
+                    "type": "object",
+                    "properties": {
+                        "application": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application"
+                    ]
+                },
+                "ApplicationCharmRelationsResults": {
+                    "type": "object",
+                    "properties": {
+                        "charm-relations": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "charm-relations"
+                    ]
+                },
+                "ApplicationConfigUnsetArgs": {
+                    "type": "object",
+                    "properties": {
+                        "Args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ApplicationUnset"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Args"
+                    ]
+                },
+                "ApplicationConstraint": {
+                    "type": "object",
+                    "properties": {
+                        "constraints": {
+                            "$ref": "#/definitions/Value"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "constraints"
+                    ]
+                },
+                "ApplicationDeploy": {
+                    "type": "object",
+                    "properties": {
+                        "Force": {
+                            "type": "boolean"
+                        },
+                        "application": {
+                            "type": "string"
+                        },
+                        "attach-storage": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "channel": {
+                            "type": "string"
+                        },
+                        "charm-origin": {
+                            "$ref": "#/definitions/CharmOrigin"
+                        },
+                        "charm-url": {
+                            "type": "string"
+                        },
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "config-yaml": {
+                            "type": "string"
+                        },
+                        "constraints": {
+                            "$ref": "#/definitions/Value"
+                        },
+                        "devices": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/Constraints"
+                                }
+                            }
+                        },
+                        "endpoint-bindings": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "num-units": {
+                            "type": "integer"
+                        },
+                        "placement": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Placement"
+                            }
+                        },
+                        "policy": {
+                            "type": "string"
+                        },
+                        "resources": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "storage": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/Constraints"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application",
+                        "charm-url",
+                        "channel",
+                        "num-units",
+                        "config-yaml",
+                        "constraints",
+                        "Force"
+                    ]
+                },
+                "ApplicationExpose": {
+                    "type": "object",
+                    "properties": {
+                        "application": {
+                            "type": "string"
+                        },
+                        "exposed-endpoints": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/ExposedEndpoint"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application"
+                    ]
+                },
+                "ApplicationGet": {
+                    "type": "object",
+                    "properties": {
+                        "application": {
+                            "type": "string"
+                        },
+                        "branch": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application",
+                        "branch"
+                    ]
+                },
+                "ApplicationGetArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ApplicationGet"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
+                "ApplicationGetConfigResults": {
+                    "type": "object",
+                    "properties": {
+                        "Results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ConfigResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Results"
+                    ]
+                },
+                "ApplicationGetConstraintsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ApplicationConstraint"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ApplicationGetResults": {
+                    "type": "object",
+                    "properties": {
+                        "application": {
+                            "type": "string"
+                        },
+                        "application-config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "base": {
+                            "$ref": "#/definitions/Base"
+                        },
+                        "channel": {
+                            "type": "string"
+                        },
+                        "charm": {
+                            "type": "string"
+                        },
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "constraints": {
+                            "$ref": "#/definitions/Value"
+                        },
+                        "endpoint-bindings": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application",
+                        "charm",
+                        "config",
+                        "constraints",
+                        "base",
+                        "channel"
+                    ]
+                },
+                "ApplicationInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/ApplicationResult"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ApplicationInfoResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ApplicationInfoResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ApplicationMergeBindings": {
+                    "type": "object",
+                    "properties": {
+                        "application-tag": {
+                            "type": "string"
+                        },
+                        "bindings": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "force": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application-tag",
+                        "bindings",
+                        "force"
+                    ]
+                },
+                "ApplicationMergeBindingsArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ApplicationMergeBindings"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
+                "ApplicationMetricCredential": {
+                    "type": "object",
+                    "properties": {
+                        "application": {
+                            "type": "string"
+                        },
+                        "metrics-credentials": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application",
+                        "metrics-credentials"
+                    ]
+                },
+                "ApplicationMetricCredentials": {
+                    "type": "object",
+                    "properties": {
+                        "creds": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ApplicationMetricCredential"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "creds"
+                    ]
+                },
+                "ApplicationOfferDetailsV5": {
+                    "type": "object",
+                    "properties": {
+                        "application-description": {
+                            "type": "string"
+                        },
+                        "endpoints": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RemoteEndpoint"
+                            }
+                        },
+                        "offer-name": {
+                            "type": "string"
+                        },
+                        "offer-url": {
+                            "type": "string"
+                        },
+                        "offer-uuid": {
+                            "type": "string"
+                        },
+                        "source-model-tag": {
+                            "type": "string"
+                        },
+                        "users": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/OfferUserDetails"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "source-model-tag",
+                        "offer-uuid",
+                        "offer-url",
+                        "offer-name",
+                        "application-description"
+                    ]
+                },
+                "ApplicationResult": {
+                    "type": "object",
+                    "properties": {
+                        "base": {
+                            "$ref": "#/definitions/Base"
+                        },
+                        "channel": {
+                            "type": "string"
+                        },
+                        "charm": {
+                            "type": "string"
+                        },
+                        "constraints": {
+                            "$ref": "#/definitions/Value"
+                        },
+                        "endpoint-bindings": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "exposed": {
+                            "type": "boolean"
+                        },
+                        "exposed-endpoints": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/ExposedEndpoint"
+                                }
+                            }
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "principal": {
+                            "type": "boolean"
+                        },
+                        "remote": {
+                            "type": "boolean"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "principal",
+                        "exposed",
+                        "remote",
+                        "life"
+                    ]
+                },
+                "ApplicationSetCharm": {
+                    "type": "object",
+                    "properties": {
+                        "application": {
+                            "type": "string"
+                        },
+                        "channel": {
+                            "type": "string"
+                        },
+                        "charm-origin": {
+                            "$ref": "#/definitions/CharmOrigin"
+                        },
+                        "charm-url": {
+                            "type": "string"
+                        },
+                        "config-settings": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "config-settings-yaml": {
+                            "type": "string"
+                        },
+                        "endpoint-bindings": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "force-base": {
+                            "type": "boolean"
+                        },
+                        "force-units": {
+                            "type": "boolean"
+                        },
+                        "generation": {
+                            "type": "string"
+                        },
+                        "resource-ids": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "storage-constraints": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/StorageConstraints"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application",
+                        "generation",
+                        "charm-url",
+                        "channel",
+                        "force",
+                        "force-units",
+                        "force-base"
+                    ]
+                },
+                "ApplicationUnexpose": {
+                    "type": "object",
+                    "properties": {
+                        "application": {
+                            "type": "string"
+                        },
+                        "exposed-endpoints": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application",
+                        "exposed-endpoints"
+                    ]
+                },
+                "ApplicationUnset": {
+                    "type": "object",
+                    "properties": {
+                        "application": {
+                            "type": "string"
+                        },
+                        "branch": {
+                            "type": "string"
+                        },
+                        "options": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application",
+                        "branch",
+                        "options"
+                    ]
+                },
+                "ApplicationsDeploy": {
+                    "type": "object",
+                    "properties": {
+                        "applications": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ApplicationDeploy"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "applications"
+                    ]
+                },
+                "Base": {
+                    "type": "object",
+                    "properties": {
+                        "channel": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "channel"
+                    ]
+                },
+                "CharmOrigin": {
+                    "type": "object",
+                    "properties": {
+                        "architecture": {
+                            "type": "string"
+                        },
+                        "base": {
+                            "$ref": "#/definitions/Base"
+                        },
+                        "branch": {
+                            "type": "string"
+                        },
+                        "hash": {
+                            "type": "string"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "instance-key": {
+                            "type": "string"
+                        },
+                        "revision": {
+                            "type": "integer"
+                        },
+                        "risk": {
+                            "type": "string"
+                        },
+                        "source": {
+                            "type": "string"
+                        },
+                        "track": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "source",
+                        "type",
+                        "id"
+                    ]
+                },
+                "CharmRelation": {
+                    "type": "object",
+                    "properties": {
+                        "interface": {
+                            "type": "string"
+                        },
+                        "limit": {
+                            "type": "integer"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "optional": {
+                            "type": "boolean"
+                        },
+                        "role": {
+                            "type": "string"
+                        },
+                        "scope": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "role",
+                        "interface",
+                        "optional",
+                        "limit",
+                        "scope"
+                    ]
+                },
+                "CharmURLOriginResult": {
+                    "type": "object",
+                    "properties": {
+                        "charm-origin": {
+                            "$ref": "#/definitions/CharmOrigin"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "url": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "url",
+                        "charm-origin"
+                    ]
+                },
+                "ConfigResult": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config"
+                    ]
+                },
+                "ConfigSet": {
+                    "type": "object",
+                    "properties": {
+                        "application": {
+                            "type": "string"
+                        },
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "config-yaml": {
+                            "type": "string"
+                        },
+                        "generation": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application",
+                        "generation",
+                        "config",
+                        "config-yaml"
+                    ]
+                },
+                "ConfigSetArgs": {
+                    "type": "object",
+                    "properties": {
+                        "Args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ConfigSet"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Args"
+                    ]
+                },
+                "Constraints": {
+                    "type": "object",
+                    "properties": {
+                        "Count": {
+                            "type": "integer"
+                        },
+                        "Pool": {
+                            "type": "string"
+                        },
+                        "Size": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Pool",
+                        "Size",
+                        "Count"
+                    ]
+                },
+                "ConsumeApplicationArgV5": {
+                    "type": "object",
+                    "properties": {
+                        "ApplicationOfferDetailsV5": {
+                            "$ref": "#/definitions/ApplicationOfferDetailsV5"
+                        },
+                        "application-alias": {
+                            "type": "string"
+                        },
+                        "application-description": {
+                            "type": "string"
+                        },
+                        "endpoints": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RemoteEndpoint"
+                            }
+                        },
+                        "external-controller": {
+                            "$ref": "#/definitions/ExternalControllerInfo"
+                        },
+                        "macaroon": {
+                            "$ref": "#/definitions/Macaroon"
+                        },
+                        "offer-name": {
+                            "type": "string"
+                        },
+                        "offer-url": {
+                            "type": "string"
+                        },
+                        "offer-uuid": {
+                            "type": "string"
+                        },
+                        "source-model-tag": {
+                            "type": "string"
+                        },
+                        "users": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/OfferUserDetails"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "source-model-tag",
+                        "offer-uuid",
+                        "offer-url",
+                        "offer-name",
+                        "application-description",
+                        "ApplicationOfferDetailsV5"
+                    ]
+                },
+                "ConsumeApplicationArgsV5": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ConsumeApplicationArgV5"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "DeployFromRepositoryArg": {
+                    "type": "object",
+                    "properties": {
+                        "ApplicationName": {
+                            "type": "string"
+                        },
+                        "AttachStorage": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "CharmName": {
+                            "type": "string"
+                        },
+                        "ConfigYAML": {
+                            "type": "string"
+                        },
+                        "Cons": {
+                            "$ref": "#/definitions/Value"
+                        },
+                        "Devices": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/Constraints"
+                                }
+                            }
+                        },
+                        "DryRun": {
+                            "type": "boolean"
+                        },
+                        "Placement": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Placement"
+                            }
+                        },
+                        "Storage": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/Constraints"
+                                }
+                            }
+                        },
+                        "Trust": {
+                            "type": "boolean"
+                        },
+                        "base": {
+                            "$ref": "#/definitions/Base"
+                        },
+                        "channel": {
+                            "type": "string"
+                        },
+                        "endpoint-bindings": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "num-units": {
+                            "type": "integer"
+                        },
+                        "resources": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "revision": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "CharmName",
+                        "ApplicationName",
+                        "AttachStorage",
+                        "ConfigYAML",
+                        "Cons",
+                        "Devices",
+                        "DryRun",
+                        "Placement",
+                        "Storage",
+                        "Trust"
+                    ]
+                },
+                "DeployFromRepositoryArgs": {
+                    "type": "object",
+                    "properties": {
+                        "Args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DeployFromRepositoryArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Args"
+                    ]
+                },
+                "DeployFromRepositoryInfo": {
+                    "type": "object",
+                    "properties": {
+                        "architecture": {
+                            "type": "string"
+                        },
+                        "base": {
+                            "$ref": "#/definitions/Base"
+                        },
+                        "channel": {
+                            "type": "string"
+                        },
+                        "effective-channel": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "revision": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "architecture",
+                        "channel",
+                        "name",
+                        "revision"
+                    ]
+                },
+                "DeployFromRepositoryResult": {
+                    "type": "object",
+                    "properties": {
+                        "Errors": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Error"
+                            }
+                        },
+                        "Info": {
+                            "$ref": "#/definitions/DeployFromRepositoryInfo"
+                        },
+                        "PendingResourceUploads": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/PendingResourceUpload"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Errors",
+                        "Info",
+                        "PendingResourceUploads"
+                    ]
+                },
+                "DeployFromRepositoryResults": {
+                    "type": "object",
+                    "properties": {
+                        "Results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DeployFromRepositoryResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Results"
+                    ]
+                },
+                "DestroyApplicationInfo": {
+                    "type": "object",
+                    "properties": {
+                        "destroyed-storage": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        },
+                        "destroyed-units": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        },
+                        "detached-storage": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "DestroyApplicationParams": {
+                    "type": "object",
+                    "properties": {
+                        "application-tag": {
+                            "type": "string"
+                        },
+                        "destroy-storage": {
+                            "type": "boolean"
+                        },
+                        "dry-run": {
+                            "type": "boolean"
+                        },
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "max-wait": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application-tag",
+                        "force"
+                    ]
+                },
+                "DestroyApplicationResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "info": {
+                            "$ref": "#/definitions/DestroyApplicationInfo"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "DestroyApplicationResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DestroyApplicationResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "DestroyApplicationsParams": {
+                    "type": "object",
+                    "properties": {
+                        "applications": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DestroyApplicationParams"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "applications"
+                    ]
+                },
+                "DestroyConsumedApplicationParams": {
+                    "type": "object",
+                    "properties": {
+                        "application-tag": {
+                            "type": "string"
+                        },
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "max-wait": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application-tag"
+                    ]
+                },
+                "DestroyConsumedApplicationsParams": {
+                    "type": "object",
+                    "properties": {
+                        "applications": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DestroyConsumedApplicationParams"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "applications"
+                    ]
+                },
+                "DestroyRelation": {
+                    "type": "object",
+                    "properties": {
+                        "endpoints": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "max-wait": {
+                            "type": "integer"
+                        },
+                        "relation-id": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "relation-id"
+                    ]
+                },
+                "DestroyUnitInfo": {
+                    "type": "object",
+                    "properties": {
+                        "destroyed-storage": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        },
+                        "detached-storage": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "DestroyUnitParams": {
+                    "type": "object",
+                    "properties": {
+                        "destroy-storage": {
+                            "type": "boolean"
+                        },
+                        "dry-run": {
+                            "type": "boolean"
+                        },
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "max-wait": {
+                            "type": "integer"
+                        },
+                        "unit-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "unit-tag"
+                    ]
+                },
+                "DestroyUnitResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "info": {
+                            "$ref": "#/definitions/DestroyUnitInfo"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "DestroyUnitResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DestroyUnitResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "DestroyUnitsParams": {
+                    "type": "object",
+                    "properties": {
+                        "units": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DestroyUnitParams"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "units"
+                    ]
+                },
+                "EndpointRelationData": {
+                    "type": "object",
+                    "properties": {
+                        "ApplicationData": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "cross-model": {
+                            "type": "boolean"
+                        },
+                        "endpoint": {
+                            "type": "string"
+                        },
+                        "related-endpoint": {
+                            "type": "string"
+                        },
+                        "relation-id": {
+                            "type": "integer"
+                        },
+                        "unit-relation-data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/RelationData"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "relation-id",
+                        "endpoint",
+                        "cross-model",
+                        "related-endpoint",
+                        "ApplicationData",
+                        "unit-relation-data"
+                    ]
+                },
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ExposedEndpoint": {
+                    "type": "object",
+                    "properties": {
+                        "expose-to-cidrs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "expose-to-spaces": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ExternalControllerInfo": {
+                    "type": "object",
+                    "properties": {
+                        "addrs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "ca-cert": {
+                            "type": "string"
+                        },
+                        "controller-alias": {
+                            "type": "string"
+                        },
+                        "controller-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "controller-tag",
+                        "controller-alias",
+                        "addrs",
+                        "ca-cert"
+                    ]
+                },
+                "Macaroon": {
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "OfferUserDetails": {
+                    "type": "object",
+                    "properties": {
+                        "access": {
+                            "type": "string"
+                        },
+                        "display-name": {
+                            "type": "string"
+                        },
+                        "user": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "user",
+                        "display-name",
+                        "access"
+                    ]
+                },
+                "PendingResourceUpload": {
+                    "type": "object",
+                    "properties": {
+                        "Filename": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Name",
+                        "Filename",
+                        "Type"
+                    ]
+                },
+                "Placement": {
+                    "type": "object",
+                    "properties": {
+                        "directive": {
+                            "type": "string"
+                        },
+                        "scope": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "scope",
+                        "directive"
+                    ]
+                },
+                "RelationData": {
+                    "type": "object",
+                    "properties": {
+                        "InScope": {
+                            "type": "boolean"
+                        },
+                        "UnitData": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "InScope",
+                        "UnitData"
+                    ]
+                },
+                "RelationSuspendedArg": {
+                    "type": "object",
+                    "properties": {
+                        "message": {
+                            "type": "string"
+                        },
+                        "relation-id": {
+                            "type": "integer"
+                        },
+                        "suspended": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "relation-id",
+                        "message",
+                        "suspended"
+                    ]
+                },
+                "RelationSuspendedArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RelationSuspendedArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
+                "RemoteEndpoint": {
+                    "type": "object",
+                    "properties": {
+                        "interface": {
+                            "type": "string"
+                        },
+                        "limit": {
+                            "type": "integer"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "role": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "role",
+                        "interface",
+                        "limit"
+                    ]
+                },
+                "ScaleApplicationInfo": {
+                    "type": "object",
+                    "properties": {
+                        "num-units": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "num-units"
+                    ]
+                },
+                "ScaleApplicationParams": {
+                    "type": "object",
+                    "properties": {
+                        "application-tag": {
+                            "type": "string"
+                        },
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "scale": {
+                            "type": "integer"
+                        },
+                        "scale-change": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application-tag",
+                        "scale",
+                        "force"
+                    ]
+                },
+                "ScaleApplicationResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "info": {
+                            "$ref": "#/definitions/ScaleApplicationInfo"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ScaleApplicationResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ScaleApplicationResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ScaleApplicationsParams": {
+                    "type": "object",
+                    "properties": {
+                        "applications": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ScaleApplicationParams"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "applications"
+                    ]
+                },
+                "SetConstraints": {
+                    "type": "object",
+                    "properties": {
+                        "application": {
+                            "type": "string"
+                        },
+                        "constraints": {
+                            "$ref": "#/definitions/Value"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application",
+                        "constraints"
+                    ]
+                },
+                "StorageConstraints": {
+                    "type": "object",
+                    "properties": {
+                        "count": {
+                            "type": "integer"
+                        },
+                        "pool": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StringResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "UnitInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/UnitResult"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "UnitInfoResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UnitInfoResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "UnitResult": {
+                    "type": "object",
+                    "properties": {
+                        "address": {
+                            "type": "string"
+                        },
+                        "charm": {
+                            "type": "string"
+                        },
+                        "leader": {
+                            "type": "boolean"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "machine": {
+                            "type": "string"
+                        },
+                        "opened-ports": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "provider-id": {
+                            "type": "string"
+                        },
+                        "public-address": {
+                            "type": "string"
+                        },
+                        "relation-data": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EndpointRelationData"
+                            }
+                        },
+                        "tag": {
+                            "type": "string"
+                        },
+                        "workload-version": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "workload-version",
+                        "opened-ports",
+                        "charm"
+                    ]
+                },
+                "UnitsResolved": {
+                    "type": "object",
+                    "properties": {
+                        "all": {
+                            "type": "boolean"
+                        },
+                        "retry": {
+                            "type": "boolean"
+                        },
+                        "tags": {
+                            "$ref": "#/definitions/Entities"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "UpdateChannelArg": {
+                    "type": "object",
+                    "properties": {
+                        "channel": {
+                            "type": "string"
+                        },
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "tag": {
+                            "$ref": "#/definitions/Entity"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "force",
+                        "channel"
+                    ]
+                },
+                "UpdateChannelArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UpdateChannelArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
+                "Value": {
+                    "type": "object",
+                    "properties": {
+                        "allocate-public-ip": {
+                            "type": "boolean"
+                        },
+                        "arch": {
+                            "type": "string"
+                        },
+                        "container": {
+                            "type": "string"
+                        },
+                        "cores": {
+                            "type": "integer"
+                        },
+                        "cpu-power": {
+                            "type": "integer"
+                        },
+                        "image-id": {
+                            "type": "string"
+                        },
+                        "instance-role": {
+                            "type": "string"
+                        },
+                        "instance-type": {
+                            "type": "string"
+                        },
+                        "mem": {
+                            "type": "integer"
+                        },
+                        "root-disk": {
+                            "type": "integer"
+                        },
+                        "root-disk-source": {
+                            "type": "string"
+                        },
+                        "spaces": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "tags": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "virt-type": {
+                            "type": "string"
+                        },
+                        "zones": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            }
+        }
+    },
+    {
+        "Name": "ApplicationOffers",
+        "Description": "OffersAPIv5 implements the cross model interface and is the concrete\nimplementation of the api end point.",
+        "Version": 5,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "controller-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "ApplicationOffers": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/OfferURLs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ApplicationOffersResults"
+                        }
+                    },
+                    "description": "ApplicationOffers gets details about remote applications that match given URLs."
+                },
+                "DestroyOffers": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/DestroyApplicationOffers"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "DestroyOffers removes the offers specified by the given URLs, forcing if necessary."
+                },
+                "FindApplicationOffers": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/OfferFilters"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/QueryApplicationOffersResultsV5"
+                        }
+                    },
+                    "description": "FindApplicationOffers gets details about remote applications that match given filter."
+                },
+                "GetConsumeDetails": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ConsumeOfferDetailsArg"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ConsumeOfferDetailsResults"
+                        }
+                    },
+                    "description": "GetConsumeDetails returns the details necessary to pass to another model\nto allow the specified args user to consume the offers represented by the args URLs."
+                },
+                "ListApplicationOffers": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/OfferFilters"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/QueryApplicationOffersResultsV5"
+                        }
+                    },
+                    "description": "ListApplicationOffers gets deployed details about application offers that match given filter.\nThe results contain details about the deployed applications such as connection count."
+                },
+                "ModifyOfferAccess": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ModifyOfferAccessRequest"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "ModifyOfferAccess changes the application offer access granted to users."
+                },
+                "Offer": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/AddApplicationOffers"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "Offer makes application endpoints available for consumption at a specified URL."
+                },
+                "RemoteApplicationInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/OfferURLs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/RemoteApplicationInfoResults"
+                        }
+                    },
+                    "description": "RemoteApplicationInfo returns information about the requested remote application.\nThis call currently has no client side API, only there for the Dashboard at this stage."
+                }
+            },
+            "definitions": {
+                "AddApplicationOffer": {
+                    "type": "object",
+                    "properties": {
+                        "application-description": {
+                            "type": "string"
+                        },
+                        "application-name": {
+                            "type": "string"
+                        },
+                        "endpoints": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "model-tag": {
+                            "type": "string"
+                        },
+                        "offer-name": {
+                            "type": "string"
+                        },
+                        "owner-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "model-tag",
+                        "offer-name",
+                        "application-name",
+                        "application-description",
+                        "endpoints"
+                    ]
+                },
+                "AddApplicationOffers": {
+                    "type": "object",
+                    "properties": {
+                        "Offers": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AddApplicationOffer"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Offers"
+                    ]
+                },
+                "ApplicationOfferAdminDetailsV5": {
+                    "type": "object",
+                    "properties": {
+                        "ApplicationOfferDetailsV5": {
+                            "$ref": "#/definitions/ApplicationOfferDetailsV5"
+                        },
+                        "application-description": {
+                            "type": "string"
+                        },
+                        "application-name": {
+                            "type": "string"
+                        },
+                        "charm-url": {
+                            "type": "string"
+                        },
+                        "connections": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/OfferConnection"
+                            }
+                        },
+                        "endpoints": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RemoteEndpoint"
+                            }
+                        },
+                        "offer-name": {
+                            "type": "string"
+                        },
+                        "offer-url": {
+                            "type": "string"
+                        },
+                        "offer-uuid": {
+                            "type": "string"
+                        },
+                        "source-model-tag": {
+                            "type": "string"
+                        },
+                        "users": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/OfferUserDetails"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "source-model-tag",
+                        "offer-uuid",
+                        "offer-url",
+                        "offer-name",
+                        "application-description",
+                        "ApplicationOfferDetailsV5",
+                        "application-name",
+                        "charm-url"
+                    ]
+                },
+                "ApplicationOfferDetailsV5": {
+                    "type": "object",
+                    "properties": {
+                        "application-description": {
+                            "type": "string"
+                        },
+                        "endpoints": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RemoteEndpoint"
+                            }
+                        },
+                        "offer-name": {
+                            "type": "string"
+                        },
+                        "offer-url": {
+                            "type": "string"
+                        },
+                        "offer-uuid": {
+                            "type": "string"
+                        },
+                        "source-model-tag": {
+                            "type": "string"
+                        },
+                        "users": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/OfferUserDetails"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "source-model-tag",
+                        "offer-uuid",
+                        "offer-url",
+                        "offer-name",
+                        "application-description"
+                    ]
+                },
+                "ApplicationOfferResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/ApplicationOfferAdminDetailsV5"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ApplicationOffersResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ApplicationOfferResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ConsumeOfferDetails": {
+                    "type": "object",
+                    "properties": {
+                        "external-controller": {
+                            "$ref": "#/definitions/ExternalControllerInfo"
+                        },
+                        "macaroon": {
+                            "$ref": "#/definitions/Macaroon"
+                        },
+                        "offer": {
+                            "$ref": "#/definitions/ApplicationOfferDetailsV5"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ConsumeOfferDetailsArg": {
+                    "type": "object",
+                    "properties": {
+                        "offer-urls": {
+                            "$ref": "#/definitions/OfferURLs"
+                        },
+                        "user-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "offer-urls"
+                    ]
+                },
+                "ConsumeOfferDetailsResult": {
+                    "type": "object",
+                    "properties": {
+                        "ConsumeOfferDetails": {
+                            "$ref": "#/definitions/ConsumeOfferDetails"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "external-controller": {
+                            "$ref": "#/definitions/ExternalControllerInfo"
+                        },
+                        "macaroon": {
+                            "$ref": "#/definitions/Macaroon"
+                        },
+                        "offer": {
+                            "$ref": "#/definitions/ApplicationOfferDetailsV5"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "ConsumeOfferDetails"
+                    ]
+                },
+                "ConsumeOfferDetailsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ConsumeOfferDetailsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "DestroyApplicationOffers": {
+                    "type": "object",
+                    "properties": {
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "offer-urls": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "offer-urls"
+                    ]
+                },
+                "EndpointFilterAttributes": {
+                    "type": "object",
+                    "properties": {
+                        "interface": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "role": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "role",
+                        "interface",
+                        "name"
+                    ]
+                },
+                "EntityStatus": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "info": {
+                            "type": "string"
+                        },
+                        "since": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "status": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "status",
+                        "info",
+                        "since"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ExternalControllerInfo": {
+                    "type": "object",
+                    "properties": {
+                        "addrs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "ca-cert": {
+                            "type": "string"
+                        },
+                        "controller-alias": {
+                            "type": "string"
+                        },
+                        "controller-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "controller-tag",
+                        "controller-alias",
+                        "addrs",
+                        "ca-cert"
+                    ]
+                },
+                "Macaroon": {
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "ModifyOfferAccess": {
+                    "type": "object",
+                    "properties": {
+                        "access": {
+                            "type": "string"
+                        },
+                        "action": {
+                            "type": "string"
+                        },
+                        "offer-url": {
+                            "type": "string"
+                        },
+                        "user-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "user-tag",
+                        "action",
+                        "access",
+                        "offer-url"
+                    ]
+                },
+                "ModifyOfferAccessRequest": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModifyOfferAccess"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "changes"
+                    ]
+                },
+                "OfferConnection": {
+                    "type": "object",
+                    "properties": {
+                        "endpoint": {
+                            "type": "string"
+                        },
+                        "ingress-subnets": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "relation-id": {
+                            "type": "integer"
+                        },
+                        "source-model-tag": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "$ref": "#/definitions/EntityStatus"
+                        },
+                        "username": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "source-model-tag",
+                        "relation-id",
+                        "username",
+                        "endpoint",
+                        "status",
+                        "ingress-subnets"
+                    ]
+                },
+                "OfferFilter": {
+                    "type": "object",
+                    "properties": {
+                        "allowed-users": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "application-description": {
+                            "type": "string"
+                        },
+                        "application-name": {
+                            "type": "string"
+                        },
+                        "application-user": {
+                            "type": "string"
+                        },
+                        "connected-users": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "endpoints": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EndpointFilterAttributes"
+                            }
+                        },
+                        "model-name": {
+                            "type": "string"
+                        },
+                        "offer-name": {
+                            "type": "string"
+                        },
+                        "owner-name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "owner-name",
+                        "model-name",
+                        "offer-name",
+                        "application-name",
+                        "application-description",
+                        "application-user",
+                        "endpoints",
+                        "connected-users",
+                        "allowed-users"
+                    ]
+                },
+                "OfferFilters": {
+                    "type": "object",
+                    "properties": {
+                        "Filters": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/OfferFilter"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Filters"
+                    ]
+                },
+                "OfferURLs": {
+                    "type": "object",
+                    "properties": {
+                        "bakery-version": {
+                            "type": "integer"
+                        },
+                        "offer-urls": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "OfferUserDetails": {
+                    "type": "object",
+                    "properties": {
+                        "access": {
+                            "type": "string"
+                        },
+                        "display-name": {
+                            "type": "string"
+                        },
+                        "user": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "user",
+                        "display-name",
+                        "access"
+                    ]
+                },
+                "QueryApplicationOffersResultsV5": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ApplicationOfferAdminDetailsV5"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "RemoteApplicationInfo": {
+                    "type": "object",
+                    "properties": {
+                        "description": {
+                            "type": "string"
+                        },
+                        "endpoints": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RemoteEndpoint"
+                            }
+                        },
+                        "icon-url-path": {
+                            "type": "string"
+                        },
+                        "model-tag": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "offer-url": {
+                            "type": "string"
+                        },
+                        "source-model-label": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "model-tag",
+                        "name",
+                        "description",
+                        "offer-url",
+                        "endpoints",
+                        "icon-url-path"
+                    ]
+                },
+                "RemoteApplicationInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/RemoteApplicationInfo"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "RemoteApplicationInfoResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RemoteApplicationInfoResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "RemoteEndpoint": {
+                    "type": "object",
+                    "properties": {
+                        "interface": {
+                            "type": "string"
+                        },
+                        "limit": {
+                            "type": "integer"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "role": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "role",
+                        "interface",
+                        "limit"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "Backups",
+        "Description": "API provides backup-specific API methods.",
+        "Version": 3,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "Create": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/BackupsCreateArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/BackupsMetadataResult"
+                        }
+                    },
+                    "description": "Create is the API method that requests juju to create a new backup\nof its state."
+                }
+            },
+            "definitions": {
+                "BackupsCreateArgs": {
+                    "type": "object",
+                    "properties": {
+                        "no-download": {
+                            "type": "boolean"
+                        },
+                        "notes": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "notes",
+                        "no-download"
+                    ]
+                },
+                "BackupsMetadataResult": {
+                    "type": "object",
+                    "properties": {
+                        "base": {
+                            "type": "string"
+                        },
+                        "checksum": {
+                            "type": "string"
+                        },
+                        "checksum-format": {
+                            "type": "string"
+                        },
+                        "controller-machine-id": {
+                            "type": "string"
+                        },
+                        "controller-machine-inst-id": {
+                            "type": "string"
+                        },
+                        "controller-uuid": {
+                            "type": "string"
+                        },
+                        "filename": {
+                            "type": "string"
+                        },
+                        "finished": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "format-version": {
+                            "type": "integer"
+                        },
+                        "ha-nodes": {
+                            "type": "integer"
+                        },
+                        "hostname": {
+                            "type": "string"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "machine": {
+                            "type": "string"
+                        },
+                        "model": {
+                            "type": "string"
+                        },
+                        "notes": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "started": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "stored": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "version": {
+                            "$ref": "#/definitions/Number"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "id",
+                        "checksum",
+                        "checksum-format",
+                        "size",
+                        "stored",
+                        "started",
+                        "finished",
+                        "notes",
+                        "model",
+                        "machine",
+                        "hostname",
+                        "version",
+                        "base",
+                        "filename",
+                        "format-version",
+                        "controller-uuid",
+                        "controller-machine-id",
+                        "controller-machine-inst-id",
+                        "ha-nodes"
+                    ]
+                },
+                "Number": {
+                    "type": "object",
+                    "properties": {
+                        "Build": {
+                            "type": "integer"
+                        },
+                        "Major": {
+                            "type": "integer"
+                        },
+                        "Minor": {
+                            "type": "integer"
+                        },
+                        "Patch": {
+                            "type": "integer"
+                        },
+                        "Tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Major",
+                        "Minor",
+                        "Tag",
+                        "Patch",
+                        "Build"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "Block",
+        "Description": "API implements Block interface and is the concrete\nimplementation of the api end point.",
+        "Version": 2,
+        "AvailableTo": [
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "List": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/BlockResults"
+                        }
+                    },
+                    "description": "List implements Block.List()."
+                },
+                "SwitchBlockOff": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/BlockSwitchParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResult"
+                        }
+                    },
+                    "description": "SwitchBlockOff implements Block.SwitchBlockOff()."
+                },
+                "SwitchBlockOn": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/BlockSwitchParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResult"
+                        }
+                    },
+                    "description": "SwitchBlockOn implements Block.SwitchBlockOn()."
+                }
+            },
+            "definitions": {
+                "Block": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "string"
+                        },
+                        "message": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "id",
+                        "tag",
+                        "type"
+                    ]
+                },
+                "BlockResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/Block"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "BlockResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/BlockResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "BlockSwitchParams": {
+                    "type": "object",
+                    "properties": {
+                        "message": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "type"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            }
+        }
+    },
+    {
+        "Name": "Bundle",
+        "Description": "APIv6 provides the Bundle API facade for version 6. It is otherwise\nidentical to V5 with the exception that the V6 adds the support for\nmulti-part yaml handling to GetChanges and GetChangesMapArgs.",
+        "Version": 6,
+        "AvailableTo": [
+            "controller-user",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "ExportBundle": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ExportBundleParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringResult"
+                        }
+                    },
+                    "description": "ExportBundle exports the current model configuration as bundle."
+                },
+                "GetChanges": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/BundleChangesParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/BundleChangesResults"
+                        }
+                    },
+                    "description": "GetChanges returns the list of changes required to deploy the given bundle\ndata. The changes are sorted by requirements, so that they can be applied in\norder.\nGetChanges has been superseded in favour of GetChangesMapArgs. It's\npreferable to use that new method to add new functionality and move clients\naway from this one."
+                },
+                "GetChangesMapArgs": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/BundleChangesParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/BundleChangesMapArgsResults"
+                        }
+                    },
+                    "description": "GetChangesMapArgs returns the list of changes required to deploy the given\nbundle data. The changes are sorted by requirements, so that they can be\napplied in order.\nV4 GetChangesMapArgs is not supported on anything less than v4"
+                }
+            },
+            "definitions": {
+                "BundleChange": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": true
+                            }
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "method": {
+                            "type": "string"
+                        },
+                        "requires": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "id",
+                        "method",
+                        "args",
+                        "requires"
+                    ]
+                },
+                "BundleChangesMapArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "method": {
+                            "type": "string"
+                        },
+                        "requires": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "id",
+                        "method",
+                        "args",
+                        "requires"
+                    ]
+                },
+                "BundleChangesMapArgsResults": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/BundleChangesMapArgs"
+                            }
+                        },
+                        "errors": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "BundleChangesParams": {
+                    "type": "object",
+                    "properties": {
+                        "bundleURL": {
+                            "type": "string"
+                        },
+                        "yaml": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "yaml",
+                        "bundleURL"
+                    ]
+                },
+                "BundleChangesResults": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/BundleChange"
+                            }
+                        },
+                        "errors": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ExportBundleParams": {
+                    "type": "object",
+                    "properties": {
+                        "include-charm-defaults": {
+                            "type": "boolean"
+                        },
+                        "include-series": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StringResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "Charms",
+        "Description": "APIv7 provides the Charms API facade for version 7.\nv7 guarantees SupportedBases will be provided in ResolveCharms",
+        "Version": 7,
+        "AvailableTo": [
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "AddCharm": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/AddCharmWithOrigin"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/CharmOriginResult"
+                        }
+                    },
+                    "description": "AddCharm adds the given charm URL (which must include revision) to the\nenvironment, if it does not exist yet. Local charms are not supported,\nonly charm store and charm hub URLs. See also AddLocalCharm()."
+                },
+                "CharmInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/CharmURL"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/Charm"
+                        }
+                    },
+                    "description": "CharmInfo returns information about the requested charm."
+                },
+                "CheckCharmPlacement": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ApplicationCharmPlacements"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "CheckCharmPlacement checks if a charm is allowed to be placed with in a\ngiven application."
+                },
+                "GetDownloadInfos": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/CharmURLAndOrigins"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/DownloadInfoResults"
+                        }
+                    },
+                    "description": "GetDownloadInfos attempts to get the bundle corresponding to the charm url\nand origin."
+                },
+                "IsMetered": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/CharmURL"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/IsMeteredResult"
+                        }
+                    },
+                    "description": "IsMetered returns whether or not the charm is metered.\nTODO (cderici) only used for metered charms in cmd MeteredDeployAPI,\nkept for client compatibility, remove in juju 4.0"
+                },
+                "List": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/CharmsList"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/CharmsListResult"
+                        }
+                    },
+                    "description": "List returns a list of charm URLs currently in the state.\nIf supplied parameter contains any names, the result will\nbe filtered to return only the charms with supplied names."
+                },
+                "ListCharmResources": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/CharmURLAndOrigins"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/CharmResourcesResults"
+                        }
+                    },
+                    "description": "ListCharmResources returns a series of resources for a given charm."
+                },
+                "ResolveCharms": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ResolveCharmsWithChannel"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ResolveCharmWithChannelResults"
+                        }
+                    },
+                    "description": "ResolveCharms resolves the given charm URLs with an optionally specified\npreferred channel.  Channel provided via CharmOrigin."
+                }
+            },
+            "definitions": {
+                "AddCharmWithOrigin": {
+                    "type": "object",
+                    "properties": {
+                        "charm-origin": {
+                            "$ref": "#/definitions/CharmOrigin"
+                        },
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "url": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "url",
+                        "charm-origin",
+                        "force"
+                    ]
+                },
+                "ApplicationCharmPlacement": {
+                    "type": "object",
+                    "properties": {
+                        "application": {
+                            "type": "string"
+                        },
+                        "charm-url": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application",
+                        "charm-url"
+                    ]
+                },
+                "ApplicationCharmPlacements": {
+                    "type": "object",
+                    "properties": {
+                        "placements": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ApplicationCharmPlacement"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "placements"
+                    ]
+                },
+                "Base": {
+                    "type": "object",
+                    "properties": {
+                        "channel": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "channel"
+                    ]
+                },
+                "Charm": {
+                    "type": "object",
+                    "properties": {
+                        "actions": {
+                            "$ref": "#/definitions/CharmActions"
+                        },
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/CharmOption"
+                                }
+                            }
+                        },
+                        "lxd-profile": {
+                            "$ref": "#/definitions/CharmLXDProfile"
+                        },
+                        "manifest": {
+                            "$ref": "#/definitions/CharmManifest"
+                        },
+                        "meta": {
+                            "$ref": "#/definitions/CharmMeta"
+                        },
+                        "metrics": {
+                            "$ref": "#/definitions/CharmMetrics"
+                        },
+                        "revision": {
+                            "type": "integer"
+                        },
+                        "url": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "revision",
+                        "url",
+                        "config"
+                    ]
+                },
+                "CharmActionSpec": {
+                    "type": "object",
+                    "properties": {
+                        "description": {
+                            "type": "string"
+                        },
+                        "params": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "description",
+                        "params"
+                    ]
+                },
+                "CharmActions": {
+                    "type": "object",
+                    "properties": {
+                        "specs": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/CharmActionSpec"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "CharmBase": {
+                    "type": "object",
+                    "properties": {
+                        "architectures": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "channel": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "CharmContainer": {
+                    "type": "object",
+                    "properties": {
+                        "gid": {
+                            "type": "integer"
+                        },
+                        "mounts": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CharmMount"
+                            }
+                        },
+                        "resource": {
+                            "type": "string"
+                        },
+                        "uid": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "CharmDeployment": {
+                    "type": "object",
+                    "properties": {
+                        "min-version": {
+                            "type": "string"
+                        },
+                        "mode": {
+                            "type": "string"
+                        },
+                        "service": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "type",
+                        "mode",
+                        "service",
+                        "min-version"
+                    ]
+                },
+                "CharmDevice": {
+                    "type": "object",
+                    "properties": {
+                        "CountMax": {
+                            "type": "integer"
+                        },
+                        "CountMin": {
+                            "type": "integer"
+                        },
+                        "Description": {
+                            "type": "string"
+                        },
+                        "Name": {
+                            "type": "string"
+                        },
+                        "Type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Name",
+                        "Description",
+                        "Type",
+                        "CountMin",
+                        "CountMax"
+                    ]
+                },
+                "CharmLXDProfile": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "devices": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "patternProperties": {
+                                        ".*": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config",
+                        "description",
+                        "devices"
+                    ]
+                },
+                "CharmManifest": {
+                    "type": "object",
+                    "properties": {
+                        "bases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CharmBase"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "CharmMeta": {
+                    "type": "object",
+                    "properties": {
+                        "assumes-expr": {
+                            "$ref": "#/definitions/ExpressionTree"
+                        },
+                        "categories": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "charm-user": {
+                            "type": "string"
+                        },
+                        "containers": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/CharmContainer"
+                                }
+                            }
+                        },
+                        "deployment": {
+                            "$ref": "#/definitions/CharmDeployment"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "devices": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/CharmDevice"
+                                }
+                            }
+                        },
+                        "extra-bindings": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "min-juju-version": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "payload-classes": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/CharmPayloadClass"
+                                }
+                            }
+                        },
+                        "peers": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/CharmRelation"
+                                }
+                            }
+                        },
+                        "provides": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/CharmRelation"
+                                }
+                            }
+                        },
+                        "requires": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/CharmRelation"
+                                }
+                            }
+                        },
+                        "resources": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/CharmResourceMeta"
+                                }
+                            }
+                        },
+                        "series": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "storage": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/CharmStorage"
+                                }
+                            }
+                        },
+                        "subordinate": {
+                            "type": "boolean"
+                        },
+                        "summary": {
+                            "type": "string"
+                        },
+                        "tags": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "terms": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "summary",
+                        "description",
+                        "subordinate"
+                    ]
+                },
+                "CharmMetric": {
+                    "type": "object",
+                    "properties": {
+                        "description": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "type",
+                        "description"
+                    ]
+                },
+                "CharmMetrics": {
+                    "type": "object",
+                    "properties": {
+                        "metrics": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/CharmMetric"
+                                }
+                            }
+                        },
+                        "plan": {
+                            "$ref": "#/definitions/CharmPlan"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "metrics",
+                        "plan"
+                    ]
+                },
+                "CharmMount": {
+                    "type": "object",
+                    "properties": {
+                        "location": {
+                            "type": "string"
+                        },
+                        "storage": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "CharmOption": {
+                    "type": "object",
+                    "properties": {
+                        "default": {
+                            "type": "object",
+                            "additionalProperties": true
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "type"
+                    ]
+                },
+                "CharmOrigin": {
+                    "type": "object",
+                    "properties": {
+                        "architecture": {
+                            "type": "string"
+                        },
+                        "base": {
+                            "$ref": "#/definitions/Base"
+                        },
+                        "branch": {
+                            "type": "string"
+                        },
+                        "hash": {
+                            "type": "string"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "instance-key": {
+                            "type": "string"
+                        },
+                        "revision": {
+                            "type": "integer"
+                        },
+                        "risk": {
+                            "type": "string"
+                        },
+                        "source": {
+                            "type": "string"
+                        },
+                        "track": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "source",
+                        "type",
+                        "id"
+                    ]
+                },
+                "CharmOriginResult": {
+                    "type": "object",
+                    "properties": {
+                        "charm-origin": {
+                            "$ref": "#/definitions/CharmOrigin"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "charm-origin"
+                    ]
+                },
+                "CharmPayloadClass": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "type"
+                    ]
+                },
+                "CharmPlan": {
+                    "type": "object",
+                    "properties": {
+                        "required": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "required"
+                    ]
+                },
+                "CharmRelation": {
+                    "type": "object",
+                    "properties": {
+                        "interface": {
+                            "type": "string"
+                        },
+                        "limit": {
+                            "type": "integer"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "optional": {
+                            "type": "boolean"
+                        },
+                        "role": {
+                            "type": "string"
+                        },
+                        "scope": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "role",
+                        "interface",
+                        "optional",
+                        "limit",
+                        "scope"
+                    ]
+                },
+                "CharmResource": {
+                    "type": "object",
+                    "properties": {
+                        "description": {
+                            "type": "string"
+                        },
+                        "fingerprint": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "origin": {
+                            "type": "string"
+                        },
+                        "path": {
+                            "type": "string"
+                        },
+                        "revision": {
+                            "type": "integer"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "type",
+                        "path",
+                        "origin",
+                        "revision",
+                        "fingerprint",
+                        "size"
+                    ]
+                },
+                "CharmResourceMeta": {
+                    "type": "object",
+                    "properties": {
+                        "description": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "path": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "type",
+                        "path",
+                        "description"
+                    ]
+                },
+                "CharmResourceResult": {
+                    "type": "object",
+                    "properties": {
+                        "CharmResource": {
+                            "$ref": "#/definitions/CharmResource"
+                        },
+                        "ErrorResult": {
+                            "$ref": "#/definitions/ErrorResult"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "fingerprint": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "origin": {
+                            "type": "string"
+                        },
+                        "path": {
+                            "type": "string"
+                        },
+                        "revision": {
+                            "type": "integer"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "ErrorResult",
+                        "name",
+                        "type",
+                        "path",
+                        "origin",
+                        "revision",
+                        "fingerprint",
+                        "size",
+                        "CharmResource"
+                    ]
+                },
+                "CharmResourcesResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "items": {
+                                    "$ref": "#/definitions/CharmResourceResult"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "CharmStorage": {
+                    "type": "object",
+                    "properties": {
+                        "count-max": {
+                            "type": "integer"
+                        },
+                        "count-min": {
+                            "type": "integer"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "location": {
+                            "type": "string"
+                        },
+                        "minimum-size": {
+                            "type": "integer"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "properties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "read-only": {
+                            "type": "boolean"
+                        },
+                        "shared": {
+                            "type": "boolean"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "description",
+                        "type",
+                        "shared",
+                        "read-only",
+                        "count-min",
+                        "count-max",
+                        "minimum-size"
+                    ]
+                },
+                "CharmURL": {
+                    "type": "object",
+                    "properties": {
+                        "url": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "url"
+                    ]
+                },
+                "CharmURLAndOrigin": {
+                    "type": "object",
+                    "properties": {
+                        "charm-origin": {
+                            "$ref": "#/definitions/CharmOrigin"
+                        },
+                        "charm-url": {
+                            "type": "string"
+                        },
+                        "macaroon": {
+                            "$ref": "#/definitions/Macaroon"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "charm-url",
+                        "charm-origin"
+                    ]
+                },
+                "CharmURLAndOrigins": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CharmURLAndOrigin"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "CharmsList": {
+                    "type": "object",
+                    "properties": {
+                        "names": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "names"
+                    ]
+                },
+                "CharmsListResult": {
+                    "type": "object",
+                    "properties": {
+                        "charm-urls": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "charm-urls"
+                    ]
+                },
+                "DownloadInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "charm-origin": {
+                            "$ref": "#/definitions/CharmOrigin"
+                        },
+                        "url": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "url",
+                        "charm-origin"
+                    ]
+                },
+                "DownloadInfoResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DownloadInfoResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ExpressionTree": {
+                    "type": "object",
+                    "properties": {
+                        "Expression": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Expression"
+                    ]
+                },
+                "IsMeteredResult": {
+                    "type": "object",
+                    "properties": {
+                        "metered": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "metered"
+                    ]
+                },
+                "Macaroon": {
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "ResolveCharmWithChannel": {
+                    "type": "object",
+                    "properties": {
+                        "charm-origin": {
+                            "$ref": "#/definitions/CharmOrigin"
+                        },
+                        "reference": {
+                            "type": "string"
+                        },
+                        "switch-charm": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "reference",
+                        "charm-origin"
+                    ]
+                },
+                "ResolveCharmWithChannelResult": {
+                    "type": "object",
+                    "properties": {
+                        "charm-origin": {
+                            "$ref": "#/definitions/CharmOrigin"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "supported-bases": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Base"
+                            }
+                        },
+                        "url": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "url",
+                        "charm-origin",
+                        "supported-bases"
+                    ]
+                },
+                "ResolveCharmWithChannelResults": {
+                    "type": "object",
+                    "properties": {
+                        "Results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ResolveCharmWithChannelResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Results"
+                    ]
+                },
+                "ResolveCharmsWithChannel": {
+                    "type": "object",
+                    "properties": {
+                        "macaroon": {
+                            "$ref": "#/definitions/Macaroon"
+                        },
+                        "resolve": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ResolveCharmWithChannel"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "resolve"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "Client",
+        "Description": "Client serves client-specific API methods.",
+        "Version": 7,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "FindTools": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/FindToolsParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/FindToolsResult"
+                        }
+                    },
+                    "description": "FindTools returns a List containing all tools matching the given parameters.\nTODO(juju 3.1) - remove, used by 2.9 client only"
+                },
+                "FullStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/StatusParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/FullStatus"
+                        }
+                    },
+                    "description": "FullStatus gives the information needed for juju status over the api"
+                },
+                "StatusHistory": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/StatusHistoryRequests"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StatusHistoryResults"
+                        }
+                    },
+                    "description": "StatusHistory returns a slice of past statuses for several entities."
+                },
+                "WatchAll": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/AllWatcherId"
+                        }
+                    },
+                    "description": "WatchAll initiates a watcher for entities in the connected model."
+                }
+            },
+            "definitions": {
+                "AllWatcherId": {
+                    "type": "object",
+                    "properties": {
+                        "watcher-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "watcher-id"
+                    ]
+                },
+                "ApplicationOfferStatus": {
+                    "type": "object",
+                    "properties": {
+                        "active-connected-count": {
+                            "type": "integer"
+                        },
+                        "application-name": {
+                            "type": "string"
+                        },
+                        "charm": {
+                            "type": "string"
+                        },
+                        "endpoints": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/RemoteEndpoint"
+                                }
+                            }
+                        },
+                        "err": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "offer-name": {
+                            "type": "string"
+                        },
+                        "total-connected-count": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "offer-name",
+                        "application-name",
+                        "charm",
+                        "endpoints",
+                        "active-connected-count",
+                        "total-connected-count"
+                    ]
+                },
+                "ApplicationStatus": {
+                    "type": "object",
+                    "properties": {
+                        "base": {
+                            "$ref": "#/definitions/Base"
+                        },
+                        "can-upgrade-to": {
+                            "type": "string"
+                        },
+                        "charm": {
+                            "type": "string"
+                        },
+                        "charm-channel": {
+                            "type": "string"
+                        },
+                        "charm-profile": {
+                            "type": "string"
+                        },
+                        "charm-rev": {
+                            "type": "integer"
+                        },
+                        "charm-version": {
+                            "type": "string"
+                        },
+                        "endpoint-bindings": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "err": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "exposed": {
+                            "type": "boolean"
+                        },
+                        "exposed-endpoints": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/ExposedEndpoint"
+                                }
+                            }
+                        },
+                        "int": {
+                            "type": "integer"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "meter-statuses": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/MeterStatus"
+                                }
+                            }
+                        },
+                        "provider-id": {
+                            "type": "string"
+                        },
+                        "public-address": {
+                            "type": "string"
+                        },
+                        "relations": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "status": {
+                            "$ref": "#/definitions/DetailedStatus"
+                        },
+                        "subordinate-to": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "units": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/UnitStatus"
+                                }
+                            }
+                        },
+                        "workload-version": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "charm",
+                        "charm-version",
+                        "charm-profile",
+                        "base",
+                        "exposed",
+                        "life",
+                        "relations",
+                        "can-upgrade-to",
+                        "subordinate-to",
+                        "units",
+                        "meter-statuses",
+                        "status",
+                        "workload-version",
+                        "endpoint-bindings",
+                        "public-address"
+                    ]
+                },
+                "Base": {
+                    "type": "object",
+                    "properties": {
+                        "channel": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "channel"
+                    ]
+                },
+                "Binary": {
+                    "type": "object",
+                    "properties": {
+                        "Arch": {
+                            "type": "string"
+                        },
+                        "Build": {
+                            "type": "integer"
+                        },
+                        "Major": {
+                            "type": "integer"
+                        },
+                        "Minor": {
+                            "type": "integer"
+                        },
+                        "Number": {
+                            "$ref": "#/definitions/Number"
+                        },
+                        "Patch": {
+                            "type": "integer"
+                        },
+                        "Release": {
+                            "type": "string"
+                        },
+                        "Tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Major",
+                        "Minor",
+                        "Tag",
+                        "Patch",
+                        "Build",
+                        "Number",
+                        "Release",
+                        "Arch"
+                    ]
+                },
+                "BranchStatus": {
+                    "type": "object",
+                    "properties": {
+                        "assigned-units": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "created": {
+                            "type": "integer"
+                        },
+                        "created-by": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "assigned-units",
+                        "created",
+                        "created-by"
+                    ]
+                },
+                "DetailedStatus": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "err": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "info": {
+                            "type": "string"
+                        },
+                        "kind": {
+                            "type": "string"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "since": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "status",
+                        "info",
+                        "data",
+                        "since",
+                        "kind",
+                        "version",
+                        "life"
+                    ]
+                },
+                "EndpointStatus": {
+                    "type": "object",
+                    "properties": {
+                        "application": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "role": {
+                            "type": "string"
+                        },
+                        "subordinate": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application",
+                        "name",
+                        "role",
+                        "subordinate"
+                    ]
+                },
+                "EntityStatus": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "info": {
+                            "type": "string"
+                        },
+                        "since": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "status": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "status",
+                        "info",
+                        "since"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ExposedEndpoint": {
+                    "type": "object",
+                    "properties": {
+                        "expose-to-cidrs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "expose-to-spaces": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "FilesystemAttachmentDetails": {
+                    "type": "object",
+                    "properties": {
+                        "FilesystemAttachmentInfo": {
+                            "$ref": "#/definitions/FilesystemAttachmentInfo"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "mount-point": {
+                            "type": "string"
+                        },
+                        "read-only": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "FilesystemAttachmentInfo"
+                    ]
+                },
+                "FilesystemAttachmentInfo": {
+                    "type": "object",
+                    "properties": {
+                        "mount-point": {
+                            "type": "string"
+                        },
+                        "read-only": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "FilesystemDetails": {
+                    "type": "object",
+                    "properties": {
+                        "filesystem-tag": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "$ref": "#/definitions/FilesystemInfo"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "machine-attachments": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/FilesystemAttachmentDetails"
+                                }
+                            }
+                        },
+                        "status": {
+                            "$ref": "#/definitions/EntityStatus"
+                        },
+                        "storage": {
+                            "$ref": "#/definitions/StorageDetails"
+                        },
+                        "unit-attachments": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/FilesystemAttachmentDetails"
+                                }
+                            }
+                        },
+                        "volume-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "filesystem-tag",
+                        "info",
+                        "status"
+                    ]
+                },
+                "FilesystemInfo": {
+                    "type": "object",
+                    "properties": {
+                        "filesystem-id": {
+                            "type": "string"
+                        },
+                        "pool": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "filesystem-id",
+                        "pool",
+                        "size"
+                    ]
+                },
+                "FindToolsParams": {
+                    "type": "object",
+                    "properties": {
+                        "agentstream": {
+                            "type": "string"
+                        },
+                        "arch": {
+                            "type": "string"
+                        },
+                        "major": {
+                            "type": "integer"
+                        },
+                        "number": {
+                            "$ref": "#/definitions/Number"
+                        },
+                        "os-type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "number",
+                        "major",
+                        "arch",
+                        "os-type",
+                        "agentstream"
+                    ]
+                },
+                "FindToolsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "list": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Tools"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "list"
+                    ]
+                },
+                "FullStatus": {
+                    "type": "object",
+                    "properties": {
+                        "applications": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/ApplicationStatus"
+                                }
+                            }
+                        },
+                        "branches": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/BranchStatus"
+                                }
+                            }
+                        },
+                        "controller-timestamp": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "filesystems": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/FilesystemDetails"
+                            }
+                        },
+                        "machines": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/MachineStatus"
+                                }
+                            }
+                        },
+                        "model": {
+                            "$ref": "#/definitions/ModelStatusInfo"
+                        },
+                        "offers": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/ApplicationOfferStatus"
+                                }
+                            }
+                        },
+                        "relations": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RelationStatus"
+                            }
+                        },
+                        "remote-applications": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/RemoteApplicationStatus"
+                                }
+                            }
+                        },
+                        "storage": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StorageDetails"
+                            }
+                        },
+                        "volumes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/VolumeDetails"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "model",
+                        "machines",
+                        "applications",
+                        "remote-applications",
+                        "offers",
+                        "relations",
+                        "controller-timestamp",
+                        "branches"
+                    ]
+                },
+                "History": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "statuses": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DetailedStatus"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "statuses"
+                    ]
+                },
+                "LXDProfile": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "devices": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "patternProperties": {
+                                        ".*": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config",
+                        "description",
+                        "devices"
+                    ]
+                },
+                "MachineStatus": {
+                    "type": "object",
+                    "properties": {
+                        "agent-status": {
+                            "$ref": "#/definitions/DetailedStatus"
+                        },
+                        "base": {
+                            "$ref": "#/definitions/Base"
+                        },
+                        "constraints": {
+                            "type": "string"
+                        },
+                        "containers": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/MachineStatus"
+                                }
+                            }
+                        },
+                        "display-name": {
+                            "type": "string"
+                        },
+                        "dns-name": {
+                            "type": "string"
+                        },
+                        "hardware": {
+                            "type": "string"
+                        },
+                        "has-vote": {
+                            "type": "boolean"
+                        },
+                        "hostname": {
+                            "type": "string"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "instance-id": {
+                            "type": "string"
+                        },
+                        "instance-status": {
+                            "$ref": "#/definitions/DetailedStatus"
+                        },
+                        "ip-addresses": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "jobs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "lxd-profiles": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/LXDProfile"
+                                }
+                            }
+                        },
+                        "modification-status": {
+                            "$ref": "#/definitions/DetailedStatus"
+                        },
+                        "network-interfaces": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/NetworkInterface"
+                                }
+                            }
+                        },
+                        "primary-controller-machine": {
+                            "type": "boolean"
+                        },
+                        "wants-vote": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "agent-status",
+                        "instance-status",
+                        "modification-status",
+                        "dns-name",
+                        "instance-id",
+                        "display-name",
+                        "base",
+                        "id",
+                        "containers",
+                        "constraints",
+                        "hardware",
+                        "jobs",
+                        "has-vote",
+                        "wants-vote"
+                    ]
+                },
+                "MeterStatus": {
+                    "type": "object",
+                    "properties": {
+                        "color": {
+                            "type": "string"
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "color",
+                        "message"
+                    ]
+                },
+                "ModelStatusInfo": {
+                    "type": "object",
+                    "properties": {
+                        "available-version": {
+                            "type": "string"
+                        },
+                        "cloud-tag": {
+                            "type": "string"
+                        },
+                        "meter-status": {
+                            "$ref": "#/definitions/MeterStatus"
+                        },
+                        "model-status": {
+                            "$ref": "#/definitions/DetailedStatus"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "region": {
+                            "type": "string"
+                        },
+                        "sla": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "type",
+                        "cloud-tag",
+                        "version",
+                        "available-version",
+                        "model-status",
+                        "meter-status",
+                        "sla"
+                    ]
+                },
+                "NetworkInterface": {
+                    "type": "object",
+                    "properties": {
+                        "dns-nameservers": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "gateway": {
+                            "type": "string"
+                        },
+                        "ip-addresses": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "is-up": {
+                            "type": "boolean"
+                        },
+                        "mac-address": {
+                            "type": "string"
+                        },
+                        "space": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "ip-addresses",
+                        "mac-address",
+                        "is-up"
+                    ]
+                },
+                "Number": {
+                    "type": "object",
+                    "properties": {
+                        "Build": {
+                            "type": "integer"
+                        },
+                        "Major": {
+                            "type": "integer"
+                        },
+                        "Minor": {
+                            "type": "integer"
+                        },
+                        "Patch": {
+                            "type": "integer"
+                        },
+                        "Tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Major",
+                        "Minor",
+                        "Tag",
+                        "Patch",
+                        "Build"
+                    ]
+                },
+                "RelationStatus": {
+                    "type": "object",
+                    "properties": {
+                        "endpoints": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EndpointStatus"
+                            }
+                        },
+                        "id": {
+                            "type": "integer"
+                        },
+                        "interface": {
+                            "type": "string"
+                        },
+                        "key": {
+                            "type": "string"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "$ref": "#/definitions/DetailedStatus"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "id",
+                        "key",
+                        "interface",
+                        "scope",
+                        "endpoints",
+                        "status"
+                    ]
+                },
+                "RemoteApplicationStatus": {
+                    "type": "object",
+                    "properties": {
+                        "endpoints": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RemoteEndpoint"
+                            }
+                        },
+                        "err": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "offer-name": {
+                            "type": "string"
+                        },
+                        "offer-url": {
+                            "type": "string"
+                        },
+                        "relations": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "status": {
+                            "$ref": "#/definitions/DetailedStatus"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "offer-url",
+                        "offer-name",
+                        "endpoints",
+                        "life",
+                        "relations",
+                        "status"
+                    ]
+                },
+                "RemoteEndpoint": {
+                    "type": "object",
+                    "properties": {
+                        "interface": {
+                            "type": "string"
+                        },
+                        "limit": {
+                            "type": "integer"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "role": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "role",
+                        "interface",
+                        "limit"
+                    ]
+                },
+                "StatusHistoryFilter": {
+                    "type": "object",
+                    "properties": {
+                        "date": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "delta": {
+                            "type": "integer"
+                        },
+                        "exclude": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "size": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "size",
+                        "date",
+                        "delta",
+                        "exclude"
+                    ]
+                },
+                "StatusHistoryRequest": {
+                    "type": "object",
+                    "properties": {
+                        "filter": {
+                            "$ref": "#/definitions/StatusHistoryFilter"
+                        },
+                        "historyKind": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "historyKind",
+                        "size",
+                        "filter",
+                        "tag"
+                    ]
+                },
+                "StatusHistoryRequests": {
+                    "type": "object",
+                    "properties": {
+                        "requests": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StatusHistoryRequest"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "requests"
+                    ]
+                },
+                "StatusHistoryResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "history": {
+                            "$ref": "#/definitions/History"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "history"
+                    ]
+                },
+                "StatusHistoryResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StatusHistoryResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "StatusParams": {
+                    "type": "object",
+                    "properties": {
+                        "include-storage": {
+                            "type": "boolean"
+                        },
+                        "patterns": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "patterns"
+                    ]
+                },
+                "StorageAttachmentDetails": {
+                    "type": "object",
+                    "properties": {
+                        "life": {
+                            "type": "string"
+                        },
+                        "location": {
+                            "type": "string"
+                        },
+                        "machine-tag": {
+                            "type": "string"
+                        },
+                        "storage-tag": {
+                            "type": "string"
+                        },
+                        "unit-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "storage-tag",
+                        "unit-tag",
+                        "machine-tag"
+                    ]
+                },
+                "StorageDetails": {
+                    "type": "object",
+                    "properties": {
+                        "attachments": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/StorageAttachmentDetails"
+                                }
+                            }
+                        },
+                        "kind": {
+                            "type": "integer"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "owner-tag": {
+                            "type": "string"
+                        },
+                        "persistent": {
+                            "type": "boolean"
+                        },
+                        "status": {
+                            "$ref": "#/definitions/EntityStatus"
+                        },
+                        "storage-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "storage-tag",
+                        "owner-tag",
+                        "kind",
+                        "status",
+                        "persistent"
+                    ]
+                },
+                "Tools": {
+                    "type": "object",
+                    "properties": {
+                        "sha256": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "url": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "$ref": "#/definitions/Binary"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "version",
+                        "url",
+                        "size"
+                    ]
+                },
+                "UnitStatus": {
+                    "type": "object",
+                    "properties": {
+                        "address": {
+                            "type": "string"
+                        },
+                        "agent-status": {
+                            "$ref": "#/definitions/DetailedStatus"
+                        },
+                        "charm": {
+                            "type": "string"
+                        },
+                        "leader": {
+                            "type": "boolean"
+                        },
+                        "machine": {
+                            "type": "string"
+                        },
+                        "opened-ports": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "provider-id": {
+                            "type": "string"
+                        },
+                        "public-address": {
+                            "type": "string"
+                        },
+                        "subordinates": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/UnitStatus"
+                                }
+                            }
+                        },
+                        "workload-status": {
+                            "$ref": "#/definitions/DetailedStatus"
+                        },
+                        "workload-version": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "agent-status",
+                        "workload-status",
+                        "workload-version",
+                        "machine",
+                        "opened-ports",
+                        "public-address",
+                        "charm",
+                        "subordinates"
+                    ]
+                },
+                "VolumeAttachmentDetails": {
+                    "type": "object",
+                    "properties": {
+                        "VolumeAttachmentInfo": {
+                            "$ref": "#/definitions/VolumeAttachmentInfo"
+                        },
+                        "bus-address": {
+                            "type": "string"
+                        },
+                        "device-link": {
+                            "type": "string"
+                        },
+                        "device-name": {
+                            "type": "string"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "plan-info": {
+                            "$ref": "#/definitions/VolumeAttachmentPlanInfo"
+                        },
+                        "read-only": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "VolumeAttachmentInfo"
+                    ]
+                },
+                "VolumeAttachmentInfo": {
+                    "type": "object",
+                    "properties": {
+                        "bus-address": {
+                            "type": "string"
+                        },
+                        "device-link": {
+                            "type": "string"
+                        },
+                        "device-name": {
+                            "type": "string"
+                        },
+                        "plan-info": {
+                            "$ref": "#/definitions/VolumeAttachmentPlanInfo"
+                        },
+                        "read-only": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "VolumeAttachmentPlanInfo": {
+                    "type": "object",
+                    "properties": {
+                        "device-attributes": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "device-type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "VolumeDetails": {
+                    "type": "object",
+                    "properties": {
+                        "info": {
+                            "$ref": "#/definitions/VolumeInfo"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "machine-attachments": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/VolumeAttachmentDetails"
+                                }
+                            }
+                        },
+                        "status": {
+                            "$ref": "#/definitions/EntityStatus"
+                        },
+                        "storage": {
+                            "$ref": "#/definitions/StorageDetails"
+                        },
+                        "unit-attachments": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/VolumeAttachmentDetails"
+                                }
+                            }
+                        },
+                        "volume-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "volume-tag",
+                        "info",
+                        "status"
+                    ]
+                },
+                "VolumeInfo": {
+                    "type": "object",
+                    "properties": {
+                        "hardware-id": {
+                            "type": "string"
+                        },
+                        "persistent": {
+                            "type": "boolean"
+                        },
+                        "pool": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "volume-id": {
+                            "type": "string"
+                        },
+                        "wwn": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "volume-id",
+                        "size",
+                        "persistent"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "Cloud",
+        "Description": "CloudAPI implements the cloud interface and is the concrete implementation\nof the api end point.",
+        "Version": 7,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "controller-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "AddCloud": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/AddCloudArgs"
+                        }
+                    },
+                    "description": "AddCloud adds a new cloud, different from the one managed by the controller."
+                },
+                "AddCredentials": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/TaggedCredentials"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "AddCredentials adds new credentials.\nIn contrast to UpdateCredentials() below, the new credentials can be\nfor a cloud that the controller does not manage (this is required\nfor CAAS models)"
+                },
+                "CheckCredentialsModels": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/TaggedCredentials"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/UpdateCredentialResults"
+                        }
+                    },
+                    "description": "CheckCredentialsModels validates supplied cloud credentials' content against\nmodels that currently use these credentials.\nIf there are any models that are using a credential and these models or their\ncloud instances are not going to be accessible with corresponding credential,\nthere will be detailed validation errors per model.\nThere's no Juju API client which uses this, but JAAS does,"
+                },
+                "Cloud": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/CloudResults"
+                        }
+                    },
+                    "description": "Cloud returns the cloud definitions for the specified clouds."
+                },
+                "CloudInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/CloudInfoResults"
+                        }
+                    },
+                    "description": "CloudInfo returns information about the specified clouds."
+                },
+                "Clouds": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/CloudsResult"
+                        }
+                    },
+                    "description": "Clouds returns the definitions of all clouds supported by the controller\nthat the logged in user can see."
+                },
+                "Credential": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/CloudCredentialResults"
+                        }
+                    },
+                    "description": "Credential returns the specified cloud credential for each tag, minus secrets."
+                },
+                "CredentialContents": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/CloudCredentialArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/CredentialContentResults"
+                        }
+                    },
+                    "description": "CredentialContents returns the specified cloud credentials,\nincluding the secrets if requested.\nIf no specific credential name/cloud was passed in, all credentials for this user\nare returned.\nOnly credential owner can see its contents as well as what models use it.\nController admin has no special superpowers here and is treated the same as all other users."
+                },
+                "InstanceTypes": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/CloudInstanceTypesConstraints"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/InstanceTypesResults"
+                        }
+                    },
+                    "description": "InstanceTypes returns instance type information for the cloud and region\nin which the current model is deployed."
+                },
+                "ListCloudInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ListCloudsRequest"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ListCloudInfoResults"
+                        }
+                    },
+                    "description": "ListCloudInfo returns clouds that the specified user has access to.\nController admins (superuser) can list clouds for any user.\nOther users can only ask about their own clouds."
+                },
+                "ModifyCloudAccess": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ModifyCloudAccessRequest"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "ModifyCloudAccess changes the model access granted to users."
+                },
+                "RemoveClouds": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "RemoveClouds removes the specified clouds from the controller.\nIf a cloud is in use (has models deployed to it), the removal will fail."
+                },
+                "RevokeCredentialsCheckModels": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/RevokeCredentialArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "RevokeCredentialsCheckModels revokes a set of cloud credentials.\nIf the credentials are used by any of the models, the credential deletion will be aborted.\nIf credential-in-use needs to be revoked nonetheless, this method allows the use of force."
+                },
+                "UpdateCloud": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/UpdateCloudArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "UpdateCloud updates an existing cloud that the controller knows about."
+                },
+                "UpdateCredentialsCheckModels": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/UpdateCredentialArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/UpdateCredentialResults"
+                        }
+                    },
+                    "description": "UpdateCredentialsCheckModels updates a set of cloud credentials' content.\nIf there are any models that are using a credential and these models\nare not going to be visible with updated credential content,\nthere will be detailed validation errors per model.  Such model errors are returned\nseparately and do not contribute to the overall method error status.\nController admins can 'force' an update of the credential\nregardless of whether it is deemed valid or not."
+                },
+                "UserCredentials": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/UserClouds"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringsResults"
+                        }
+                    },
+                    "description": "UserCredentials returns the cloud credentials for a set of users."
+                }
+            },
+            "definitions": {
+                "AddCloudArgs": {
+                    "type": "object",
+                    "properties": {
+                        "cloud": {
+                            "$ref": "#/definitions/Cloud"
+                        },
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "cloud",
+                        "name"
+                    ]
+                },
+                "Cloud": {
+                    "type": "object",
+                    "properties": {
+                        "auth-types": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "ca-certificates": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "endpoint": {
+                            "type": "string"
+                        },
+                        "host-cloud-region": {
+                            "type": "string"
+                        },
+                        "identity-endpoint": {
+                            "type": "string"
+                        },
+                        "is-controller-cloud": {
+                            "type": "boolean"
+                        },
+                        "region-config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "patternProperties": {
+                                        ".*": {
+                                            "type": "object",
+                                            "additionalProperties": true
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "regions": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CloudRegion"
+                            }
+                        },
+                        "skip-tls-verify": {
+                            "type": "boolean"
+                        },
+                        "storage-endpoint": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "type"
+                    ]
+                },
+                "CloudCredential": {
+                    "type": "object",
+                    "properties": {
+                        "attrs": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "auth-type": {
+                            "type": "string"
+                        },
+                        "redacted": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "auth-type"
+                    ]
+                },
+                "CloudCredentialArg": {
+                    "type": "object",
+                    "properties": {
+                        "cloud-name": {
+                            "type": "string"
+                        },
+                        "credential-name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "cloud-name",
+                        "credential-name"
+                    ]
+                },
+                "CloudCredentialArgs": {
+                    "type": "object",
+                    "properties": {
+                        "credentials": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CloudCredentialArg"
+                            }
+                        },
+                        "include-secrets": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "include-secrets"
+                    ]
+                },
+                "CloudCredentialResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/CloudCredential"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "CloudCredentialResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CloudCredentialResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "CloudDetails": {
+                    "type": "object",
+                    "properties": {
+                        "auth-types": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "endpoint": {
+                            "type": "string"
+                        },
+                        "identity-endpoint": {
+                            "type": "string"
+                        },
+                        "regions": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CloudRegion"
+                            }
+                        },
+                        "storage-endpoint": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "type"
+                    ]
+                },
+                "CloudInfo": {
+                    "type": "object",
+                    "properties": {
+                        "CloudDetails": {
+                            "$ref": "#/definitions/CloudDetails"
+                        },
+                        "users": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CloudUserInfo"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "CloudDetails",
+                        "users"
+                    ]
+                },
+                "CloudInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/CloudInfo"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "CloudInfoResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CloudInfoResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "CloudInstanceTypesConstraint": {
+                    "type": "object",
+                    "properties": {
+                        "cloud-tag": {
+                            "type": "string"
+                        },
+                        "constraints": {
+                            "$ref": "#/definitions/Value"
+                        },
+                        "region": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "cloud-tag",
+                        "region"
+                    ]
+                },
+                "CloudInstanceTypesConstraints": {
+                    "type": "object",
+                    "properties": {
+                        "constraints": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CloudInstanceTypesConstraint"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "constraints"
+                    ]
+                },
+                "CloudRegion": {
+                    "type": "object",
+                    "properties": {
+                        "endpoint": {
+                            "type": "string"
+                        },
+                        "identity-endpoint": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "storage-endpoint": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name"
+                    ]
+                },
+                "CloudResult": {
+                    "type": "object",
+                    "properties": {
+                        "cloud": {
+                            "$ref": "#/definitions/Cloud"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "CloudResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CloudResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "CloudUserInfo": {
+                    "type": "object",
+                    "properties": {
+                        "access": {
+                            "type": "string"
+                        },
+                        "display-name": {
+                            "type": "string"
+                        },
+                        "user": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "user",
+                        "display-name",
+                        "access"
+                    ]
+                },
+                "CloudsResult": {
+                    "type": "object",
+                    "properties": {
+                        "clouds": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/Cloud"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ControllerCredentialInfo": {
+                    "type": "object",
+                    "properties": {
+                        "content": {
+                            "$ref": "#/definitions/CredentialContent"
+                        },
+                        "models": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModelAccess"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "CredentialContent": {
+                    "type": "object",
+                    "properties": {
+                        "attrs": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "auth-type": {
+                            "type": "string"
+                        },
+                        "cloud": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "valid": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "cloud",
+                        "auth-type"
+                    ]
+                },
+                "CredentialContentResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/ControllerCredentialInfo"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "CredentialContentResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CredentialContentResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "InstanceType": {
+                    "type": "object",
+                    "properties": {
+                        "arches": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "cost": {
+                            "type": "integer"
+                        },
+                        "cpu-cores": {
+                            "type": "integer"
+                        },
+                        "memory": {
+                            "type": "integer"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "root-disk": {
+                            "type": "integer"
+                        },
+                        "virt-type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "arches",
+                        "cpu-cores",
+                        "memory"
+                    ]
+                },
+                "InstanceTypesResult": {
+                    "type": "object",
+                    "properties": {
+                        "cost-currency": {
+                            "type": "string"
+                        },
+                        "cost-divisor": {
+                            "type": "integer"
+                        },
+                        "cost-unit": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "instance-types": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/InstanceType"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "InstanceTypesResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/InstanceTypesResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ListCloudInfo": {
+                    "type": "object",
+                    "properties": {
+                        "CloudDetails": {
+                            "$ref": "#/definitions/CloudDetails"
+                        },
+                        "user-access": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "CloudDetails",
+                        "user-access"
+                    ]
+                },
+                "ListCloudInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/ListCloudInfo"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ListCloudInfoResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ListCloudInfoResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ListCloudsRequest": {
+                    "type": "object",
+                    "properties": {
+                        "all": {
+                            "type": "boolean"
+                        },
+                        "user-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "user-tag"
+                    ]
+                },
+                "ModelAccess": {
+                    "type": "object",
+                    "properties": {
+                        "access": {
+                            "type": "string"
+                        },
+                        "model": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ModifyCloudAccess": {
+                    "type": "object",
+                    "properties": {
+                        "access": {
+                            "type": "string"
+                        },
+                        "action": {
+                            "type": "string"
+                        },
+                        "cloud-tag": {
+                            "type": "string"
+                        },
+                        "user-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "user-tag",
+                        "cloud-tag",
+                        "action",
+                        "access"
+                    ]
+                },
+                "ModifyCloudAccessRequest": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModifyCloudAccess"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "changes"
+                    ]
+                },
+                "RevokeCredentialArg": {
+                    "type": "object",
+                    "properties": {
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "force"
+                    ]
+                },
+                "RevokeCredentialArgs": {
+                    "type": "object",
+                    "properties": {
+                        "credentials": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RevokeCredentialArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "credentials"
+                    ]
+                },
+                "StringsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StringsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StringsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "TaggedCredential": {
+                    "type": "object",
+                    "properties": {
+                        "credential": {
+                            "$ref": "#/definitions/CloudCredential"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "credential"
+                    ]
+                },
+                "TaggedCredentials": {
+                    "type": "object",
+                    "properties": {
+                        "credentials": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/TaggedCredential"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "UpdateCloudArgs": {
+                    "type": "object",
+                    "properties": {
+                        "clouds": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AddCloudArgs"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "clouds"
+                    ]
+                },
+                "UpdateCredentialArgs": {
+                    "type": "object",
+                    "properties": {
+                        "credentials": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/TaggedCredential"
+                            }
+                        },
+                        "force": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "credentials",
+                        "force"
+                    ]
+                },
+                "UpdateCredentialModelResult": {
+                    "type": "object",
+                    "properties": {
+                        "errors": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "uuid": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "uuid",
+                        "name"
+                    ]
+                },
+                "UpdateCredentialResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "models": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UpdateCredentialModelResult"
+                            }
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "UpdateCredentialResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UpdateCredentialResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "UserCloud": {
+                    "type": "object",
+                    "properties": {
+                        "cloud-tag": {
+                            "type": "string"
+                        },
+                        "user-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "user-tag",
+                        "cloud-tag"
+                    ]
+                },
+                "UserClouds": {
+                    "type": "object",
+                    "properties": {
+                        "user-clouds": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UserCloud"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "Value": {
+                    "type": "object",
+                    "properties": {
+                        "allocate-public-ip": {
+                            "type": "boolean"
+                        },
+                        "arch": {
+                            "type": "string"
+                        },
+                        "container": {
+                            "type": "string"
+                        },
+                        "cores": {
+                            "type": "integer"
+                        },
+                        "cpu-power": {
+                            "type": "integer"
+                        },
+                        "image-id": {
+                            "type": "string"
+                        },
+                        "instance-role": {
+                            "type": "string"
+                        },
+                        "instance-type": {
+                            "type": "string"
+                        },
+                        "mem": {
+                            "type": "integer"
+                        },
+                        "root-disk": {
+                            "type": "integer"
+                        },
+                        "root-disk-source": {
+                            "type": "string"
+                        },
+                        "spaces": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "tags": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "virt-type": {
+                            "type": "string"
+                        },
+                        "zones": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            }
+        }
+    },
+    {
+        "Name": "Controller",
+        "Description": "ControllerAPI provides the Controller API.",
+        "Version": 11,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "controller-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "AllModels": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/UserModelList"
+                        }
+                    },
+                    "description": "AllModels allows controller administrators to get the list of all the\nmodels in the controller."
+                },
+                "CloudSpec": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/CloudSpecResults"
+                        }
+                    },
+                    "description": "CloudSpec returns the model's cloud spec."
+                },
+                "ConfigSet": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ControllerConfigSet"
+                        }
+                    },
+                    "description": "ConfigSet changes the value of specified controller configuration\nsettings. Only some settings can be changed after bootstrap.\nSettings that aren't specified in the params are left unchanged."
+                },
+                "ControllerAPIInfoForModels": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ControllerAPIInfoResults"
+                        }
+                    },
+                    "description": "ControllerAPIInfoForModels returns the controller api connection details for the specified models."
+                },
+                "ControllerConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/ControllerConfigResult"
+                        }
+                    },
+                    "description": "ControllerConfig returns the controller's configuration."
+                },
+                "ControllerVersion": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/ControllerVersionResults"
+                        }
+                    },
+                    "description": "ControllerVersion returns the version information associated with this\ncontroller binary.\n\nNOTE: the implementation intentionally does not check for SuperuserAccess\nas the Version is known even to users with login access."
+                },
+                "DashboardConnectionInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/DashboardConnectionInfo"
+                        }
+                    },
+                    "description": "DashboardConnectionInfo returns the connection information for a client to\nconnect to the Juju Dashboard including any proxying information."
+                },
+                "DestroyController": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/DestroyControllerArgs"
+                        }
+                    },
+                    "description": "DestroyController destroys the controller.\n\nIf the args specify the destruction of the models, this method will\nattempt to do so. Otherwise, if the controller has any non-empty,\nnon-Dead hosted models, then an error with the code\nparams.CodeHasHostedModels will be transmitted."
+                },
+                "GetCloudSpec": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ModelTag"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/CloudSpecResult"
+                        }
+                    },
+                    "description": "GetCloudSpec constructs the CloudSpec for a validated and authorized model."
+                },
+                "GetControllerAccess": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/UserAccessResults"
+                        }
+                    },
+                    "description": "GetControllerAccess returns the level of access the specified users\nhave on the controller."
+                },
+                "HostedModelConfigs": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/HostedModelConfigsResults"
+                        }
+                    },
+                    "description": "HostedModelConfigs returns all the information that the client needs in\norder to connect directly with the host model's provider and destroy it\ndirectly."
+                },
+                "IdentityProviderURL": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/StringResult"
+                        }
+                    },
+                    "description": "IdentityProviderURL returns the URL of the configured external identity\nprovider for this controller or an empty string if no external identity\nprovider has been configured when the controller was bootstrapped.\n\nNOTE: the implementation intentionally does not check for SuperuserAccess\nas the URL is known even to users with login access."
+                },
+                "InitiateMigration": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/InitiateMigrationArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/InitiateMigrationResults"
+                        }
+                    },
+                    "description": "InitiateMigration attempts to begin the migration of one or\nmore models to other controllers."
+                },
+                "ListBlockedModels": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/ModelBlockInfoList"
+                        }
+                    },
+                    "description": "ListBlockedModels returns a list of all models on the controller\nwhich have a block in place.  The resulting slice is sorted by model\nname, then owner. Callers must be controller administrators to retrieve the\nlist."
+                },
+                "ModelConfig": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/ModelConfigResults"
+                        }
+                    },
+                    "description": "ModelConfig returns the model config for the controller\nmodel.  For information on the current model, use\nclient.ModelGet"
+                },
+                "ModelStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ModelStatusResults"
+                        }
+                    },
+                    "description": "ModelStatus returns a summary of the model."
+                },
+                "ModifyControllerAccess": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ModifyControllerAccessRequest"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "ModifyControllerAccess changes the model access granted to users."
+                },
+                "MongoVersion": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/StringResult"
+                        }
+                    },
+                    "description": "MongoVersion allows the introspection of the mongo version per controller"
+                },
+                "RemoveBlocks": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/RemoveBlocksArgs"
+                        }
+                    },
+                    "description": "RemoveBlocks removes all the blocks in the controller."
+                },
+                "WatchAllModelSummaries": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/SummaryWatcherID"
+                        }
+                    },
+                    "description": "WatchAllModelSummaries starts watching the summary updates from the cache.\nThis method is superuser access only, and watches all models in the\ncontroller."
+                },
+                "WatchAllModels": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/AllWatcherId"
+                        }
+                    },
+                    "description": "WatchAllModels starts watching events for all models in the\ncontroller. The returned AllWatcherId should be used with Next on the\nAllModelWatcher endpoint to receive deltas."
+                },
+                "WatchCloudSpecsChanges": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
+                        }
+                    },
+                    "description": "WatchCloudSpecsChanges returns a watcher for cloud spec changes."
+                },
+                "WatchModelSummaries": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/SummaryWatcherID"
+                        }
+                    },
+                    "description": "WatchModelSummaries starts watching the summary updates from the cache.\nOnly models that the user has access to are returned."
+                }
+            },
+            "definitions": {
+                "AllWatcherId": {
+                    "type": "object",
+                    "properties": {
+                        "watcher-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "watcher-id"
+                    ]
+                },
+                "CloudCredential": {
+                    "type": "object",
+                    "properties": {
+                        "attrs": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "auth-type": {
+                            "type": "string"
+                        },
+                        "redacted": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "auth-type"
+                    ]
+                },
+                "CloudSpec": {
+                    "type": "object",
+                    "properties": {
+                        "cacertificates": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "credential": {
+                            "$ref": "#/definitions/CloudCredential"
+                        },
+                        "endpoint": {
+                            "type": "string"
+                        },
+                        "identity-endpoint": {
+                            "type": "string"
+                        },
+                        "is-controller-cloud": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "region": {
+                            "type": "string"
+                        },
+                        "skip-tls-verify": {
+                            "type": "boolean"
+                        },
+                        "storage-endpoint": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "type",
+                        "name"
+                    ]
+                },
+                "CloudSpecResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/CloudSpec"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "CloudSpecResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CloudSpecResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ConfigValue": {
+                    "type": "object",
+                    "properties": {
+                        "source": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "value",
+                        "source"
+                    ]
+                },
+                "ControllerAPIInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "addresses": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "cacert": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "addresses",
+                        "cacert"
+                    ]
+                },
+                "ControllerAPIInfoResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ControllerAPIInfoResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ControllerConfigResult": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config"
+                    ]
+                },
+                "ControllerConfigSet": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config"
+                    ]
+                },
+                "ControllerVersionResults": {
+                    "type": "object",
+                    "properties": {
+                        "git-commit": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "version",
+                        "git-commit"
+                    ]
+                },
+                "DashboardConnectionInfo": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "proxy-connection": {
+                            "$ref": "#/definitions/Proxy"
+                        },
+                        "ssh-connection": {
+                            "$ref": "#/definitions/DashboardConnectionSSHTunnel"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "proxy-connection",
+                        "ssh-connection"
+                    ]
+                },
+                "DashboardConnectionSSHTunnel": {
+                    "type": "object",
+                    "properties": {
+                        "entity": {
+                            "type": "string"
+                        },
+                        "host": {
+                            "type": "string"
+                        },
+                        "model": {
+                            "type": "string"
+                        },
+                        "port": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "host",
+                        "port"
+                    ]
+                },
+                "DestroyControllerArgs": {
+                    "type": "object",
+                    "properties": {
+                        "destroy-models": {
+                            "type": "boolean"
+                        },
+                        "destroy-storage": {
+                            "type": "boolean"
+                        },
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "max-wait": {
+                            "type": "integer"
+                        },
+                        "model-timeout": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "destroy-models"
+                    ]
+                },
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "HostedModelConfig": {
+                    "type": "object",
+                    "properties": {
+                        "cloud-spec": {
+                            "$ref": "#/definitions/CloudSpec"
+                        },
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "owner": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "owner"
+                    ]
+                },
+                "HostedModelConfigsResults": {
+                    "type": "object",
+                    "properties": {
+                        "models": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/HostedModelConfig"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "models"
+                    ]
+                },
+                "InitiateMigrationArgs": {
+                    "type": "object",
+                    "properties": {
+                        "specs": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MigrationSpec"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "specs"
+                    ]
+                },
+                "InitiateMigrationResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "migration-id": {
+                            "type": "string"
+                        },
+                        "model-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "model-tag",
+                        "migration-id"
+                    ]
+                },
+                "InitiateMigrationResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/InitiateMigrationResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "MachineHardware": {
+                    "type": "object",
+                    "properties": {
+                        "arch": {
+                            "type": "string"
+                        },
+                        "availability-zone": {
+                            "type": "string"
+                        },
+                        "cores": {
+                            "type": "integer"
+                        },
+                        "cpu-power": {
+                            "type": "integer"
+                        },
+                        "mem": {
+                            "type": "integer"
+                        },
+                        "root-disk": {
+                            "type": "integer"
+                        },
+                        "tags": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "virt-type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "MigrationSpec": {
+                    "type": "object",
+                    "properties": {
+                        "model-tag": {
+                            "type": "string"
+                        },
+                        "target-info": {
+                            "$ref": "#/definitions/MigrationTargetInfo"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "model-tag",
+                        "target-info"
+                    ]
+                },
+                "MigrationTargetInfo": {
+                    "type": "object",
+                    "properties": {
+                        "addrs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "auth-tag": {
+                            "type": "string"
+                        },
+                        "ca-cert": {
+                            "type": "string"
+                        },
+                        "controller-alias": {
+                            "type": "string"
+                        },
+                        "controller-tag": {
+                            "type": "string"
+                        },
+                        "macaroons": {
+                            "type": "string"
+                        },
+                        "password": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "controller-tag",
+                        "addrs",
+                        "ca-cert",
+                        "auth-tag"
+                    ]
+                },
+                "Model": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "owner-tag": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "uuid": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "uuid",
+                        "type",
+                        "owner-tag"
+                    ]
+                },
+                "ModelApplicationInfo": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name"
+                    ]
+                },
+                "ModelBlockInfo": {
+                    "type": "object",
+                    "properties": {
+                        "blocks": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "model-uuid": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "owner-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "model-uuid",
+                        "owner-tag",
+                        "blocks"
+                    ]
+                },
+                "ModelBlockInfoList": {
+                    "type": "object",
+                    "properties": {
+                        "models": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModelBlockInfo"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ModelConfigResults": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/ConfigValue"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config"
+                    ]
+                },
+                "ModelFilesystemInfo": {
+                    "type": "object",
+                    "properties": {
+                        "detachable": {
+                            "type": "boolean"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "message": {
+                            "type": "string"
+                        },
+                        "provider-id": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "id"
+                    ]
+                },
+                "ModelMachineInfo": {
+                    "type": "object",
+                    "properties": {
+                        "display-name": {
+                            "type": "string"
+                        },
+                        "ha-primary": {
+                            "type": "boolean"
+                        },
+                        "hardware": {
+                            "$ref": "#/definitions/MachineHardware"
+                        },
+                        "has-vote": {
+                            "type": "boolean"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "instance-id": {
+                            "type": "string"
+                        },
+                        "message": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "wants-vote": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "id"
+                    ]
+                },
+                "ModelStatus": {
+                    "type": "object",
+                    "properties": {
+                        "application-count": {
+                            "type": "integer"
+                        },
+                        "applications": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModelApplicationInfo"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "filesystems": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModelFilesystemInfo"
+                            }
+                        },
+                        "hosted-machine-count": {
+                            "type": "integer"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "machines": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModelMachineInfo"
+                            }
+                        },
+                        "model-tag": {
+                            "type": "string"
+                        },
+                        "owner-tag": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "unit-count": {
+                            "type": "integer"
+                        },
+                        "volumes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModelVolumeInfo"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "model-tag",
+                        "life",
+                        "type",
+                        "hosted-machine-count",
+                        "application-count",
+                        "unit-count",
+                        "owner-tag"
+                    ]
+                },
+                "ModelStatusResults": {
+                    "type": "object",
+                    "properties": {
+                        "models": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModelStatus"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "models"
+                    ]
+                },
+                "ModelTag": {
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "ModelVolumeInfo": {
+                    "type": "object",
+                    "properties": {
+                        "detachable": {
+                            "type": "boolean"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "message": {
+                            "type": "string"
+                        },
+                        "provider-id": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "id"
+                    ]
+                },
+                "ModifyControllerAccess": {
+                    "type": "object",
+                    "properties": {
+                        "access": {
+                            "type": "string"
+                        },
+                        "action": {
+                            "type": "string"
+                        },
+                        "user-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "user-tag",
+                        "action",
+                        "access"
+                    ]
+                },
+                "ModifyControllerAccessRequest": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModifyControllerAccess"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "changes"
+                    ]
+                },
+                "NotifyWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "NotifyWatcherId": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "NotifyWatcherId"
+                    ]
+                },
+                "NotifyWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NotifyWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "Proxy": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config",
+                        "type"
+                    ]
+                },
+                "RemoveBlocksArgs": {
+                    "type": "object",
+                    "properties": {
+                        "all": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "all"
+                    ]
+                },
+                "StringResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "SummaryWatcherID": {
+                    "type": "object",
+                    "properties": {
+                        "watcher-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "watcher-id"
+                    ]
+                },
+                "UserAccess": {
+                    "type": "object",
+                    "properties": {
+                        "access": {
+                            "type": "string"
+                        },
+                        "user-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "user-tag",
+                        "access"
+                    ]
+                },
+                "UserAccessResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/UserAccess"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "UserAccessResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UserAccessResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "UserModel": {
+                    "type": "object",
+                    "properties": {
+                        "last-connection": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "model": {
+                            "$ref": "#/definitions/Model"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "model",
+                        "last-connection"
+                    ]
+                },
+                "UserModelList": {
+                    "type": "object",
+                    "properties": {
+                        "user-models": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UserModel"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "user-models"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "CredentialManager",
+        "Description": "",
+        "Version": 1,
+        "AvailableTo": [
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "InvalidateModelCredential": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/InvalidateCredentialArg"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResult"
+                        }
+                    },
+                    "description": "InvalidateModelCredential marks the cloud credential for this model as invalid."
+                }
+            },
+            "definitions": {
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "InvalidateCredentialArg": {
+                    "type": "object",
+                    "properties": {
+                        "reason": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            }
+        }
+    },
+    {
+        "Name": "HighAvailability",
+        "Description": "HighAvailabilityAPI implements the HighAvailability interface and is the concrete\nimplementation of the api end point.",
+        "Version": 2,
+        "AvailableTo": [
+            "controller-user",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "EnableHA": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ControllersSpecs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ControllersChangeResults"
+                        }
+                    },
+                    "description": "EnableHA adds controller machines as necessary to ensure the\ncontroller has the number of machines specified."
+                }
+            },
+            "definitions": {
+                "ControllersChangeResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/ControllersChanges"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "ControllersChangeResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ControllersChangeResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ControllersChanges": {
+                    "type": "object",
+                    "properties": {
+                        "added": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "converted": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "maintained": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "removed": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ControllersSpec": {
+                    "type": "object",
+                    "properties": {
+                        "constraints": {
+                            "$ref": "#/definitions/Value"
+                        },
+                        "num-controllers": {
+                            "type": "integer"
+                        },
+                        "placement": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "num-controllers"
+                    ]
+                },
+                "ControllersSpecs": {
+                    "type": "object",
+                    "properties": {
+                        "specs": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ControllersSpec"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "specs"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "Value": {
+                    "type": "object",
+                    "properties": {
+                        "allocate-public-ip": {
+                            "type": "boolean"
+                        },
+                        "arch": {
+                            "type": "string"
+                        },
+                        "container": {
+                            "type": "string"
+                        },
+                        "cores": {
+                            "type": "integer"
+                        },
+                        "cpu-power": {
+                            "type": "integer"
+                        },
+                        "image-id": {
+                            "type": "string"
+                        },
+                        "instance-role": {
+                            "type": "string"
+                        },
+                        "instance-type": {
+                            "type": "string"
+                        },
+                        "mem": {
+                            "type": "integer"
+                        },
+                        "root-disk": {
+                            "type": "integer"
+                        },
+                        "root-disk-source": {
+                            "type": "string"
+                        },
+                        "spaces": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "tags": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "virt-type": {
+                            "type": "string"
+                        },
+                        "zones": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            }
+        }
+    },
+    {
+        "Name": "ImageMetadataManager",
+        "Description": "API is the concrete implementation of the api end point\nfor loud image metadata manipulations.",
+        "Version": 1,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "Delete": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/MetadataImageIds"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "Delete deletes cloud image metadata for given image ids.\nIt supports bulk calls."
+                },
+                "List": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ImageMetadataFilter"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ListCloudImageMetadataResult"
+                        }
+                    },
+                    "description": "List returns all found cloud image metadata that satisfy\ngiven filter.\nReturned list contains metadata ordered by priority."
+                },
+                "Save": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/MetadataSaveParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "Save stores given cloud image metadata.\nIt supports bulk calls."
+                }
+            },
+            "definitions": {
+                "CloudImageMetadata": {
+                    "type": "object",
+                    "properties": {
+                        "arch": {
+                            "type": "string"
+                        },
+                        "image-id": {
+                            "type": "string"
+                        },
+                        "priority": {
+                            "type": "integer"
+                        },
+                        "region": {
+                            "type": "string"
+                        },
+                        "root-storage-size": {
+                            "type": "integer"
+                        },
+                        "root-storage-type": {
+                            "type": "string"
+                        },
+                        "source": {
+                            "type": "string"
+                        },
+                        "stream": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        },
+                        "virt-type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "image-id",
+                        "region",
+                        "version",
+                        "arch",
+                        "source",
+                        "priority"
+                    ]
+                },
+                "CloudImageMetadataList": {
+                    "type": "object",
+                    "properties": {
+                        "metadata": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CloudImageMetadata"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ImageMetadataFilter": {
+                    "type": "object",
+                    "properties": {
+                        "arches": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "region": {
+                            "type": "string"
+                        },
+                        "root-storage-type": {
+                            "type": "string"
+                        },
+                        "stream": {
+                            "type": "string"
+                        },
+                        "versions": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "virt-type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ListCloudImageMetadataResult": {
+                    "type": "object",
+                    "properties": {
+                        "result": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CloudImageMetadata"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "MetadataImageIds": {
+                    "type": "object",
+                    "properties": {
+                        "image-ids": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "image-ids"
+                    ]
+                },
+                "MetadataSaveParams": {
+                    "type": "object",
+                    "properties": {
+                        "metadata": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CloudImageMetadataList"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            }
+        }
+    },
+    {
+        "Name": "KeyManager",
+        "Description": "KeyManagerAPI provides api endpoints for manipulating ssh keys",
+        "Version": 1,
+        "AvailableTo": [
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "AddKeys": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ModifyUserSSHKeys"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "AddKeys adds new authorised ssh keys for the specified user."
+                },
+                "DeleteKeys": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ModifyUserSSHKeys"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "DeleteKeys deletes the authorised ssh keys for the specified user."
+                },
+                "ImportKeys": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ModifyUserSSHKeys"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "ImportKeys imports new authorised ssh keys from the specified key ids for the specified user."
+                },
+                "ListKeys": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ListSSHKeys"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringsResults"
+                        }
+                    },
+                    "description": "ListKeys returns the authorised ssh keys for the specified users."
+                }
+            },
+            "definitions": {
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ListSSHKeys": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "mode": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities",
+                        "mode"
+                    ]
+                },
+                "ModifyUserSSHKeys": {
+                    "type": "object",
+                    "properties": {
+                        "ssh-keys": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "user": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "user",
+                        "ssh-keys"
+                    ]
+                },
+                "StringsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StringsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StringsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "MachineManager",
+        "Description": "MachineManagerAPI provides access to the MachineManager API facade.",
+        "Version": 10,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "AddMachines": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/AddMachines"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/AddMachinesResults"
+                        }
+                    },
+                    "description": "AddMachines adds new machines with the supplied parameters.\nThe args will contain Base info."
+                },
+                "DestroyMachineWithParams": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/DestroyMachinesParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/DestroyMachineResults"
+                        }
+                    },
+                    "description": "DestroyMachineWithParams removes a set of machines from the model."
+                },
+                "GetUpgradeSeriesMessages": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/UpgradeSeriesNotificationParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringsResults"
+                        }
+                    },
+                    "description": "GetUpgradeSeriesMessages returns all new messages associated with upgrade\nseries events. Messages that have already been retrieved once are not\nreturned by this method."
+                },
+                "InstanceTypes": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ModelInstanceTypesConstraints"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/InstanceTypesResults"
+                        }
+                    },
+                    "description": "InstanceTypes returns instance type information for the cloud and region\nin which the current model is deployed."
+                },
+                "ProvisioningScript": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ProvisioningScriptParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ProvisioningScriptResult"
+                        }
+                    },
+                    "description": "ProvisioningScript returns a shell script that, when run,\nprovisions a machine agent on the machine executing the script."
+                },
+                "RetryProvisioning": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/RetryProvisioningArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "RetryProvisioning marks a provisioning error as transient on the machines."
+                },
+                "UpgradeSeriesComplete": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/UpdateChannelArg"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResult"
+                        }
+                    },
+                    "description": "UpgradeSeriesComplete marks a machine as having completed a managed series\nupgrade."
+                },
+                "UpgradeSeriesPrepare": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/UpdateChannelArg"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResult"
+                        }
+                    },
+                    "description": "UpgradeSeriesPrepare prepares a machine for a OS series upgrade."
+                },
+                "UpgradeSeriesValidate": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/UpdateChannelArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/UpgradeSeriesUnitsResults"
+                        }
+                    },
+                    "description": "UpgradeSeriesValidate validates that the incoming arguments correspond to a\nvalid series upgrade for the target machine.\nIf they do, a list of the machine's current units is returned for use in\nsoliciting user confirmation of the command."
+                },
+                "WatchUpgradeSeriesNotifications": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/NotifyWatchResults"
+                        }
+                    },
+                    "description": "WatchUpgradeSeriesNotifications returns a watcher that fires on upgrade\nseries events."
+                }
+            },
+            "definitions": {
+                "AddMachineParams": {
+                    "type": "object",
+                    "properties": {
+                        "addresses": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Address"
+                            }
+                        },
+                        "base": {
+                            "$ref": "#/definitions/Base"
+                        },
+                        "constraints": {
+                            "$ref": "#/definitions/Value"
+                        },
+                        "container-type": {
+                            "type": "string"
+                        },
+                        "disks": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Constraints"
+                            }
+                        },
+                        "hardware-characteristics": {
+                            "$ref": "#/definitions/HardwareCharacteristics"
+                        },
+                        "instance-id": {
+                            "type": "string"
+                        },
+                        "jobs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "nonce": {
+                            "type": "string"
+                        },
+                        "parent-id": {
+                            "type": "string"
+                        },
+                        "placement": {
+                            "$ref": "#/definitions/Placement"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "constraints",
+                        "jobs",
+                        "parent-id",
+                        "container-type",
+                        "instance-id",
+                        "nonce",
+                        "hardware-characteristics",
+                        "addresses"
+                    ]
+                },
+                "AddMachines": {
+                    "type": "object",
+                    "properties": {
+                        "params": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AddMachineParams"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "params"
+                    ]
+                },
+                "AddMachinesResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "machine": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "machine"
+                    ]
+                },
+                "AddMachinesResults": {
+                    "type": "object",
+                    "properties": {
+                        "machines": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AddMachinesResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "machines"
+                    ]
+                },
+                "Address": {
+                    "type": "object",
+                    "properties": {
+                        "cidr": {
+                            "type": "string"
+                        },
+                        "config-type": {
+                            "type": "string"
+                        },
+                        "is-secondary": {
+                            "type": "boolean"
+                        },
+                        "scope": {
+                            "type": "string"
+                        },
+                        "space-id": {
+                            "type": "string"
+                        },
+                        "space-name": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "value",
+                        "type",
+                        "scope"
+                    ]
+                },
+                "Base": {
+                    "type": "object",
+                    "properties": {
+                        "channel": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "channel"
+                    ]
+                },
+                "Constraints": {
+                    "type": "object",
+                    "properties": {
+                        "Count": {
+                            "type": "integer"
+                        },
+                        "Pool": {
+                            "type": "string"
+                        },
+                        "Size": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Pool",
+                        "Size",
+                        "Count"
+                    ]
+                },
+                "DestroyMachineInfo": {
+                    "type": "object",
+                    "properties": {
+                        "destroyed-containers": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DestroyMachineResult"
+                            }
+                        },
+                        "destroyed-storage": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        },
+                        "destroyed-units": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        },
+                        "detached-storage": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        },
+                        "machine-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "machine-id"
+                    ]
+                },
+                "DestroyMachineResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "info": {
+                            "$ref": "#/definitions/DestroyMachineInfo"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "DestroyMachineResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DestroyMachineResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "DestroyMachinesParams": {
+                    "type": "object",
+                    "properties": {
+                        "dry-run": {
+                            "type": "boolean"
+                        },
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "keep": {
+                            "type": "boolean"
+                        },
+                        "machine-tags": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "max-wait": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "machine-tags"
+                    ]
+                },
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "HardwareCharacteristics": {
+                    "type": "object",
+                    "properties": {
+                        "arch": {
+                            "type": "string"
+                        },
+                        "availability-zone": {
+                            "type": "string"
+                        },
+                        "cpu-cores": {
+                            "type": "integer"
+                        },
+                        "cpu-power": {
+                            "type": "integer"
+                        },
+                        "mem": {
+                            "type": "integer"
+                        },
+                        "root-disk": {
+                            "type": "integer"
+                        },
+                        "root-disk-source": {
+                            "type": "string"
+                        },
+                        "tags": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "virt-type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "InstanceType": {
+                    "type": "object",
+                    "properties": {
+                        "arches": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "cost": {
+                            "type": "integer"
+                        },
+                        "cpu-cores": {
+                            "type": "integer"
+                        },
+                        "memory": {
+                            "type": "integer"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "root-disk": {
+                            "type": "integer"
+                        },
+                        "virt-type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "arches",
+                        "cpu-cores",
+                        "memory"
+                    ]
+                },
+                "InstanceTypesResult": {
+                    "type": "object",
+                    "properties": {
+                        "cost-currency": {
+                            "type": "string"
+                        },
+                        "cost-divisor": {
+                            "type": "integer"
+                        },
+                        "cost-unit": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "instance-types": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/InstanceType"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "InstanceTypesResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/InstanceTypesResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ModelInstanceTypesConstraint": {
+                    "type": "object",
+                    "properties": {
+                        "value": {
+                            "$ref": "#/definitions/Value"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ModelInstanceTypesConstraints": {
+                    "type": "object",
+                    "properties": {
+                        "constraints": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModelInstanceTypesConstraint"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "constraints"
+                    ]
+                },
+                "NotifyWatchResult": {
+                    "type": "object",
+                    "properties": {
+                        "NotifyWatcherId": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "NotifyWatcherId"
+                    ]
+                },
+                "NotifyWatchResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/NotifyWatchResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "Placement": {
+                    "type": "object",
+                    "properties": {
+                        "directive": {
+                            "type": "string"
+                        },
+                        "scope": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "scope",
+                        "directive"
+                    ]
+                },
+                "ProvisioningScriptParams": {
+                    "type": "object",
+                    "properties": {
+                        "data-dir": {
+                            "type": "string"
+                        },
+                        "disable-package-commands": {
+                            "type": "boolean"
+                        },
+                        "machine-id": {
+                            "type": "string"
+                        },
+                        "nonce": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "machine-id",
+                        "nonce",
+                        "data-dir",
+                        "disable-package-commands"
+                    ]
+                },
+                "ProvisioningScriptResult": {
+                    "type": "object",
+                    "properties": {
+                        "script": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "script"
+                    ]
+                },
+                "RetryProvisioningArgs": {
+                    "type": "object",
+                    "properties": {
+                        "all": {
+                            "type": "boolean"
+                        },
+                        "machines": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "all"
+                    ]
+                },
+                "StringsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StringsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StringsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "UpdateChannelArg": {
+                    "type": "object",
+                    "properties": {
+                        "channel": {
+                            "type": "string"
+                        },
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "tag": {
+                            "$ref": "#/definitions/Entity"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "force",
+                        "channel"
+                    ]
+                },
+                "UpdateChannelArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UpdateChannelArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
+                "UpgradeSeriesNotificationParam": {
+                    "type": "object",
+                    "properties": {
+                        "entity": {
+                            "$ref": "#/definitions/Entity"
+                        },
+                        "watcher-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entity",
+                        "watcher-id"
+                    ]
+                },
+                "UpgradeSeriesNotificationParams": {
+                    "type": "object",
+                    "properties": {
+                        "params": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UpgradeSeriesNotificationParam"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "params"
+                    ]
+                },
+                "UpgradeSeriesUnitsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "unit-names": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "unit-names"
+                    ]
+                },
+                "UpgradeSeriesUnitsResults": {
+                    "type": "object",
+                    "properties": {
+                        "Results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UpgradeSeriesUnitsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Results"
+                    ]
+                },
+                "Value": {
+                    "type": "object",
+                    "properties": {
+                        "allocate-public-ip": {
+                            "type": "boolean"
+                        },
+                        "arch": {
+                            "type": "string"
+                        },
+                        "container": {
+                            "type": "string"
+                        },
+                        "cores": {
+                            "type": "integer"
+                        },
+                        "cpu-power": {
+                            "type": "integer"
+                        },
+                        "image-id": {
+                            "type": "string"
+                        },
+                        "instance-role": {
+                            "type": "string"
+                        },
+                        "instance-type": {
+                            "type": "string"
+                        },
+                        "mem": {
+                            "type": "integer"
+                        },
+                        "root-disk": {
+                            "type": "integer"
+                        },
+                        "root-disk-source": {
+                            "type": "string"
+                        },
+                        "spaces": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "tags": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "virt-type": {
+                            "type": "string"
+                        },
+                        "zones": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            }
+        }
+    },
+    {
+        "Name": "MetricsDebug",
+        "Description": "MetricsDebugAPI implements the metricsdebug interface and is the concrete\nimplementation of the api end point.",
+        "Version": 2,
+        "AvailableTo": [
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "GetMetrics": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/MetricResults"
+                        }
+                    },
+                    "description": "GetMetrics returns all metrics stored by the state server."
+                },
+                "SetMeterStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/MeterStatusParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "SetMeterStatus sets meter statuses for entities."
+                }
+            },
+            "definitions": {
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "EntityMetrics": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "metrics": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MetricResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "MeterStatusParam": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "code"
+                    ]
+                },
+                "MeterStatusParams": {
+                    "type": "object",
+                    "properties": {
+                        "statues": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MeterStatusParam"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "statues"
+                    ]
+                },
+                "MetricResult": {
+                    "type": "object",
+                    "properties": {
+                        "key": {
+                            "type": "string"
+                        },
+                        "labels": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "unit": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "time",
+                        "key",
+                        "value",
+                        "unit",
+                        "labels"
+                    ]
+                },
+                "MetricResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EntityMetrics"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "ModelConfig",
+        "Description": "ModelConfigAPIV3 is currently the latest.",
+        "Version": 3,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "controller-user",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "GetModelConstraints": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/GetConstraintsResults"
+                        }
+                    },
+                    "description": "GetModelConstraints returns the constraints for the model."
+                },
+                "ModelGet": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/ModelConfigResults"
+                        }
+                    },
+                    "description": "ModelGet implements the server-side part of the\nmodel-config CLI command."
+                },
+                "ModelSet": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ModelSet"
+                        }
+                    },
+                    "description": "ModelSet implements the server-side part of the\nset-model-config CLI command."
+                },
+                "ModelUnset": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ModelUnset"
+                        }
+                    },
+                    "description": "ModelUnset implements the server-side part of the\nset-model-config CLI command."
+                },
+                "SLALevel": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/StringResult"
+                        }
+                    },
+                    "description": "SLALevel returns the current sla level for the model."
+                },
+                "Sequences": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/ModelSequencesResult"
+                        }
+                    },
+                    "description": "Sequences returns the model's sequence names and next values."
+                },
+                "SetModelConstraints": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetConstraints"
+                        }
+                    },
+                    "description": "SetModelConstraints sets the constraints for the model."
+                },
+                "SetSLALevel": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ModelSLA"
+                        }
+                    },
+                    "description": "SetSLALevel sets the sla level on the model."
+                }
+            },
+            "definitions": {
+                "ConfigValue": {
+                    "type": "object",
+                    "properties": {
+                        "source": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "value",
+                        "source"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "GetConstraintsResults": {
+                    "type": "object",
+                    "properties": {
+                        "constraints": {
+                            "$ref": "#/definitions/Value"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "constraints"
+                    ]
+                },
+                "ModelConfigResults": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/ConfigValue"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config"
+                    ]
+                },
+                "ModelSLA": {
+                    "type": "object",
+                    "properties": {
+                        "ModelSLAInfo": {
+                            "$ref": "#/definitions/ModelSLAInfo"
+                        },
+                        "creds": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "level": {
+                            "type": "string"
+                        },
+                        "owner": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "level",
+                        "owner",
+                        "ModelSLAInfo",
+                        "creds"
+                    ]
+                },
+                "ModelSLAInfo": {
+                    "type": "object",
+                    "properties": {
+                        "level": {
+                            "type": "string"
+                        },
+                        "owner": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "level",
+                        "owner"
+                    ]
+                },
+                "ModelSequencesResult": {
+                    "type": "object",
+                    "properties": {
+                        "sequences": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "sequences"
+                    ]
+                },
+                "ModelSet": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config"
+                    ]
+                },
+                "ModelUnset": {
+                    "type": "object",
+                    "properties": {
+                        "keys": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "keys"
+                    ]
+                },
+                "SetConstraints": {
+                    "type": "object",
+                    "properties": {
+                        "application": {
+                            "type": "string"
+                        },
+                        "constraints": {
+                            "$ref": "#/definitions/Value"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application",
+                        "constraints"
+                    ]
+                },
+                "StringResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "Value": {
+                    "type": "object",
+                    "properties": {
+                        "allocate-public-ip": {
+                            "type": "boolean"
+                        },
+                        "arch": {
+                            "type": "string"
+                        },
+                        "container": {
+                            "type": "string"
+                        },
+                        "cores": {
+                            "type": "integer"
+                        },
+                        "cpu-power": {
+                            "type": "integer"
+                        },
+                        "image-id": {
+                            "type": "string"
+                        },
+                        "instance-role": {
+                            "type": "string"
+                        },
+                        "instance-type": {
+                            "type": "string"
+                        },
+                        "mem": {
+                            "type": "integer"
+                        },
+                        "root-disk": {
+                            "type": "integer"
+                        },
+                        "root-disk-source": {
+                            "type": "string"
+                        },
+                        "spaces": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "tags": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "virt-type": {
+                            "type": "string"
+                        },
+                        "zones": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            }
+        }
+    },
+    {
+        "Name": "ModelGeneration",
+        "Description": "API is the concrete implementation of the API endpoint.",
+        "Version": 4,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "AbortBranch": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/BranchArg"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResult"
+                        }
+                    },
+                    "description": "AbortBranch aborts the input branch, marking it complete.  However no\nchanges are made applicable to the whole model.  No units may be assigned\nto the branch when aborting."
+                },
+                "AddBranch": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/BranchArg"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResult"
+                        }
+                    },
+                    "description": "AddBranch adds a new branch with the input name to the model."
+                },
+                "BranchInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/BranchInfoArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/BranchResults"
+                        }
+                    },
+                    "description": "BranchInfo will return details of branch identified by the input argument,\nincluding units on the branch and the configuration disjoint with the\nmaster generation.\nAn error is returned if no in-flight branch matching in input is found."
+                },
+                "CommitBranch": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/BranchArg"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/IntResult"
+                        }
+                    },
+                    "description": "CommitBranch commits the input branch, making its changes applicable to\nthe whole model and marking it complete."
+                },
+                "HasActiveBranch": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/BranchArg"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/BoolResult"
+                        }
+                    },
+                    "description": "HasActiveBranch returns a true result if the input model has an \"in-flight\"\nbranch matching the input name."
+                },
+                "ListCommits": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/BranchResults"
+                        }
+                    },
+                    "description": "ListCommits will return the commits, hence only branches with generation_id higher than 0"
+                },
+                "ShowCommit": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/GenerationId"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/GenerationResult"
+                        }
+                    },
+                    "description": "ShowCommit will return details a commit given by its generationId\nAn error is returned if either no branch can be found corresponding to the generation id.\nOr the generation id given is below 1."
+                },
+                "TrackBranch": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/BranchTrackArg"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "TrackBranch marks the input units and/or applications as tracking the input\nbranch, causing them to realise changes made under that branch."
+                }
+            },
+            "definitions": {
+                "BoolResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "BranchArg": {
+                    "type": "object",
+                    "properties": {
+                        "branch": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "branch"
+                    ]
+                },
+                "BranchInfoArgs": {
+                    "type": "object",
+                    "properties": {
+                        "branches": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "detailed": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "branches",
+                        "detailed"
+                    ]
+                },
+                "BranchResults": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "generations": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Generation"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "generations"
+                    ]
+                },
+                "BranchTrackArg": {
+                    "type": "object",
+                    "properties": {
+                        "branch": {
+                            "type": "string"
+                        },
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        },
+                        "num-units": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "branch",
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "Generation": {
+                    "type": "object",
+                    "properties": {
+                        "applications": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/GenerationApplication"
+                            }
+                        },
+                        "branch": {
+                            "type": "string"
+                        },
+                        "completed": {
+                            "type": "integer"
+                        },
+                        "completed-by": {
+                            "type": "string"
+                        },
+                        "created": {
+                            "type": "integer"
+                        },
+                        "created-by": {
+                            "type": "string"
+                        },
+                        "generation-id": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "branch",
+                        "created",
+                        "created-by",
+                        "applications"
+                    ]
+                },
+                "GenerationApplication": {
+                    "type": "object",
+                    "properties": {
+                        "application": {
+                            "type": "string"
+                        },
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "pending": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "progress": {
+                            "type": "string"
+                        },
+                        "tracking": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "application",
+                        "progress",
+                        "config"
+                    ]
+                },
+                "GenerationId": {
+                    "type": "object",
+                    "properties": {
+                        "generation-id": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "generation-id"
+                    ]
+                },
+                "GenerationResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "generation": {
+                            "$ref": "#/definitions/Generation"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "generation"
+                    ]
+                },
+                "IntResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "ModelManager",
+        "Description": "ModelManagerAPI implements the model manager interface and is\nthe concrete implementation of the api end point.\nV10 of the facade does not return default-series or default-base\nin model info",
+        "Version": 10,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "controller-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "ChangeModelCredential": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ChangeModelCredentialsParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "ChangeModelCredential changes cloud credential reference for models.\nThese new cloud credentials must already exist on the controller."
+                },
+                "CreateModel": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ModelCreateArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ModelInfo"
+                        }
+                    },
+                    "description": "CreateModel creates a new model using the account and\nmodel config specified in the args."
+                },
+                "DestroyModels": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/DestroyModelsParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "DestroyModels will try to destroy the specified models.\nIf there is a block on destruction, this method will return an error.\nFrom ModelManager v7 onwards, DestroyModels gains 'force' and 'max-wait' parameters."
+                },
+                "DumpModels": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/DumpModelRequest"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringResults"
+                        }
+                    },
+                    "description": "DumpModels will export the models into the database agnostic\nrepresentation. The user needs to either be a controller admin, or have\nadmin privileges on the model itself."
+                },
+                "DumpModelsDB": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/MapResults"
+                        }
+                    },
+                    "description": "DumpModelsDB will gather all documents from all model collections\nfor the specified model. The map result contains a map of collection\nnames to lists of documents represented as maps."
+                },
+                "ListModelSummaries": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ModelSummariesRequest"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ModelSummaryResults"
+                        }
+                    },
+                    "description": "ListModelSummaries returns models that the specified user\nhas access to in the current server.  Controller admins (superuser)\ncan list models for any user.  Other users\ncan only ask about their own models."
+                },
+                "ListModels": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entity"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/UserModelList"
+                        }
+                    },
+                    "description": "ListModels returns the models that the specified user\nhas access to in the current server.  Controller admins (superuser)\ncan list models for any user.  Other users\ncan only ask about their own models."
+                },
+                "ModelDefaultsForClouds": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ModelDefaultsResults"
+                        }
+                    },
+                    "description": "ModelDefaultsForClouds returns the default config values for the specified\nclouds."
+                },
+                "ModelInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ModelInfoResults"
+                        }
+                    },
+                    "description": "ModelInfo returns information about the specified models."
+                },
+                "ModelStatus": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ModelStatusResults"
+                        }
+                    },
+                    "description": "ModelStatus returns a summary of the model."
+                },
+                "ModifyModelAccess": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ModifyModelAccessRequest"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "ModifyModelAccess changes the model access granted to users."
+                },
+                "SetModelDefaults": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SetModelDefaults"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "SetModelDefaults writes new values for the specified default model settings."
+                },
+                "UnsetModelDefaults": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/UnsetModelDefaults"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "UnsetModelDefaults removes the specified default model settings."
+                }
+            },
+            "definitions": {
+                "ChangeModelCredentialParams": {
+                    "type": "object",
+                    "properties": {
+                        "credential-tag": {
+                            "type": "string"
+                        },
+                        "model-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "model-tag",
+                        "credential-tag"
+                    ]
+                },
+                "ChangeModelCredentialsParams": {
+                    "type": "object",
+                    "properties": {
+                        "model-credentials": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ChangeModelCredentialParams"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "model-credentials"
+                    ]
+                },
+                "DestroyModelParams": {
+                    "type": "object",
+                    "properties": {
+                        "destroy-storage": {
+                            "type": "boolean"
+                        },
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "max-wait": {
+                            "type": "integer"
+                        },
+                        "model-tag": {
+                            "type": "string"
+                        },
+                        "timeout": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "model-tag"
+                    ]
+                },
+                "DestroyModelsParams": {
+                    "type": "object",
+                    "properties": {
+                        "models": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DestroyModelParams"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "models"
+                    ]
+                },
+                "DumpModelRequest": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        },
+                        "simplified": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities",
+                        "simplified"
+                    ]
+                },
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "EntityStatus": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "info": {
+                            "type": "string"
+                        },
+                        "since": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "status": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "status",
+                        "info",
+                        "since"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "MachineHardware": {
+                    "type": "object",
+                    "properties": {
+                        "arch": {
+                            "type": "string"
+                        },
+                        "availability-zone": {
+                            "type": "string"
+                        },
+                        "cores": {
+                            "type": "integer"
+                        },
+                        "cpu-power": {
+                            "type": "integer"
+                        },
+                        "mem": {
+                            "type": "integer"
+                        },
+                        "root-disk": {
+                            "type": "integer"
+                        },
+                        "tags": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "virt-type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "MapResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "MapResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MapResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "Model": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "owner-tag": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "uuid": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "uuid",
+                        "type",
+                        "owner-tag"
+                    ]
+                },
+                "ModelApplicationInfo": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name"
+                    ]
+                },
+                "ModelCreateArgs": {
+                    "type": "object",
+                    "properties": {
+                        "cloud-tag": {
+                            "type": "string"
+                        },
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "credential": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "owner-tag": {
+                            "type": "string"
+                        },
+                        "region": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "owner-tag"
+                    ]
+                },
+                "ModelDefaultValues": {
+                    "type": "object",
+                    "properties": {
+                        "cloud-region": {
+                            "type": "string"
+                        },
+                        "cloud-tag": {
+                            "type": "string"
+                        },
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config"
+                    ]
+                },
+                "ModelDefaults": {
+                    "type": "object",
+                    "properties": {
+                        "controller": {
+                            "type": "object",
+                            "additionalProperties": true
+                        },
+                        "default": {
+                            "type": "object",
+                            "additionalProperties": true
+                        },
+                        "regions": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RegionDefaults"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ModelDefaultsResult": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/ModelDefaults"
+                                }
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config"
+                    ]
+                },
+                "ModelDefaultsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModelDefaultsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ModelEntityCount": {
+                    "type": "object",
+                    "properties": {
+                        "count": {
+                            "type": "integer"
+                        },
+                        "entity": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entity",
+                        "count"
+                    ]
+                },
+                "ModelFilesystemInfo": {
+                    "type": "object",
+                    "properties": {
+                        "detachable": {
+                            "type": "boolean"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "message": {
+                            "type": "string"
+                        },
+                        "provider-id": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "id"
+                    ]
+                },
+                "ModelInfo": {
+                    "type": "object",
+                    "properties": {
+                        "agent-version": {
+                            "$ref": "#/definitions/Number"
+                        },
+                        "cloud-credential-tag": {
+                            "type": "string"
+                        },
+                        "cloud-credential-validity": {
+                            "type": "boolean"
+                        },
+                        "cloud-region": {
+                            "type": "string"
+                        },
+                        "cloud-tag": {
+                            "type": "string"
+                        },
+                        "controller-uuid": {
+                            "type": "string"
+                        },
+                        "default-base": {
+                            "type": "string"
+                        },
+                        "default-series": {
+                            "type": "string"
+                        },
+                        "is-controller": {
+                            "type": "boolean"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "machines": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModelMachineInfo"
+                            }
+                        },
+                        "migration": {
+                            "$ref": "#/definitions/ModelMigrationStatus"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "owner-tag": {
+                            "type": "string"
+                        },
+                        "provider-type": {
+                            "type": "string"
+                        },
+                        "secret-backends": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SecretBackendResult"
+                            }
+                        },
+                        "sla": {
+                            "$ref": "#/definitions/ModelSLAInfo"
+                        },
+                        "status": {
+                            "$ref": "#/definitions/EntityStatus"
+                        },
+                        "supported-features": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SupportedFeature"
+                            }
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "users": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModelUserInfo"
+                            }
+                        },
+                        "uuid": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "type",
+                        "uuid",
+                        "controller-uuid",
+                        "is-controller",
+                        "cloud-tag",
+                        "owner-tag",
+                        "life",
+                        "users",
+                        "machines",
+                        "secret-backends",
+                        "sla",
+                        "agent-version"
+                    ]
+                },
+                "ModelInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/ModelInfo"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ModelInfoResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModelInfoResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ModelMachineInfo": {
+                    "type": "object",
+                    "properties": {
+                        "display-name": {
+                            "type": "string"
+                        },
+                        "ha-primary": {
+                            "type": "boolean"
+                        },
+                        "hardware": {
+                            "$ref": "#/definitions/MachineHardware"
+                        },
+                        "has-vote": {
+                            "type": "boolean"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "instance-id": {
+                            "type": "string"
+                        },
+                        "message": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "wants-vote": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "id"
+                    ]
+                },
+                "ModelMigrationStatus": {
+                    "type": "object",
+                    "properties": {
+                        "end": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "start": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "status": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "status",
+                        "start"
+                    ]
+                },
+                "ModelSLAInfo": {
+                    "type": "object",
+                    "properties": {
+                        "level": {
+                            "type": "string"
+                        },
+                        "owner": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "level",
+                        "owner"
+                    ]
+                },
+                "ModelStatus": {
+                    "type": "object",
+                    "properties": {
+                        "application-count": {
+                            "type": "integer"
+                        },
+                        "applications": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModelApplicationInfo"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "filesystems": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModelFilesystemInfo"
+                            }
+                        },
+                        "hosted-machine-count": {
+                            "type": "integer"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "machines": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModelMachineInfo"
+                            }
+                        },
+                        "model-tag": {
+                            "type": "string"
+                        },
+                        "owner-tag": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "unit-count": {
+                            "type": "integer"
+                        },
+                        "volumes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModelVolumeInfo"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "model-tag",
+                        "life",
+                        "type",
+                        "hosted-machine-count",
+                        "application-count",
+                        "unit-count",
+                        "owner-tag"
+                    ]
+                },
+                "ModelStatusResults": {
+                    "type": "object",
+                    "properties": {
+                        "models": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModelStatus"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "models"
+                    ]
+                },
+                "ModelSummariesRequest": {
+                    "type": "object",
+                    "properties": {
+                        "all": {
+                            "type": "boolean"
+                        },
+                        "user-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "user-tag"
+                    ]
+                },
+                "ModelSummary": {
+                    "type": "object",
+                    "properties": {
+                        "agent-version": {
+                            "$ref": "#/definitions/Number"
+                        },
+                        "cloud-credential-tag": {
+                            "type": "string"
+                        },
+                        "cloud-region": {
+                            "type": "string"
+                        },
+                        "cloud-tag": {
+                            "type": "string"
+                        },
+                        "controller-uuid": {
+                            "type": "string"
+                        },
+                        "counts": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModelEntityCount"
+                            }
+                        },
+                        "default-series": {
+                            "type": "string"
+                        },
+                        "is-controller": {
+                            "type": "boolean"
+                        },
+                        "last-connection": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "migration": {
+                            "$ref": "#/definitions/ModelMigrationStatus"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "owner-tag": {
+                            "type": "string"
+                        },
+                        "provider-type": {
+                            "type": "string"
+                        },
+                        "sla": {
+                            "$ref": "#/definitions/ModelSLAInfo"
+                        },
+                        "status": {
+                            "$ref": "#/definitions/EntityStatus"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "user-access": {
+                            "type": "string"
+                        },
+                        "uuid": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "uuid",
+                        "type",
+                        "controller-uuid",
+                        "is-controller",
+                        "cloud-tag",
+                        "owner-tag",
+                        "life",
+                        "user-access",
+                        "last-connection",
+                        "counts",
+                        "sla",
+                        "agent-version"
+                    ]
+                },
+                "ModelSummaryResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/ModelSummary"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ModelSummaryResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModelSummaryResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ModelUnsetKeys": {
+                    "type": "object",
+                    "properties": {
+                        "cloud-region": {
+                            "type": "string"
+                        },
+                        "cloud-tag": {
+                            "type": "string"
+                        },
+                        "keys": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "keys"
+                    ]
+                },
+                "ModelUserInfo": {
+                    "type": "object",
+                    "properties": {
+                        "access": {
+                            "type": "string"
+                        },
+                        "display-name": {
+                            "type": "string"
+                        },
+                        "last-connection": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "model-tag": {
+                            "type": "string"
+                        },
+                        "user": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "model-tag",
+                        "user",
+                        "display-name",
+                        "last-connection",
+                        "access"
+                    ]
+                },
+                "ModelVolumeInfo": {
+                    "type": "object",
+                    "properties": {
+                        "detachable": {
+                            "type": "boolean"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "message": {
+                            "type": "string"
+                        },
+                        "provider-id": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "id"
+                    ]
+                },
+                "ModifyModelAccess": {
+                    "type": "object",
+                    "properties": {
+                        "access": {
+                            "type": "string"
+                        },
+                        "action": {
+                            "type": "string"
+                        },
+                        "model-tag": {
+                            "type": "string"
+                        },
+                        "user-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "user-tag",
+                        "action",
+                        "access",
+                        "model-tag"
+                    ]
+                },
+                "ModifyModelAccessRequest": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModifyModelAccess"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "changes"
+                    ]
+                },
+                "Number": {
+                    "type": "object",
+                    "properties": {
+                        "Build": {
+                            "type": "integer"
+                        },
+                        "Major": {
+                            "type": "integer"
+                        },
+                        "Minor": {
+                            "type": "integer"
+                        },
+                        "Patch": {
+                            "type": "integer"
+                        },
+                        "Tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Major",
+                        "Minor",
+                        "Tag",
+                        "Patch",
+                        "Build"
+                    ]
+                },
+                "RegionDefaults": {
+                    "type": "object",
+                    "properties": {
+                        "region-name": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "region-name",
+                        "value"
+                    ]
+                },
+                "SecretBackend": {
+                    "type": "object",
+                    "properties": {
+                        "backend-type": {
+                            "type": "string"
+                        },
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "token-rotate-interval": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "backend-type",
+                        "config"
+                    ]
+                },
+                "SecretBackendResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "message": {
+                            "type": "string"
+                        },
+                        "num-secrets": {
+                            "type": "integer"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/SecretBackend"
+                        },
+                        "status": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result",
+                        "id",
+                        "num-secrets",
+                        "status"
+                    ]
+                },
+                "SetModelDefaults": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModelDefaultValues"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "config"
+                    ]
+                },
+                "StringResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "StringResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StringResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "SupportedFeature": {
+                    "type": "object",
+                    "properties": {
+                        "description": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "description"
+                    ]
+                },
+                "UnsetModelDefaults": {
+                    "type": "object",
+                    "properties": {
+                        "keys": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModelUnsetKeys"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "keys"
+                    ]
+                },
+                "UserModel": {
+                    "type": "object",
+                    "properties": {
+                        "last-connection": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "model": {
+                            "$ref": "#/definitions/Model"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "model",
+                        "last-connection"
+                    ]
+                },
+                "UserModelList": {
+                    "type": "object",
+                    "properties": {
+                        "user-models": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UserModel"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "user-models"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "ModelUpgrader",
+        "Description": "ModelUpgraderAPI implements the model upgrader interface and is\nthe concrete implementation of the api end point.",
+        "Version": 1,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "controller-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "AbortModelUpgrade": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ModelParam"
+                        }
+                    },
+                    "description": "AbortModelUpgrade aborts and archives the model upgrade\nsynchronisation record, if any."
+                },
+                "UpgradeModel": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/UpgradeModelParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/UpgradeModelResult"
+                        }
+                    },
+                    "description": "UpgradeModel upgrades a model."
+                }
+            },
+            "definitions": {
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ModelParam": {
+                    "type": "object",
+                    "properties": {
+                        "model-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "model-tag"
+                    ]
+                },
+                "Number": {
+                    "type": "object",
+                    "properties": {
+                        "Build": {
+                            "type": "integer"
+                        },
+                        "Major": {
+                            "type": "integer"
+                        },
+                        "Minor": {
+                            "type": "integer"
+                        },
+                        "Patch": {
+                            "type": "integer"
+                        },
+                        "Tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "Major",
+                        "Minor",
+                        "Tag",
+                        "Patch",
+                        "Build"
+                    ]
+                },
+                "UpgradeModelParams": {
+                    "type": "object",
+                    "properties": {
+                        "agent-stream": {
+                            "type": "string"
+                        },
+                        "dry-run": {
+                            "type": "boolean"
+                        },
+                        "ignore-agent-versions": {
+                            "type": "boolean"
+                        },
+                        "model-tag": {
+                            "type": "string"
+                        },
+                        "target-version": {
+                            "$ref": "#/definitions/Number"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "model-tag",
+                        "target-version"
+                    ]
+                },
+                "UpgradeModelResult": {
+                    "type": "object",
+                    "properties": {
+                        "chosen-version": {
+                            "$ref": "#/definitions/Number"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "chosen-version"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "Payloads",
+        "Description": "API serves payload-specific API methods.",
+        "Version": 1,
+        "AvailableTo": [
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "List": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/PayloadListArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/PayloadListResults"
+                        }
+                    },
+                    "description": "List builds the list of payloads being tracked for\nthe given unit and IDs. If no IDs are provided then all tracked\npayloads for the unit are returned."
+                }
+            },
+            "definitions": {
+                "Payload": {
+                    "type": "object",
+                    "properties": {
+                        "class": {
+                            "type": "string"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "labels": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "machine": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "unit": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "class",
+                        "type",
+                        "id",
+                        "status",
+                        "labels",
+                        "unit",
+                        "machine"
+                    ]
+                },
+                "PayloadListArgs": {
+                    "type": "object",
+                    "properties": {
+                        "patterns": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "patterns"
+                    ]
+                },
+                "PayloadListResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Payload"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "Pinger",
+        "Description": "pinger describes a resource that can be pinged and stopped.",
+        "Version": 1,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "controller-user",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "Ping": {
+                    "type": "object"
+                },
+                "Stop": {
+                    "type": "object"
+                }
+            }
+        }
+    },
+    {
+        "Name": "Resources",
+        "Description": "API is the public API facade for resources.",
+        "Version": 3,
+        "AvailableTo": [
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "AddPendingResources": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/AddPendingResourcesArgsV2"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/AddPendingResourcesResult"
+                        }
+                    },
+                    "description": "AddPendingResources adds the provided resources (info) to the Juju\nmodel in a pending state, meaning they are not available until\nresolved. Handles CharmHub and Local charms."
+                },
+                "ListResources": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ListResourcesArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ResourcesResults"
+                        }
+                    },
+                    "description": "ListResources returns the list of resources for the given application."
+                }
+            },
+            "definitions": {
+                "AddPendingResourcesArgsV2": {
+                    "type": "object",
+                    "properties": {
+                        "Entity": {
+                            "$ref": "#/definitions/Entity"
+                        },
+                        "charm-origin": {
+                            "$ref": "#/definitions/CharmOrigin"
+                        },
+                        "macaroon": {
+                            "$ref": "#/definitions/Macaroon"
+                        },
+                        "resources": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CharmResource"
+                            }
+                        },
+                        "tag": {
+                            "type": "string"
+                        },
+                        "url": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "Entity",
+                        "url",
+                        "charm-origin",
+                        "macaroon",
+                        "resources"
+                    ]
+                },
+                "AddPendingResourcesResult": {
+                    "type": "object",
+                    "properties": {
+                        "ErrorResult": {
+                            "$ref": "#/definitions/ErrorResult"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "pending-ids": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "ErrorResult",
+                        "pending-ids"
+                    ]
+                },
+                "Base": {
+                    "type": "object",
+                    "properties": {
+                        "channel": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "channel"
+                    ]
+                },
+                "CharmOrigin": {
+                    "type": "object",
+                    "properties": {
+                        "architecture": {
+                            "type": "string"
+                        },
+                        "base": {
+                            "$ref": "#/definitions/Base"
+                        },
+                        "branch": {
+                            "type": "string"
+                        },
+                        "hash": {
+                            "type": "string"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "instance-key": {
+                            "type": "string"
+                        },
+                        "revision": {
+                            "type": "integer"
+                        },
+                        "risk": {
+                            "type": "string"
+                        },
+                        "source": {
+                            "type": "string"
+                        },
+                        "track": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "source",
+                        "type",
+                        "id"
+                    ]
+                },
+                "CharmResource": {
+                    "type": "object",
+                    "properties": {
+                        "description": {
+                            "type": "string"
+                        },
+                        "fingerprint": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "origin": {
+                            "type": "string"
+                        },
+                        "path": {
+                            "type": "string"
+                        },
+                        "revision": {
+                            "type": "integer"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "type",
+                        "path",
+                        "origin",
+                        "revision",
+                        "fingerprint",
+                        "size"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ListResourcesArgs": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Macaroon": {
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "Resource": {
+                    "type": "object",
+                    "properties": {
+                        "CharmResource": {
+                            "$ref": "#/definitions/CharmResource"
+                        },
+                        "application": {
+                            "type": "string"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "fingerprint": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "origin": {
+                            "type": "string"
+                        },
+                        "path": {
+                            "type": "string"
+                        },
+                        "pending-id": {
+                            "type": "string"
+                        },
+                        "revision": {
+                            "type": "integer"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "timestamp": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "username": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "type",
+                        "path",
+                        "origin",
+                        "revision",
+                        "fingerprint",
+                        "size",
+                        "CharmResource",
+                        "id",
+                        "pending-id",
+                        "application",
+                        "username",
+                        "timestamp"
+                    ]
+                },
+                "ResourcesResult": {
+                    "type": "object",
+                    "properties": {
+                        "ErrorResult": {
+                            "$ref": "#/definitions/ErrorResult"
+                        },
+                        "charm-store-resources": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CharmResource"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "resources": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Resource"
+                            }
+                        },
+                        "unit-resources": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UnitResources"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "ErrorResult",
+                        "resources",
+                        "charm-store-resources",
+                        "unit-resources"
+                    ]
+                },
+                "ResourcesResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ResourcesResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "UnitResources": {
+                    "type": "object",
+                    "properties": {
+                        "Entity": {
+                            "$ref": "#/definitions/Entity"
+                        },
+                        "download-progress": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "resources": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Resource"
+                            }
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "Entity",
+                        "resources",
+                        "download-progress"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "SSHClient",
+        "Description": "Facade implements the API required by the sshclient worker.",
+        "Version": 4,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "AllAddresses": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/SSHAddressesResults"
+                        }
+                    },
+                    "description": "AllAddresses reports all addresses that might have SSH listening for each\nentity in args. The result is sorted with public addresses first.\nMachines and units are supported as entity types."
+                },
+                "ModelCredentialForSSH": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/CloudSpecResult"
+                        }
+                    },
+                    "description": "ModelCredentialForSSH returns a cloud spec for ssh purpose.\nThis facade call is only used for k8s model."
+                },
+                "PrivateAddress": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/SSHAddressResults"
+                        }
+                    },
+                    "description": "PrivateAddress reports the preferred private network address for one or\nmore entities. Machines and units are supported."
+                },
+                "Proxy": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/SSHProxyResult"
+                        }
+                    },
+                    "description": "Proxy returns whether SSH connections should be proxied through the\ncontroller hosts for the model associated with the API connection."
+                },
+                "PublicAddress": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/SSHAddressResults"
+                        }
+                    },
+                    "description": "PublicAddress reports the preferred public network address for one\nor more entities. Machines and units are supported."
+                },
+                "PublicKeys": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/SSHPublicKeysResults"
+                        }
+                    },
+                    "description": "PublicKeys returns the public SSH hosts for one or more\nentities. Machines and units are supported."
+                }
+            },
+            "definitions": {
+                "CloudCredential": {
+                    "type": "object",
+                    "properties": {
+                        "attrs": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "auth-type": {
+                            "type": "string"
+                        },
+                        "redacted": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "auth-type"
+                    ]
+                },
+                "CloudSpec": {
+                    "type": "object",
+                    "properties": {
+                        "cacertificates": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "credential": {
+                            "$ref": "#/definitions/CloudCredential"
+                        },
+                        "endpoint": {
+                            "type": "string"
+                        },
+                        "identity-endpoint": {
+                            "type": "string"
+                        },
+                        "is-controller-cloud": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "region": {
+                            "type": "string"
+                        },
+                        "skip-tls-verify": {
+                            "type": "boolean"
+                        },
+                        "storage-endpoint": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "type",
+                        "name"
+                    ]
+                },
+                "CloudSpecResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/CloudSpec"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "SSHAddressResult": {
+                    "type": "object",
+                    "properties": {
+                        "address": {
+                            "type": "string"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "SSHAddressResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SSHAddressResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "SSHAddressesResult": {
+                    "type": "object",
+                    "properties": {
+                        "addresses": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "addresses"
+                    ]
+                },
+                "SSHAddressesResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SSHAddressesResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "SSHProxyResult": {
+                    "type": "object",
+                    "properties": {
+                        "use-proxy": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "use-proxy"
+                    ]
+                },
+                "SSHPublicKeysResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "public-keys": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "SSHPublicKeysResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SSHPublicKeysResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "SecretBackends",
+        "Description": "SecretBackendsAPI is the server implementation for the SecretBackends facade.",
+        "Version": 1,
+        "AvailableTo": [
+            "controller-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "AddSecretBackends": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/AddSecretBackendArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "AddSecretBackends adds new secret backends."
+                },
+                "ListSecretBackends": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ListSecretBackendsArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ListSecretBackendsResults"
+                        }
+                    },
+                    "description": "ListSecretBackends lists available secret backends."
+                },
+                "RemoveSecretBackends": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/RemoveSecretBackendArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "RemoveSecretBackends removes secret backends."
+                },
+                "UpdateSecretBackends": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/UpdateSecretBackendArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "UpdateSecretBackends updates secret backends."
+                }
+            },
+            "definitions": {
+                "AddSecretBackendArg": {
+                    "type": "object",
+                    "properties": {
+                        "SecretBackend": {
+                            "$ref": "#/definitions/SecretBackend"
+                        },
+                        "backend-type": {
+                            "type": "string"
+                        },
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "token-rotate-interval": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "backend-type",
+                        "config",
+                        "SecretBackend"
+                    ]
+                },
+                "AddSecretBackendArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AddSecretBackendArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ListSecretBackendsArgs": {
+                    "type": "object",
+                    "properties": {
+                        "names": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "reveal": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "names",
+                        "reveal"
+                    ]
+                },
+                "ListSecretBackendsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SecretBackendResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "RemoveSecretBackendArg": {
+                    "type": "object",
+                    "properties": {
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name"
+                    ]
+                },
+                "RemoveSecretBackendArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RemoveSecretBackendArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
+                "SecretBackend": {
+                    "type": "object",
+                    "properties": {
+                        "backend-type": {
+                            "type": "string"
+                        },
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "token-rotate-interval": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "backend-type",
+                        "config"
+                    ]
+                },
+                "SecretBackendResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "message": {
+                            "type": "string"
+                        },
+                        "num-secrets": {
+                            "type": "integer"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/SecretBackend"
+                        },
+                        "status": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result",
+                        "id",
+                        "num-secrets",
+                        "status"
+                    ]
+                },
+                "UpdateSecretBackendArg": {
+                    "type": "object",
+                    "properties": {
+                        "config": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "name-change": {
+                            "type": "string"
+                        },
+                        "reset": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "token-rotate-interval": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "token-rotate-interval",
+                        "config",
+                        "reset"
+                    ]
+                },
+                "UpdateSecretBackendArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UpdateSecretBackendArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "Secrets",
+        "Description": "SecretsAPI is the backend for the Secrets facade.",
+        "Version": 2,
+        "AvailableTo": [
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "CreateSecrets": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/CreateSecretArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StringResults"
+                        }
+                    },
+                    "description": "CreateSecrets creates new secrets."
+                },
+                "GrantSecret": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/GrantRevokeUserSecretArg"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "GrantSecret grants access to a user secret."
+                },
+                "ListSecrets": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/ListSecretsArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ListSecretResults"
+                        }
+                    },
+                    "description": "ListSecrets lists available secrets."
+                },
+                "RemoveSecrets": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/DeleteSecretArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "RemoveSecrets remove user secret."
+                },
+                "RevokeSecret": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/GrantRevokeUserSecretArg"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "RevokeSecret revokes access to a user secret."
+                },
+                "UpdateSecrets": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/UpdateUserSecretArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "UpdateSecrets creates new secrets."
+                }
+            },
+            "definitions": {
+                "AccessInfo": {
+                    "type": "object",
+                    "properties": {
+                        "role": {
+                            "type": "string"
+                        },
+                        "scope-tag": {
+                            "type": "string"
+                        },
+                        "target-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "target-tag",
+                        "scope-tag",
+                        "role"
+                    ]
+                },
+                "CreateSecretArg": {
+                    "type": "object",
+                    "properties": {
+                        "UpsertSecretArg": {
+                            "$ref": "#/definitions/UpsertSecretArg"
+                        },
+                        "content": {
+                            "$ref": "#/definitions/SecretContentParams"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "expire-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "label": {
+                            "type": "string"
+                        },
+                        "owner-tag": {
+                            "type": "string"
+                        },
+                        "params": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "rotate-policy": {
+                            "type": "string"
+                        },
+                        "uri": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "UpsertSecretArg",
+                        "owner-tag"
+                    ]
+                },
+                "CreateSecretArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CreateSecretArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
+                "DeleteSecretArg": {
+                    "type": "object",
+                    "properties": {
+                        "label": {
+                            "type": "string"
+                        },
+                        "revisions": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "uri": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "uri",
+                        "label"
+                    ]
+                },
+                "DeleteSecretArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DeleteSecretArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "GrantRevokeUserSecretArg": {
+                    "type": "object",
+                    "properties": {
+                        "applications": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "label": {
+                            "type": "string"
+                        },
+                        "uri": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "uri",
+                        "label",
+                        "applications"
+                    ]
+                },
+                "ListSecretResult": {
+                    "type": "object",
+                    "properties": {
+                        "access": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AccessInfo"
+                            }
+                        },
+                        "create-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "label": {
+                            "type": "string"
+                        },
+                        "latest-expire-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "latest-revision": {
+                            "type": "integer"
+                        },
+                        "next-rotate-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "owner-tag": {
+                            "type": "string"
+                        },
+                        "revisions": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SecretRevision"
+                            }
+                        },
+                        "rotate-policy": {
+                            "type": "string"
+                        },
+                        "update-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "uri": {
+                            "type": "string"
+                        },
+                        "value": {
+                            "$ref": "#/definitions/SecretValueResult"
+                        },
+                        "version": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "uri",
+                        "version",
+                        "owner-tag",
+                        "latest-revision",
+                        "create-time",
+                        "update-time",
+                        "revisions"
+                    ]
+                },
+                "ListSecretResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ListSecretResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ListSecretsArgs": {
+                    "type": "object",
+                    "properties": {
+                        "filter": {
+                            "$ref": "#/definitions/SecretsFilter"
+                        },
+                        "show-secrets": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "show-secrets",
+                        "filter"
+                    ]
+                },
+                "SecretContentParams": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "value-ref": {
+                            "$ref": "#/definitions/SecretValueRef"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "SecretRevision": {
+                    "type": "object",
+                    "properties": {
+                        "backend-name": {
+                            "type": "string"
+                        },
+                        "create-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "expire-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "revision": {
+                            "type": "integer"
+                        },
+                        "update-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "value-ref": {
+                            "$ref": "#/definitions/SecretValueRef"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "revision"
+                    ]
+                },
+                "SecretValueRef": {
+                    "type": "object",
+                    "properties": {
+                        "backend-id": {
+                            "type": "string"
+                        },
+                        "revision-id": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "backend-id",
+                        "revision-id"
+                    ]
+                },
+                "SecretValueResult": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "SecretsFilter": {
+                    "type": "object",
+                    "properties": {
+                        "label": {
+                            "type": "string"
+                        },
+                        "owner-tag": {
+                            "type": "string"
+                        },
+                        "revision": {
+                            "type": "integer"
+                        },
+                        "uri": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StringResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "result"
+                    ]
+                },
+                "StringResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StringResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "UpdateUserSecretArg": {
+                    "type": "object",
+                    "properties": {
+                        "UpsertSecretArg": {
+                            "$ref": "#/definitions/UpsertSecretArg"
+                        },
+                        "auto-prune": {
+                            "type": "boolean"
+                        },
+                        "content": {
+                            "$ref": "#/definitions/SecretContentParams"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "existing-label": {
+                            "type": "string"
+                        },
+                        "expire-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "label": {
+                            "type": "string"
+                        },
+                        "params": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "rotate-policy": {
+                            "type": "string"
+                        },
+                        "uri": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "UpsertSecretArg",
+                        "uri",
+                        "existing-label"
+                    ]
+                },
+                "UpdateUserSecretArgs": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UpdateUserSecretArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
+                "UpsertSecretArg": {
+                    "type": "object",
+                    "properties": {
+                        "content": {
+                            "$ref": "#/definitions/SecretContentParams"
+                        },
+                        "description": {
+                            "type": "string"
+                        },
+                        "expire-time": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "label": {
+                            "type": "string"
+                        },
+                        "params": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "rotate-policy": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            }
+        }
+    },
+    {
+        "Name": "Spaces",
+        "Description": "API provides the spaces API facade for version 6.",
+        "Version": 6,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "CreateSpaces": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/CreateSpacesParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "CreateSpaces creates a new Juju network space, associating the\nspecified subnets with it (optional; can be empty)."
+                },
+                "ListSpaces": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/ListSpacesResults"
+                        }
+                    },
+                    "description": "ListSpaces lists all the available spaces and their associated subnets."
+                },
+                "MoveSubnets": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/MoveSubnetsParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/MoveSubnetsResults"
+                        }
+                    },
+                    "description": "MoveSubnets ensures that the input subnets are in the input space."
+                },
+                "ReloadSpaces": {
+                    "type": "object",
+                    "description": "ReloadSpaces refreshes spaces from substrate"
+                },
+                "RemoveSpace": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/RemoveSpaceParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/RemoveSpaceResults"
+                        }
+                    },
+                    "description": "RemoveSpace removes a space.\nReturns SpaceResults if entities/settings are found which makes the deletion not possible."
+                },
+                "RenameSpace": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/RenameSpacesParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "RenameSpace renames a space."
+                },
+                "ShowSpace": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ShowSpaceResults"
+                        }
+                    },
+                    "description": "ShowSpace shows the spaces for a set of given entities."
+                }
+            },
+            "definitions": {
+                "CreateSpaceParams": {
+                    "type": "object",
+                    "properties": {
+                        "cidrs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "provider-id": {
+                            "type": "string"
+                        },
+                        "public": {
+                            "type": "boolean"
+                        },
+                        "space-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "cidrs",
+                        "space-tag",
+                        "public"
+                    ]
+                },
+                "CreateSpacesParams": {
+                    "type": "object",
+                    "properties": {
+                        "spaces": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/CreateSpaceParams"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "spaces"
+                    ]
+                },
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ListSpacesResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Space"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "MoveSubnetsParam": {
+                    "type": "object",
+                    "properties": {
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "space-tag": {
+                            "type": "string"
+                        },
+                        "subnets": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "subnets",
+                        "space-tag",
+                        "force"
+                    ]
+                },
+                "MoveSubnetsParams": {
+                    "type": "object",
+                    "properties": {
+                        "args": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MoveSubnetsParam"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "args"
+                    ]
+                },
+                "MoveSubnetsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "moved-subnets": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MovedSubnet"
+                            }
+                        },
+                        "new-space": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "new-space"
+                    ]
+                },
+                "MoveSubnetsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MoveSubnetsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "MovedSubnet": {
+                    "type": "object",
+                    "properties": {
+                        "cidr": {
+                            "type": "string"
+                        },
+                        "old-space": {
+                            "type": "string"
+                        },
+                        "subnet": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "subnet",
+                        "old-space",
+                        "cidr"
+                    ]
+                },
+                "RemoveSpaceParam": {
+                    "type": "object",
+                    "properties": {
+                        "dry-run": {
+                            "type": "boolean"
+                        },
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "space": {
+                            "$ref": "#/definitions/Entity"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "space"
+                    ]
+                },
+                "RemoveSpaceParams": {
+                    "type": "object",
+                    "properties": {
+                        "space-param": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RemoveSpaceParam"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "space-param"
+                    ]
+                },
+                "RemoveSpaceResult": {
+                    "type": "object",
+                    "properties": {
+                        "bindings": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        },
+                        "constraints": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        },
+                        "controller-settings": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "RemoveSpaceResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RemoveSpaceResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "RenameSpaceParams": {
+                    "type": "object",
+                    "properties": {
+                        "from-space-tag": {
+                            "type": "string"
+                        },
+                        "to-space-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "from-space-tag",
+                        "to-space-tag"
+                    ]
+                },
+                "RenameSpacesParams": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RenameSpaceParams"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "changes"
+                    ]
+                },
+                "ShowSpaceResult": {
+                    "type": "object",
+                    "properties": {
+                        "applications": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "machine-count": {
+                            "type": "integer"
+                        },
+                        "space": {
+                            "$ref": "#/definitions/Space"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "space",
+                        "applications",
+                        "machine-count"
+                    ]
+                },
+                "ShowSpaceResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ShowSpaceResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "Space": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "subnets": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Subnet"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "id",
+                        "name",
+                        "subnets"
+                    ]
+                },
+                "Subnet": {
+                    "type": "object",
+                    "properties": {
+                        "cidr": {
+                            "type": "string"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "provider-id": {
+                            "type": "string"
+                        },
+                        "provider-network-id": {
+                            "type": "string"
+                        },
+                        "provider-space-id": {
+                            "type": "string"
+                        },
+                        "space-tag": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "vlan-tag": {
+                            "type": "integer"
+                        },
+                        "zones": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "cidr",
+                        "vlan-tag",
+                        "life",
+                        "space-tag",
+                        "zones"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "Storage",
+        "Description": "StorageAPI implements the latest version (v6) of the Storage API.",
+        "Version": 6,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "AddToUnit": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/StoragesAddParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/AddStorageResults"
+                        }
+                    },
+                    "description": "AddToUnit validates and creates additional storage instances for units.\nA \"CHANGE\" block can block this operation."
+                },
+                "Attach": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/StorageAttachmentIds"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "Attach attaches existing storage instances to units.\nA \"CHANGE\" block can block this operation."
+                },
+                "CreatePool": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/StoragePoolArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "CreatePool creates a new pool with specified parameters."
+                },
+                "DetachStorage": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/StorageDetachmentParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "DetachStorage sets the specified storage attachments to Dying, unless they are\nalready Dying or Dead. Any associated, persistent storage will remain\nalive. This call can be forced."
+                },
+                "Import": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/BulkImportStorageParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ImportStorageResults"
+                        }
+                    },
+                    "description": "Import imports existing storage into the model.\nA \"CHANGE\" block can block this operation."
+                },
+                "ListFilesystems": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/FilesystemFilters"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/FilesystemDetailsListResults"
+                        }
+                    },
+                    "description": "ListFilesystems returns a list of filesystems in the environment matching\nthe provided filter. Each result describes a filesystem in detail, including\nthe filesystem's attachments."
+                },
+                "ListPools": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/StoragePoolFilters"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StoragePoolsResults"
+                        }
+                    },
+                    "description": "ListPools returns a list of pools.\nIf filter is provided, returned list only contains pools that match\nthe filter.\nPools can be filtered on names and provider types.\nIf both names and types are provided as filter,\npools that match either are returned.\nThis method lists union of pools and environment provider types.\nIf no filter is provided, all pools are returned."
+                },
+                "ListStorageDetails": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/StorageFilters"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StorageDetailsListResults"
+                        }
+                    },
+                    "description": "ListStorageDetails returns storage matching a filter."
+                },
+                "ListVolumes": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/VolumeFilters"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/VolumeDetailsListResults"
+                        }
+                    },
+                    "description": "ListVolumes lists volumes with the given filters. Each filter produces\nan independent list of volumes, or an error if the filter is invalid\nor the volumes could not be listed."
+                },
+                "Remove": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/RemoveStorage"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "Remove sets the specified storage entities to Dying, unless they are\nalready Dying or Dead, such that the storage will eventually be removed\nfrom the model. If the arguments specify that the storage should be\ndestroyed, then the associated cloud storage will be destroyed first;\notherwise it will only be released from Juju's control."
+                },
+                "RemovePool": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/StoragePoolDeleteArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "RemovePool deletes the named pool"
+                },
+                "StorageDetails": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/StorageDetailsResults"
+                        }
+                    },
+                    "description": "StorageDetails retrieves and returns detailed information about desired\nstorage identified by supplied tags. If specified storage cannot be\nretrieved, individual error is returned instead of storage information."
+                },
+                "UpdatePool": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/StoragePoolArgs"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "UpdatePool deletes the named pool"
+                }
+            },
+            "definitions": {
+                "AddStorageDetails": {
+                    "type": "object",
+                    "properties": {
+                        "storage-tags": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "storage-tags"
+                    ]
+                },
+                "AddStorageResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/AddStorageDetails"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "AddStorageResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AddStorageResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "BulkImportStorageParams": {
+                    "type": "object",
+                    "properties": {
+                        "storage": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ImportStorageParams"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "storage"
+                    ]
+                },
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "EntityStatus": {
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "info": {
+                            "type": "string"
+                        },
+                        "since": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "status": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "status",
+                        "info",
+                        "since"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "FilesystemAttachmentDetails": {
+                    "type": "object",
+                    "properties": {
+                        "FilesystemAttachmentInfo": {
+                            "$ref": "#/definitions/FilesystemAttachmentInfo"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "mount-point": {
+                            "type": "string"
+                        },
+                        "read-only": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "FilesystemAttachmentInfo"
+                    ]
+                },
+                "FilesystemAttachmentInfo": {
+                    "type": "object",
+                    "properties": {
+                        "mount-point": {
+                            "type": "string"
+                        },
+                        "read-only": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "FilesystemDetails": {
+                    "type": "object",
+                    "properties": {
+                        "filesystem-tag": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "$ref": "#/definitions/FilesystemInfo"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "machine-attachments": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/FilesystemAttachmentDetails"
+                                }
+                            }
+                        },
+                        "status": {
+                            "$ref": "#/definitions/EntityStatus"
+                        },
+                        "storage": {
+                            "$ref": "#/definitions/StorageDetails"
+                        },
+                        "unit-attachments": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/FilesystemAttachmentDetails"
+                                }
+                            }
+                        },
+                        "volume-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "filesystem-tag",
+                        "info",
+                        "status"
+                    ]
+                },
+                "FilesystemDetailsListResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/FilesystemDetails"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "FilesystemDetailsListResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/FilesystemDetailsListResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "FilesystemFilter": {
+                    "type": "object",
+                    "properties": {
+                        "machines": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "FilesystemFilters": {
+                    "type": "object",
+                    "properties": {
+                        "filters": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/FilesystemFilter"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "FilesystemInfo": {
+                    "type": "object",
+                    "properties": {
+                        "filesystem-id": {
+                            "type": "string"
+                        },
+                        "pool": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "filesystem-id",
+                        "pool",
+                        "size"
+                    ]
+                },
+                "ImportStorageDetails": {
+                    "type": "object",
+                    "properties": {
+                        "storage-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "storage-tag"
+                    ]
+                },
+                "ImportStorageParams": {
+                    "type": "object",
+                    "properties": {
+                        "kind": {
+                            "type": "integer"
+                        },
+                        "pool": {
+                            "type": "string"
+                        },
+                        "provider-id": {
+                            "type": "string"
+                        },
+                        "storage-name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "kind",
+                        "pool",
+                        "provider-id",
+                        "storage-name"
+                    ]
+                },
+                "ImportStorageResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/ImportStorageDetails"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ImportStorageResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ImportStorageResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "RemoveStorage": {
+                    "type": "object",
+                    "properties": {
+                        "storage": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/RemoveStorageInstance"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "storage"
+                    ]
+                },
+                "RemoveStorageInstance": {
+                    "type": "object",
+                    "properties": {
+                        "destroy-attachments": {
+                            "type": "boolean"
+                        },
+                        "destroy-storage": {
+                            "type": "boolean"
+                        },
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "max-wait": {
+                            "type": "integer"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "StorageAddParams": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "storage": {
+                            "$ref": "#/definitions/StorageConstraints"
+                        },
+                        "unit": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "unit",
+                        "name",
+                        "storage"
+                    ]
+                },
+                "StorageAttachmentDetails": {
+                    "type": "object",
+                    "properties": {
+                        "life": {
+                            "type": "string"
+                        },
+                        "location": {
+                            "type": "string"
+                        },
+                        "machine-tag": {
+                            "type": "string"
+                        },
+                        "storage-tag": {
+                            "type": "string"
+                        },
+                        "unit-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "storage-tag",
+                        "unit-tag",
+                        "machine-tag"
+                    ]
+                },
+                "StorageAttachmentId": {
+                    "type": "object",
+                    "properties": {
+                        "storage-tag": {
+                            "type": "string"
+                        },
+                        "unit-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "storage-tag",
+                        "unit-tag"
+                    ]
+                },
+                "StorageAttachmentIds": {
+                    "type": "object",
+                    "properties": {
+                        "ids": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StorageAttachmentId"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "ids"
+                    ]
+                },
+                "StorageConstraints": {
+                    "type": "object",
+                    "properties": {
+                        "count": {
+                            "type": "integer"
+                        },
+                        "pool": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StorageDetachmentParams": {
+                    "type": "object",
+                    "properties": {
+                        "force": {
+                            "type": "boolean"
+                        },
+                        "ids": {
+                            "$ref": "#/definitions/StorageAttachmentIds"
+                        },
+                        "max-wait": {
+                            "type": "integer"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "ids"
+                    ]
+                },
+                "StorageDetails": {
+                    "type": "object",
+                    "properties": {
+                        "attachments": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/StorageAttachmentDetails"
+                                }
+                            }
+                        },
+                        "kind": {
+                            "type": "integer"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "owner-tag": {
+                            "type": "string"
+                        },
+                        "persistent": {
+                            "type": "boolean"
+                        },
+                        "status": {
+                            "$ref": "#/definitions/EntityStatus"
+                        },
+                        "storage-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "storage-tag",
+                        "owner-tag",
+                        "kind",
+                        "status",
+                        "persistent"
+                    ]
+                },
+                "StorageDetailsListResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StorageDetails"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StorageDetailsListResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StorageDetailsListResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StorageDetailsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/StorageDetails"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StorageDetailsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StorageDetailsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StorageFilter": {
+                    "type": "object",
+                    "additionalProperties": false
+                },
+                "StorageFilters": {
+                    "type": "object",
+                    "properties": {
+                        "filters": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StorageFilter"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StoragePool": {
+                    "type": "object",
+                    "properties": {
+                        "attrs": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "provider": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "provider",
+                        "attrs"
+                    ]
+                },
+                "StoragePoolArgs": {
+                    "type": "object",
+                    "properties": {
+                        "pools": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StoragePool"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "pools"
+                    ]
+                },
+                "StoragePoolDeleteArg": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name"
+                    ]
+                },
+                "StoragePoolDeleteArgs": {
+                    "type": "object",
+                    "properties": {
+                        "pools": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StoragePoolDeleteArg"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "pools"
+                    ]
+                },
+                "StoragePoolFilter": {
+                    "type": "object",
+                    "properties": {
+                        "names": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "providers": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StoragePoolFilters": {
+                    "type": "object",
+                    "properties": {
+                        "filters": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StoragePoolFilter"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StoragePoolsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "storage-pools": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StoragePool"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StoragePoolsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StoragePoolsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "StoragesAddParams": {
+                    "type": "object",
+                    "properties": {
+                        "storages": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/StorageAddParams"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "storages"
+                    ]
+                },
+                "VolumeAttachmentDetails": {
+                    "type": "object",
+                    "properties": {
+                        "VolumeAttachmentInfo": {
+                            "$ref": "#/definitions/VolumeAttachmentInfo"
+                        },
+                        "bus-address": {
+                            "type": "string"
+                        },
+                        "device-link": {
+                            "type": "string"
+                        },
+                        "device-name": {
+                            "type": "string"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "plan-info": {
+                            "$ref": "#/definitions/VolumeAttachmentPlanInfo"
+                        },
+                        "read-only": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "VolumeAttachmentInfo"
+                    ]
+                },
+                "VolumeAttachmentInfo": {
+                    "type": "object",
+                    "properties": {
+                        "bus-address": {
+                            "type": "string"
+                        },
+                        "device-link": {
+                            "type": "string"
+                        },
+                        "device-name": {
+                            "type": "string"
+                        },
+                        "plan-info": {
+                            "$ref": "#/definitions/VolumeAttachmentPlanInfo"
+                        },
+                        "read-only": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "VolumeAttachmentPlanInfo": {
+                    "type": "object",
+                    "properties": {
+                        "device-attributes": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "device-type": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "VolumeDetails": {
+                    "type": "object",
+                    "properties": {
+                        "info": {
+                            "$ref": "#/definitions/VolumeInfo"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "machine-attachments": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/VolumeAttachmentDetails"
+                                }
+                            }
+                        },
+                        "status": {
+                            "$ref": "#/definitions/EntityStatus"
+                        },
+                        "storage": {
+                            "$ref": "#/definitions/StorageDetails"
+                        },
+                        "unit-attachments": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "$ref": "#/definitions/VolumeAttachmentDetails"
+                                }
+                            }
+                        },
+                        "volume-tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "volume-tag",
+                        "info",
+                        "status"
+                    ]
+                },
+                "VolumeDetailsListResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/VolumeDetails"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "VolumeDetailsListResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/VolumeDetailsListResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "VolumeFilter": {
+                    "type": "object",
+                    "properties": {
+                        "machines": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "VolumeFilters": {
+                    "type": "object",
+                    "properties": {
+                        "filters": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/VolumeFilter"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "VolumeInfo": {
+                    "type": "object",
+                    "properties": {
+                        "hardware-id": {
+                            "type": "string"
+                        },
+                        "persistent": {
+                            "type": "boolean"
+                        },
+                        "pool": {
+                            "type": "string"
+                        },
+                        "size": {
+                            "type": "integer"
+                        },
+                        "volume-id": {
+                            "type": "string"
+                        },
+                        "wwn": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "volume-id",
+                        "size",
+                        "persistent"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "Subnets",
+        "Description": "API provides the subnets API facade for version 5.",
+        "Version": 5,
+        "AvailableTo": [
+            "controller-machine-agent",
+            "machine-agent",
+            "unit-agent",
+            "model-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "AllZones": {
+                    "type": "object",
+                    "properties": {
+                        "Result": {
+                            "$ref": "#/definitions/ZoneResults"
+                        }
+                    },
+                    "description": "AllZones returns all availability zones known to Juju. If a\nzone is unusable, unavailable, or deprecated the Available\nfield will be false."
+                },
+                "ListSubnets": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/SubnetsFilters"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ListSubnetsResults"
+                        }
+                    },
+                    "description": "ListSubnets returns the matching subnets after applying\noptional filters."
+                },
+                "SubnetsByCIDR": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/CIDRParams"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/SubnetsResults"
+                        }
+                    },
+                    "description": "SubnetsByCIDR returns the collection of subnets matching each CIDR in the input."
+                }
+            },
+            "definitions": {
+                "CIDRParams": {
+                    "type": "object",
+                    "properties": {
+                        "cidrs": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "cidrs"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ListSubnetsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Subnet"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "Subnet": {
+                    "type": "object",
+                    "properties": {
+                        "cidr": {
+                            "type": "string"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "provider-id": {
+                            "type": "string"
+                        },
+                        "provider-network-id": {
+                            "type": "string"
+                        },
+                        "provider-space-id": {
+                            "type": "string"
+                        },
+                        "space-tag": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "vlan-tag": {
+                            "type": "integer"
+                        },
+                        "zones": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "cidr",
+                        "vlan-tag",
+                        "life",
+                        "space-tag",
+                        "zones"
+                    ]
+                },
+                "SubnetV2": {
+                    "type": "object",
+                    "properties": {
+                        "Subnet": {
+                            "$ref": "#/definitions/Subnet"
+                        },
+                        "cidr": {
+                            "type": "string"
+                        },
+                        "id": {
+                            "type": "string"
+                        },
+                        "life": {
+                            "type": "string"
+                        },
+                        "provider-id": {
+                            "type": "string"
+                        },
+                        "provider-network-id": {
+                            "type": "string"
+                        },
+                        "provider-space-id": {
+                            "type": "string"
+                        },
+                        "space-tag": {
+                            "type": "string"
+                        },
+                        "status": {
+                            "type": "string"
+                        },
+                        "vlan-tag": {
+                            "type": "integer"
+                        },
+                        "zones": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "cidr",
+                        "vlan-tag",
+                        "life",
+                        "space-tag",
+                        "zones",
+                        "Subnet"
+                    ]
+                },
+                "SubnetsFilters": {
+                    "type": "object",
+                    "properties": {
+                        "space-tag": {
+                            "type": "string"
+                        },
+                        "zone": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "SubnetsResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "subnets": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SubnetV2"
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "SubnetsResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/SubnetsResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ZoneResult": {
+                    "type": "object",
+                    "properties": {
+                        "available": {
+                            "type": "boolean"
+                        },
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "name",
+                        "available"
+                    ]
+                },
+                "ZoneResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ZoneResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                }
+            }
+        }
+    },
+    {
+        "Name": "UserManager",
+        "Description": "UserManagerAPI implements the user manager interface and is the concrete\nimplementation of the api end point.",
+        "Version": 3,
+        "AvailableTo": [
+            "controller-user"
+        ],
+        "Schema": {
+            "type": "object",
+            "properties": {
+                "AddUser": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/AddUsers"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/AddUserResults"
+                        }
+                    },
+                    "description": "AddUser adds a user with a username, and either a password or\na randomly generated secret key which will be returned."
+                },
+                "DisableUser": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "DisableUser disables one or more users.  If the user is already disabled,\nthe action is considered a success."
+                },
+                "EnableUser": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "EnableUser enables one or more users.  If the user is already enabled,\nthe action is considered a success."
+                },
+                "ModelUserInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ModelUserInfoResults"
+                        }
+                    },
+                    "description": "ModelUserInfo returns information on all users in the model."
+                },
+                "RemoveUser": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "RemoveUser permanently removes a user from the current controller for each\nentity provided. While the user is permanently removed we keep it's\ninformation around for auditing purposes.\nTODO(redir): Add information about getting deleted user information when we\nadd that capability."
+                },
+                "ResetPassword": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/Entities"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/AddUserResults"
+                        }
+                    },
+                    "description": "ResetPassword resets password for supplied users by\ninvalidating current passwords (if any) and generating\nnew random secret keys which will be returned.\nUsers cannot reset their own password."
+                },
+                "SetPassword": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/EntityPasswords"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/ErrorResults"
+                        }
+                    },
+                    "description": "SetPassword changes the stored password for the specified users."
+                },
+                "UserInfo": {
+                    "type": "object",
+                    "properties": {
+                        "Params": {
+                            "$ref": "#/definitions/UserInfoRequest"
+                        },
+                        "Result": {
+                            "$ref": "#/definitions/UserInfoResults"
+                        }
+                    },
+                    "description": "UserInfo returns information on a user."
+                }
+            },
+            "definitions": {
+                "AddUser": {
+                    "type": "object",
+                    "properties": {
+                        "display-name": {
+                            "type": "string"
+                        },
+                        "password": {
+                            "type": "string"
+                        },
+                        "username": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "username",
+                        "display-name"
+                    ]
+                },
+                "AddUserResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "secret-key": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "AddUserResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AddUserResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "AddUsers": {
+                    "type": "object",
+                    "properties": {
+                        "users": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AddUser"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "users"
+                    ]
+                },
+                "Entities": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities"
+                    ]
+                },
+                "Entity": {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag"
+                    ]
+                },
+                "EntityPassword": {
+                    "type": "object",
+                    "properties": {
+                        "password": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "tag",
+                        "password"
+                    ]
+                },
+                "EntityPasswords": {
+                    "type": "object",
+                    "properties": {
+                        "changes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/EntityPassword"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "changes"
+                    ]
+                },
+                "Error": {
+                    "type": "object",
+                    "properties": {
+                        "code": {
+                            "type": "string"
+                        },
+                        "info": {
+                            "type": "object",
+                            "patternProperties": {
+                                ".*": {
+                                    "type": "object",
+                                    "additionalProperties": true
+                                }
+                            }
+                        },
+                        "message": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "message",
+                        "code"
+                    ]
+                },
+                "ErrorResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ErrorResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ErrorResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "ModelUserInfo": {
+                    "type": "object",
+                    "properties": {
+                        "access": {
+                            "type": "string"
+                        },
+                        "display-name": {
+                            "type": "string"
+                        },
+                        "last-connection": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "model-tag": {
+                            "type": "string"
+                        },
+                        "user": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "model-tag",
+                        "user",
+                        "display-name",
+                        "last-connection",
+                        "access"
+                    ]
+                },
+                "ModelUserInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/ModelUserInfo"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "ModelUserInfoResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/ModelUserInfoResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                },
+                "UserInfo": {
+                    "type": "object",
+                    "properties": {
+                        "access": {
+                            "type": "string"
+                        },
+                        "created-by": {
+                            "type": "string"
+                        },
+                        "date-created": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "disabled": {
+                            "type": "boolean"
+                        },
+                        "display-name": {
+                            "type": "string"
+                        },
+                        "last-connection": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "username": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "username",
+                        "display-name",
+                        "access",
+                        "created-by",
+                        "date-created",
+                        "disabled"
+                    ]
+                },
+                "UserInfoRequest": {
+                    "type": "object",
+                    "properties": {
+                        "entities": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/Entity"
+                            }
+                        },
+                        "include-disabled": {
+                            "type": "boolean"
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "entities",
+                        "include-disabled"
+                    ]
+                },
+                "UserInfoResult": {
+                    "type": "object",
+                    "properties": {
+                        "error": {
+                            "$ref": "#/definitions/Error"
+                        },
+                        "result": {
+                            "$ref": "#/definitions/UserInfo"
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "UserInfoResults": {
+                    "type": "object",
+                    "properties": {
+                        "results": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/UserInfoResult"
+                            }
+                        }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                        "results"
+                    ]
+                }
+            }
+        }
+    }
+]


### PR DESCRIPTION
#### Description

The Juju 3.5.5 schema adds the charm-rev field to ApplicationStatus, but there are no changes to the generated code because this field is present in the 3.6.0 schema that was previously added.


#### QA Steps

As there are no code changes in this PR, CI outcomes shouldn't be affected