### PR TITLE
fix: don't strip valid characters from secret data

### DIFF
--- a/juju/secrets.py
+++ b/juju/secrets.py
@@ -27,14 +27,9 @@ def create_secret_data(args):
     """
     data = {}
     for val in args:
-        # Remove any base64 padding ("=") before splitting the key=value.
-        stripped = val.rstrip(base64.b64encode(b"=").decode("utf-8"))
-        idx = stripped.find("=")
-        if idx < 1:
+        key, _, value = val.partition('=')
+        if not key or not value:
             raise ValueError(f"Invalid key value {val}")
-
-        key = stripped[0:idx]
-        value = stripped[idx + 1 :]
 
         # If the key doesn't have the #file suffix, then add it to the bag and continue.
         if not key.endswith(file_suffix):

--- a/juju/secrets.py
+++ b/juju/secrets.py
@@ -27,7 +27,7 @@ def create_secret_data(args):
     """
     data = {}
     for val in args:
-        key, _, value = val.partition('=')
+        key, _, value = val.partition("=")
         if not key or not value:
             raise ValueError(f"Invalid key value {val}")
 

--- a/tests/unit/test_secrets.py
+++ b/tests/unit/test_secrets.py
@@ -12,11 +12,12 @@ from juju.secrets import create_secret_data, read_secret_data
 
 
 class TestCreateSecretData:
-    @pytest.mark.parametrize("keyval", ["foo", "=bar", "baz=", "f=bar", "fo=bar", "foo_bar=baz"])
+    @pytest.mark.parametrize(
+        "keyval", ["foo", "=bar", "baz=", "f=bar", "ff=bar", "foo_bar=baz"]
+    )
     def test_bad_key(self, keyval: str):
         with pytest.raises(ValueError):
             create_secret_data([keyval])
-
 
     @pytest.mark.parametrize(
         "keyval,expected_key,expected_val",
@@ -27,13 +28,12 @@ class TestCreateSecretData:
             ("equalsign==", "equalsign", "PQ=="),
             ("equalsign#base64=PQ==", "equalsign", "PQ=="),
             ("pq-identity-theorem=P===Q", "pq-identity-theorem", "UD09PVE="),
-        ]
+        ],
     )
     def test_goo_key_values(self, keyval: str, expected_key: str, expected_val: str):
         actual = create_secret_data([keyval])
         expected = {expected_key: expected_val}
         assert actual == expected
-
 
     def test_key_content_too_large(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
#### Description

`create_secret_data` unnecessarily attempts to strip trailing `=` symbols from secret data, and inadvertently strips all trailing `P`, `Q` and `=` characters instead. This PR drops the unnecessary removal of trailing characters, and adds unit tests covering cases that would previously have been handled badly (as well as some test cases validating existing behaviour that wasn't covered).

Fixes: #1275

#### QA Steps

Unit test should pass. Locally I have `tests/unit/test_jujudata.py::TestJujuData::test_verify_controller_uninitialized` failing both on `main` and on this branch.