### PR TITLE
feat: add resolute (26.04) to supported series

### DIFF
--- a/juju/utils.py
+++ b/juju/utils.py
@@ -325,6 +325,7 @@ KINETIC = "kinetic"
 LUNAR = "lunar"
 MANTIC = "mantic"
 NOBLE = "noble"
+RESOLUTE = "resolute"
 
 UBUNTU_SERIES = {
     PRECISE: "12.04",
@@ -352,6 +353,7 @@ UBUNTU_SERIES = {
     LUNAR: "23.04",
     MANTIC: "23.10",
     NOBLE: "24.04",
+    RESOLUTE: "26.04",
 }
 
 KUBERNETES = "kubernetes"


### PR DESCRIPTION
#### Description

*\<Please add why this change is needed and what it does.\>*
Add support for `reoluste` (26.04). We're trying to deploy with `series: resolute` using `python-libjuju`, and it fails with `Unknown series: resolute`.

*\<Fixes: \>*


#### QA Steps

*\<Commands / tests / steps to run to verify that the change works:\>*

```
tox -e py3 -- tests/unit/...
```

```
tox -e integration -- tests/integration/...
```

All CI tests need to pass.

*\<Please note that most likely an additional test will be required by the reviewers for any change that's not a one liner to land.\>*

#### Notes & Discussion

*\<Additional notes for the reviewers if needed. Please delete section if not applicable.\>*
