### PR TITLE
ci: disable test that fails on all Juju versions

### DIFF
--- a/tests/integration/test_unit.py
+++ b/tests/integration/test_unit.py
@@ -254,6 +254,8 @@ async def test_unit_introspect():
         )
 
 
+# Probably a mismatch between `ubuntu` available for 24.04 and `ntp` only for 22.04
+@pytest.mark.xfail
 @base.bootstrapped
 async def test_subordinate_units():
     async with base.CleanModel() as model:


### PR DESCRIPTION
#### Description

Disable the test that fails on all Juju versions.

I suspect that it's due base incompatibility:
- `ubuntu` goes first and is available on 24.04
- `ntp` goes next, but it tops out at 22.04 on the default channel

Ref: #1267 