### PR TITLE
ci: drop Juju 3.3

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,7 +74,6 @@ jobs:
           - "3.10"
         juju:
           - "3.1/stable"
-          - "3.3/stable"
           - "3.4/stable"
           - "3.5/stable"
           - "3.6/stable"
@@ -135,7 +134,6 @@ jobs:
           - "3.10"
         juju:
           - "3.1/stable"
-          - "3.3/stable"
           - "3.4/stable"
           - "3.5/stable"
           - "3.6/stable"


### PR DESCRIPTION
Juju 3.3 has reached end of life.

> 🔸 Juju 3.3.7 - 10 September 2024
> NOTE: This is the last release of 3.3. There will be no more releases.

https://documentation.ubuntu.com/juju/latest/reference/juju/juju-roadmap-and-releases/index.html?dfghjkl=#juju-3-3

Meanwhile, 8 integration tests are failing against Juju 3.3 specifically #1267 

This PR removed Juju 3.3 from CI to close #1267

