### PR TITLE
release: 3.6.1.1

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,19 @@
 Changelog
 ---------
 
+3.6.1.1
+^^^^^^^
+
+Wednesday 19th Mar 2025
+
+## What's Changed
+
+* chore: fix changelog format by @dimaqq in https://github.com/juju/python-libjuju/pull/1248
+* docs: move docs from juju.is by @tmihoc in https://github.com/juju/python-libjuju/pull/1244
+* chore: type hint improvements from the helper thread branch by @dimaqq in https://github.com/juju/python-libjuju/pull/1250
+* chore: remove pyrfc3339 and change to datetime.datetime.fromisoformat… by @EdmilsonRodrigues in https://github.com/juju/python-libjuju/pull/1247
+* fix: create websockets ConnectionClosed error correctly by @james-garner-canonical in https://github.com/juju/python-libjuju/pull/1255
+
 3.6.1.0
 ^^^^^^^
 

--- a/juju/version.py
+++ b/juju/version.py
@@ -6,4 +6,4 @@ LTS_RELEASES = ["jammy", "focal", "bionic", "xenial", "trusty", "precise"]
 
 DEFAULT_ARCHITECTURE = "amd64"
 
-CLIENT_VERSION = "3.6.1.0"
+CLIENT_VERSION = "3.6.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "juju"
-version = "3.6.1.0"  # Stop-gap until dynamic versioning is done; must be in sync with juju/version.py:CLIENT_VERSION
+version = "3.6.1.1"  # Stop-gap until dynamic versioning is done; must be in sync with juju/version.py:CLIENT_VERSION
 description = "Python library for Juju"
 readme = "docs/readme.rst"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## What's Changed
* chore: fix changelog format by @dimaqq in https://github.com/juju/python-libjuju/pull/1248
* docs: move docs from juju.is by @tmihoc in https://github.com/juju/python-libjuju/pull/1244
* chore: type hint improvements from the helper thread branch by @dimaqq in https://github.com/juju/python-libjuju/pull/1250
* chore: remove pyrfc3339 and change to datetime.datetime.fromisoformat… by @EdmilsonRodrigues in https://github.com/juju/python-libjuju/pull/1247
* fix: create websockets ConnectionClosed error correctly by @james-garner-canonical in https://github.com/juju/python-libjuju/pull/1255