### PR TITLE
chore: remove pyrfc3339 and change to datetime.datetime.fromisoformat…

### DIFF
--- a/juju/machine.py
+++ b/juju/machine.py
@@ -6,7 +6,7 @@ import ipaddress
 import logging
 import typing
 
-import pyrfc3339
+from backports.datetime_fromisoformat import datetime_fromisoformat
 
 from juju.utils import block_until, juju_ssh_key_paths
 
@@ -239,7 +239,7 @@ class Machine(model.ModelEntity):
     @property
     def agent_status_since(self):
         """Get the time when the `agent_status` was last updated."""
-        return pyrfc3339.parse(self.safe_data["agent-status"]["since"])
+        return datetime_fromisoformat(self.safe_data["agent-status"]["since"])
 
     @property
     def agent_version(self):
@@ -266,7 +266,7 @@ class Machine(model.ModelEntity):
     @property
     def status_since(self):
         """Get the time when the `status` was last updated."""
-        return pyrfc3339.parse(self.safe_data["instance-status"]["since"])
+        return datetime_fromisoformat(self.safe_data["instance-status"]["since"])
 
     @property
     def dns_name(self):

--- a/juju/unit.py
+++ b/juju/unit.py
@@ -3,7 +3,7 @@
 
 import logging
 
-import pyrfc3339
+from backports.datetime_fromisoformat import datetime_fromisoformat
 
 from juju.errors import JujuAPIError, JujuError
 
@@ -27,7 +27,7 @@ class Unit(model.ModelEntity):
     @property
     def agent_status_since(self):
         """Get the time when the `agent_status` was last updated."""
-        return pyrfc3339.parse(self.safe_data["agent-status"]["since"])
+        return datetime_fromisoformat(self.safe_data["agent-status"]["since"])
 
     @property
     def is_subordinate(self):
@@ -54,7 +54,7 @@ class Unit(model.ModelEntity):
     @property
     def workload_status_since(self):
         """Get the time when the `workload_status` was last updated."""
-        return pyrfc3339.parse(self.safe_data["workload-status"]["since"])
+        return datetime_fromisoformat(self.safe_data["workload-status"]["since"])
 
     @property
     def workload_status_message(self):

--- a/juju/user.py
+++ b/juju/user.py
@@ -3,7 +3,7 @@
 
 import logging
 
-import pyrfc3339
+from backports.datetime_fromisoformat import datetime_fromisoformat
 
 from . import errors, tag
 from .client import client
@@ -31,7 +31,7 @@ class User:
 
     @property
     def last_connection(self):
-        return pyrfc3339.parse(self._user_info.last_connection)
+        return datetime_fromisoformat(self._user_info.last_connection)
 
     @property
     def access(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ classifiers = [
 ]
 dependencies = [
     "macaroonbakery>=1.1,<2.0",
-    "pyRFC3339>=1.0,<2.0",
     "pyyaml>=5.1.2",
     "websockets>=13.0.1",
     "paramiko>=2.4.0",
@@ -35,6 +34,7 @@ dependencies = [
     "packaging",
     "typing-extensions>=4.5.0",
     'backports.strenum>=1.3.1; python_version < "3.11"',
+    "backports-datetime-fromisoformat>=2.0.2",
 ]
 [project.optional-dependencies]
 dev = [

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
     package_data={"juju": ["py.typed"]},
     install_requires=[
         "macaroonbakery>=1.1,<2.0",
-        "pyRFC3339>=1.0,<2.0",
         "pyyaml>=5.1.2",
         "websockets>=13.0.1",
         "paramiko>=2.4.0",
@@ -33,6 +32,7 @@ setup(
         "packaging",
         "typing-extensions>=4.5.0",
         'backports.strenum>=1.3.1; python_version < "3.11"',
+        "backports-datetime-fromisoformat>=2.0.2",
     ],
     extras_require={
         "dev": [

--- a/tests/unit/test_gocookies.py
+++ b/tests/unit/test_gocookies.py
@@ -8,13 +8,14 @@ import tempfile
 import unittest
 import urllib.request
 
-import pyrfc3339
+from backports.datetime_fromisoformat import datetime_fromisoformat
 
 from juju.client.gocookies import GoCookieJar
 
 # cookie_content holds the JSON contents of a Go-produced
 # cookie file (reformatted so it's not all on one line but
 # otherwise unchanged).
+
 cookie_content = """
 [
     {
@@ -223,7 +224,7 @@ class TestGoCookieJar(unittest.TestCase):
         ]"""
         jar = self.load_jar(content)
         got_expires = tuple(jar)[0].expires
-        want_expires = int(pyrfc3339.parse("2345-11-15T18:16:08Z").timestamp())
+        want_expires = int(datetime_fromisoformat("2345-11-15T18:16:08Z").timestamp())
         self.assertEqual(got_expires, want_expires)
 
     def load_jar(self, content):


### PR DESCRIPTION
…() and datetime.datetime.isoformat()

#### Description

*I tried using backports.datetime_fromisoformat but than the tox tests broke, probably because it required an import in the unit tests. I tried than just using the usual builtin datetime.datetime.fromisoformat and it worked just well.*

*\<Fixes: \>*


#### QA Steps

*\<Commands / tests / steps to run to verify that the change works:\>*

```
tox -e py3 -- tests/unit/...
```

```
tox -e integration -- tests/integration/...
```

All CI tests need to pass.

*\<Please note that most likely an additional test will be required by the reviewers for any change that's not a one liner to land.\>*

#### Notes & Discussion

*This is a secondary branch from the Pull Request #1243 *
