### PR TITLE
chore: hint machine addresses as list of dicts

### DIFF
--- a/juju/machine.py
+++ b/juju/machine.py
@@ -227,7 +227,7 @@ class Machine(model.ModelEntity):
         return stdout.decode()
 
     @property
-    def addresses(self) -> typing.List[str]:
+    def addresses(self) -> typing.List[dict]:
         """Returns the machine addresses."""
         return self.safe_data["addresses"] or []
 


### PR DESCRIPTION
#### Description

Having `list[str]` has type-hinting made working with a type-checker awkward as an addresses is defined as a dict of mostly [str, str] key-values pairs, with one key-value being a [str, boolean] key-value pairs.

#### QA Steps
Just a type hint change

#### Notes & Discussion

I chose not to type as `typing.List[typing.Dict[str, typing.Union[str, boolean]]]` as it would make working with that type also awkward...

https://github.com/juju/python-libjuju/blob/fdbbbe9ccbbeb596fc500fdf6225ea937856f507/juju/client/schemas-juju-3.6.0.json#L10586