### PR TITLE
fix: creating offer when connecting to existing model, fixes #1264

### DIFF
--- a/juju/client/proxy/kubernetes/proxy.py
+++ b/juju/client/proxy/kubernetes/proxy.py
@@ -39,7 +39,7 @@ class KubernetesProxy(Proxy):
             raise ValueError(f"Invalid port number: {remote_port}")
 
         if ca_cert:
-            with tempfile.NamedTemporaryFile(delete=True) as f:
+            with tempfile.NamedTemporaryFile(delete=False) as f:
                 f.write(bytes(ca_cert, "utf-8"))
             self.temp_ca_file = config.ssl_ca_cert = f.name
 


### PR DESCRIPTION
#### Description

#1044 fixed proxy object reuse some time ago
I accidentally undid that change in #1186 as I didn't realise that multiple connect/close calls were expected on a given instance.
This PR re-applies the change, and cleans up init.

(I've rearranged the initialisation order, because `__del__()` is run on a partially-initialised instance if `__init__()` fails half-way through. That's something that happens in unit tests, although unlikely to affect legitimate use.)

Fixes: #1264 creating offer fails when connecting to existing model

#### QA Steps

- No regression in unit or integration tests
- Eyeball the code change

All CI tests need to pass.

Fixes #1264