### PR TITLE
refactor: change use of pyrfc3339 to use ciso8601

### DIFF
--- a/juju/client/gocookies.py
+++ b/juju/client/gocookies.py
@@ -109,7 +109,10 @@ def py_to_go_cookie(py_cookie):
 
 
 def generate_rfc3339_from_unix_time(unix_time: datetime.datetime) -> str:
-    rfc, discard = unix_time.isoformat().split(".")
+    splitted_rfc = unix_time.isoformat().split(".")
+    if len(splitted_rfc) == 1:
+        return f"{splitted_rfc[0]}Z"
+    rfc, discard = splitted_rfc
     discard = discard.split("+")
     if len(discard) > 1:
         rfc = datetime.datetime.fromisoformat(rfc)

--- a/juju/machine.py
+++ b/juju/machine.py
@@ -6,7 +6,7 @@ import ipaddress
 import logging
 import typing
 
-import pyrfc3339
+import ciso8601
 
 from juju.utils import block_until, juju_ssh_key_paths
 
@@ -239,7 +239,7 @@ class Machine(model.ModelEntity):
     @property
     def agent_status_since(self):
         """Get the time when the `agent_status` was last updated."""
-        return pyrfc3339.parse(self.safe_data["agent-status"]["since"])
+        return ciso8601.parse_rfc3339(self.safe_data["agent-status"]["since"])
 
     @property
     def agent_version(self):
@@ -266,7 +266,7 @@ class Machine(model.ModelEntity):
     @property
     def status_since(self):
         """Get the time when the `status` was last updated."""
-        return pyrfc3339.parse(self.safe_data["instance-status"]["since"])
+        return ciso8601.parse_rfc3339(self.safe_data["instance-status"]["since"])
 
     @property
     def dns_name(self):

--- a/juju/unit.py
+++ b/juju/unit.py
@@ -3,7 +3,7 @@
 
 import logging
 
-import pyrfc3339
+import ciso8601
 
 from juju.errors import JujuAPIError, JujuError
 
@@ -25,7 +25,7 @@ class Unit(model.ModelEntity):
     @property
     def agent_status_since(self):
         """Get the time when the `agent_status` was last updated."""
-        return pyrfc3339.parse(self.safe_data["agent-status"]["since"])
+        return ciso8601.parse_rfc3339(self.safe_data["agent-status"]["since"])
 
     @property
     def is_subordinate(self):
@@ -52,7 +52,7 @@ class Unit(model.ModelEntity):
     @property
     def workload_status_since(self):
         """Get the time when the `workload_status` was last updated."""
-        return pyrfc3339.parse(self.safe_data["workload-status"]["since"])
+        return ciso8601.parse_rfc3339(self.safe_data["workload-status"]["since"])
 
     @property
     def workload_status_message(self):

--- a/juju/user.py
+++ b/juju/user.py
@@ -3,7 +3,7 @@
 
 import logging
 
-import pyrfc3339
+import ciso8601
 
 from . import errors, tag
 from .client import client
@@ -31,7 +31,7 @@ class User:
 
     @property
     def last_connection(self):
-        return pyrfc3339.parse(self._user_info.last_connection)
+        return ciso8601.parse_rfc3339(self._user_info.last_connection)
 
     @property
     def access(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 ]
 dependencies = [
     "macaroonbakery>=1.1,<2.0",
-    "pyRFC3339>=1.0,<2.0",
     "pyyaml>=5.1.2",
     "websockets>=13.0.1",
     "paramiko>=2.4.0",
@@ -35,6 +34,7 @@ dependencies = [
     "packaging",
     "typing-extensions>=4.5.0",
     'backports.strenum>=1.3.1; python_version < "3.11"',
+    "ciso8601>=2.3.2",
 ]
 [project.optional-dependencies]
 dev = [

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     package_data={"juju": ["py.typed"]},
     install_requires=[
         "macaroonbakery>=1.1,<2.0",
-        "pyRFC3339>=1.0,<2.0",
+        "ciso8601>=2.3.2",
         "pyyaml>=5.1.2",
         "websockets>=13.0.1",
         "paramiko>=2.4.0",

--- a/tests/unit/test_gocookies.py
+++ b/tests/unit/test_gocookies.py
@@ -8,7 +8,7 @@ import tempfile
 import unittest
 import urllib.request
 
-import pyrfc3339
+import ciso8601
 
 from juju.client.gocookies import GoCookieJar
 
@@ -223,7 +223,7 @@ class TestGoCookieJar(unittest.TestCase):
         ]"""
         jar = self.load_jar(content)
         got_expires = tuple(jar)[0].expires
-        want_expires = int(pyrfc3339.parse("2345-11-15T18:16:08Z").timestamp())
+        want_expires = int(ciso8601.parse_rfc3339("2345-11-15T18:16:08Z").timestamp())
         self.assertEqual(got_expires, want_expires)
 
     def load_jar(self, content):


### PR DESCRIPTION
#### Description

*This change was mentioned in the issue #1101 . There is just one change that is not simply replacing, and that one is the generation of the rfc3339, but I created a simple function to handle this conversion.*


*\Replaced old pyrfc3339 that has not received an updated for the last 6 years and is not typed to use ciso8601 instead*


#### QA Steps

*\<Commands / tests / steps to run to verify that the change works:\>*

```
tox -e py3 -- tests/unit/...
```

```
tox -e integration -- tests/integration/...
```

All CI tests need to pass.

*\<Please note that most likely an additional test will be required by the reviewers for any change that's not a one liner to land.\>*

#### Notes & Discussion

*Should I also write the tests for this one? Like assert pyrfc3339.parse(timestamp) == ciso8601.parse_rfc339(timestamp) and assert pyrfc3339.generate(datetime) == generate_rfc3339_from_unix_time(datetime)?*
