### PR TITLE
chore: release 3.6.1.2

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,17 @@
 Changelog
 ---------
 
+3.6.1.2
+^^^^^^^
+
+Monday 26th May 2025
+
+## What's Changed
+
+* chore: hint machine addresses as list of dicts by @gboutry in https://github.com/juju/python-libjuju/pull/1258
+* ci: disable test that fails on all Juju versions by @dimaqq in https://github.com/juju/python-libjuju/pull/1268
+* fix: creating offer when connecting to existing model, fixes #1264 by @dimaqq in https://github.com/juju/python-libjuju/pull/1265
+
 3.6.1.1
 ^^^^^^^
 

--- a/juju/version.py
+++ b/juju/version.py
@@ -6,4 +6,4 @@ LTS_RELEASES = ["jammy", "focal", "bionic", "xenial", "trusty", "precise"]
 
 DEFAULT_ARCHITECTURE = "amd64"
 
-CLIENT_VERSION = "3.6.1.1"
+CLIENT_VERSION = "3.6.1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "juju"
-version = "3.6.1.1"  # Stop-gap until dynamic versioning is done; must be in sync with juju/version.py:CLIENT_VERSION
+version = "3.6.1.2"  # Stop-gap until dynamic versioning is done; must be in sync with juju/version.py:CLIENT_VERSION
 description = "Python library for Juju"
 readme = "docs/readme.rst"
 license = { file = "LICENSE" }


### PR DESCRIPTION
#### Description

PR to release python-libjuju 3.6.1.2


Runtime fixes:
- #1265 

Typing fixes:
- #1258

Chores & CI:
- #1268 

